### PR TITLE
fix: added clean up for temp files

### DIFF
--- a/packages/contentstack-clone/package.json
+++ b/packages/contentstack-clone/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contentstack/cli-cm-clone",
   "description": "Contentstack stack clone plugin",
-  "version": "0.1.0-beta.1",
+  "version": "0.1.0-beta.2",
   "author": "Contentstack",
   "bugs": "https://github.com/rohitmishra209/cli-cm-clone/issues",
   "dependencies": {

--- a/packages/contentstack-clone/src/commands/cm/stack-clone.js
+++ b/packages/contentstack-clone/src/commands/cm/stack-clone.js
@@ -1,28 +1,60 @@
-const { Command, flags } = require('@contentstack/cli-command')
+const {Command} = require('@contentstack/cli-command')
 const Configstore = require('configstore')
 const credStore = new Configstore('contentstack_cli')
 const {CloneHandler} = require('../../lib/util/clone-handler')
 let config = require('../../lib/util/dummyConfig.json')
 const path = require('path')
-const fs = require('fs');
 const rimraf = require('rimraf')
+let pathdir = path.join(__dirname.split('src')[0], 'contents')
 
 class StackCloneCommand extends Command { 
   async run() {
-    let _authToken = credStore.get('authtoken')
-    if (_authToken && _authToken !== undefined) {
-      config.auth_token = _authToken
-      config.host = this.cmaHost
-      config.cdn  = this.cdaHost
-      const cloneHandler = new CloneHandler(config)
-      let result = await cloneHandler.start()
-      var pathdir = path.join(__dirname.split("src")[0], 'contents')
-      rimraf(pathdir, function(err) {
-        console.log("Stack cloning process have been completed successfully");
-      })
-    } else {
-      console.log("AuthToken is not present in local drive, Hence use 'csdx auth:login' command for login");
+    try {
+      this.registerCleanupOnInterrupt(pathdir)
+      let _authToken = credStore.get('authtoken')
+      if (_authToken && _authToken !== undefined) {
+        config.auth_token = _authToken
+        config.host = this.cmaHost
+        config.cdn  = this.cdaHost
+        const cloneHandler = new CloneHandler(config)
+        let result = await cloneHandler.start()
+        let successMessage = 'Stack cloning process have been completed successfully'
+        await this.cleanUp(pathdir, successMessage)
+      } else {
+        console.log("AuthToken is not present in local drive, Hence use 'csdx auth:login' command for login");
+      }
+    } catch (error) {
+      await this.cleanUp(pathdir)
+      // eslint-disable-next-line no-console
+      console.log(error.message || error)
     }
+  }
+
+  async cleanUp(pathDir, message) {
+    return new Promise(resolve => {
+      rimraf(pathDir, function (err) {
+        if (err)
+          throw err
+        if (message) {
+          // eslint-disable-next-line no-console
+          console.log(message)
+        }
+        resolve()
+      })
+    })
+  }
+
+  registerCleanupOnInterrupt(pathDir) {
+    ['SIGINT', 'SIGQUIT', 'SIGTERM']
+    .forEach(signal => process.on(signal, async () => {
+      // eslint-disable-next-line no-console
+      console.log('\nCleaning up')
+      await this.cleanUp(pathDir)
+      // eslint-disable-next-line no-console
+      console.log('done')
+      // eslint-disable-next-line no-process-exit
+      process.exit()
+    }))
   }
 }
 
@@ -31,8 +63,7 @@ Use this plugin to automate the process of cloning a stack in a few steps.
 `
 
 StackCloneCommand.examples = [
-  'csdx cm:stack-clone'
+  'csdx cm:stack-clone',
 ]
-
 
 module.exports = StackCloneCommand

--- a/packages/contentstack/package.json
+++ b/packages/contentstack/package.json
@@ -11,7 +11,7 @@
     "@contentstack/cli-cm-migrate-rte": "^1.0.1",
     "@contentstack/cli-auth": "0.1.1-beta.1",
     "@contentstack/cli-cm-bulk-publish": "0.1.1-beta.2",
-    "@contentstack/cli-cm-clone": "0.1.0-beta.1",
+    "@contentstack/cli-cm-clone": "0.1.0-beta.2",
     "@contentstack/cli-cm-export": "0.1.1-beta.5",
     "@contentstack/cli-cm-export-to-csv": "0.1.0-beta.1",
     "@contentstack/cli-cm-import": "0.1.1-beta.7",


### PR DESCRIPTION
Description:
Fix for the issue where, upon cancelling a stack clone command operation mid import, the temporary files weren't being cleared. Due to this, when the stack clone command is run another time, the old temporary also gets imported.

Here is the relevant [ticket](https://contentstack.atlassian.net/browse/CS-18825)