### PR TITLE
fix: added a fix for assets not being published

### DIFF
--- a/packages/contentstack-bulk-publish/package.json
+++ b/packages/contentstack-bulk-publish/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contentstack/cli-cm-bulk-publish",
   "description": "Contentstack CLI plugin for bulk publish actions",
-  "version": "0.1.1-beta.2",
+  "version": "0.1.1-beta.3",
   "author": "Contentstack",
   "bugs": "https://github.com/contentstack/cli/issues",
   "dependencies": {

--- a/packages/contentstack-bulk-publish/src/commands/cm/bulk-publish/unpublish.js
+++ b/packages/contentstack-bulk-publish/src/commands/cm/bulk-publish/unpublish.js
@@ -58,7 +58,7 @@ class UnpublishCommand extends Command {
     }
   }
 
-  validate({environment, retryFailed, locale, onlyAssets, onlyEntries}) {
+  validate({environment, retryFailed, locale, contentType, onlyAssets, onlyEntries}) {
     let missing = []
     if (retryFailed) {
       return true
@@ -66,6 +66,10 @@ class UnpublishCommand extends Command {
 
     if (onlyAssets && onlyEntries) {
       this.error(`The flags onlyAssets and onlyEntries need not be used at the same time. Unpublish command unpublishes entries and assts at the same time by default`)
+    }
+
+    if (onlyAssets && contentType) {
+      this.error(`Specifying content-type and onlyAssets together will have unexpected results. Please do not use these 2 flags together. Thank you.`)
     }
 
     if (!environment) {
@@ -90,19 +94,19 @@ class UnpublishCommand extends Command {
     }
   }
 
-  async confirmFlags(flags) {  
+  async confirmFlags(flags) {
     let confirmation
     prettyPrint(flags)
-    if(flags.yes) { 
-      return true 
-    } 
+    if (flags.yes) {
+      return true
+    }
 
-    if(!flags.contentType && !flags.onlyAssets) {
+    if (!flags.contentType && !flags.onlyAssets) {
       confirmation = await cli.confirm('Do you want to continue with this configuration. This will unpublish all the entries from all content types? [yes or no]')
     } else {
-      confirmation = await cli.confirm('Do you want to continue with this configuration ? [yes or no]') 
+      confirmation = await cli.confirm('Do you want to continue with this configuration ? [yes or no]')
     }
-    return confirmation 
+    return confirmation
   }
 }
 

--- a/packages/contentstack-bulk-publish/src/producer/unpublish.js
+++ b/packages/contentstack-bulk-publish/src/producer/unpublish.js
@@ -11,7 +11,6 @@ const {
 } = require('../consumer/publish')
 const retryFailedLogs = require('../util/retryfailed')
 const {validateFile} = require('../util/fs')
-const types = 'asset_published,entry_published'
 const queue = getQueue()
 const entryQueue = getQueue()
 const assetQueue = getQueue()
@@ -193,9 +192,12 @@ async function start({retryFailed, bulkUnpublish, contentType, locale, environme
         environment,
         locale,
       }
-      filter.type = (f_types) ? f_types : types // types mentioned in the config file (f_types) are given preference
+      if (f_types)
+        filter.type = f_types
+      // filter.type = (f_types) ? f_types : types // types mentioned in the config file (f_types) are given preference
       if (contentType) {
         filter.content_type_uid = contentType
+        filter.type = 'entry_published'
       }
       if (onlyAssets) {
         filter.type = 'asset_published'
@@ -212,7 +214,7 @@ async function start({retryFailed, bulkUnpublish, contentType, locale, environme
         throw error
       }
     }
-  } catch(error) {
+  } catch (error) {
     throw error
   }
 }

--- a/packages/contentstack/package.json
+++ b/packages/contentstack/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@contentstack/cli-cm-migrate-rte": "^1.0.1",
     "@contentstack/cli-auth": "0.1.1-beta.1",
-    "@contentstack/cli-cm-bulk-publish": "0.1.1-beta.2",
+    "@contentstack/cli-cm-bulk-publish": "0.1.1-beta.3",
     "@contentstack/cli-cm-clone": "0.1.0-beta.1",
     "@contentstack/cli-cm-export": "0.1.1-beta.5",
     "@contentstack/cli-cm-export-to-csv": "0.1.0-beta.1",


### PR DESCRIPTION
Description: 
This is a fix for the issue where assets were not getting published while using the cross publish command.
This command uses the sync api for publishing both assets and entries, the problem was that the `type` paramter, in the 
`filter` query parameter needed to be left empty for publishing both entries and assets.

Here is the relevant [ticket](https://contentstack.atlassian.net/browse/CS-18803)