### PR TITLE
Fix/cs 38886

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20307,7 +20307,7 @@
         "@contentstack/cli-cm-bulk-publish": "~1.3.11",
         "@contentstack/cli-cm-clone": "~1.4.16",
         "@contentstack/cli-cm-export": "~1.8.1",
-        "@contentstack/cli-cm-export-to-csv": "~1.4.1",
+        "@contentstack/cli-cm-export-to-csv": "~1.4.2",
         "@contentstack/cli-cm-import": "~1.8.3",
         "@contentstack/cli-cm-migrate-rte": "~1.4.11",
         "@contentstack/cli-cm-seed": "~1.4.15",
@@ -21072,7 +21072,7 @@
     },
     "packages/contentstack-export-to-csv": {
       "name": "@contentstack/cli-cm-export-to-csv",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "license": "MIT",
       "dependencies": {
         "@contentstack/cli-command": "~1.2.12",
@@ -23721,7 +23721,7 @@
         "@contentstack/cli-cm-bulk-publish": "~1.3.11",
         "@contentstack/cli-cm-clone": "~1.4.16",
         "@contentstack/cli-cm-export": "~1.8.1",
-        "@contentstack/cli-cm-export-to-csv": "~1.4.1",
+        "@contentstack/cli-cm-export-to-csv": "~1.4.2",
         "@contentstack/cli-cm-import": "~1.8.3",
         "@contentstack/cli-cm-migrate-rte": "~1.4.11",
         "@contentstack/cli-cm-seed": "~1.4.15",

--- a/packages/contentstack-export-to-csv/package.json
+++ b/packages/contentstack-export-to-csv/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contentstack/cli-cm-export-to-csv",
   "description": "Export entities to csv",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "author": "Abhinav Gupta @abhinav-from-contentstack",
   "bugs": "https://github.com/contentstack/cli/issues",
   "dependencies": {

--- a/packages/contentstack-export-to-csv/src/util/index.js
+++ b/packages/contentstack-export-to-csv/src/util/index.js
@@ -371,6 +371,22 @@ function exitProgram() {
   process.exit();
 }
 
+function sanitizeEntries(flatEntry) {
+  // sanitize against CSV Injections
+  const CSVRegex = /^[\\+\\=@\\-]/
+  for (key in flatEntry) {
+    if (typeof flatEntry[key] === 'string' && flatEntry[key].match(CSVRegex)) {
+      flatEntry[key] = flatEntry[key].replace(/\"/g, "\"\"");
+      flatEntry[key] = `"'${flatEntry[key]}"`
+    } else if (typeof flatEntry[key] === 'object') {
+      // convert any objects or arrays to string
+      // to store this data correctly in csv
+      flatEntry[key] = JSON.stringify(flatEntry[key]);
+    }
+  }
+  return flatEntry;
+}
+
 function cleanEntries(entries, language, environments, contentTypeUid) {
   const filteredEntries = entries.filter((entry) => {
     return entry['locale'] === language;
@@ -393,6 +409,7 @@ function cleanEntries(entries, language, environments, contentTypeUid) {
         }
     }
     entry = flatten(entry);
+    entry = sanitizeEntries(entry);
     entry['publish_details'] = envArr;
     entry['_workflow'] = workflow;
     entry['ACL'] = JSON.stringify({}); // setting ACL to empty obj
@@ -409,7 +426,6 @@ function cleanEntries(entries, language, environments, contentTypeUid) {
     delete entry.publishRequest;
     return entry;
   });
-  console.log(filteredEntries.length);
 }
 
 function getDateTime() {

--- a/packages/contentstack/package.json
+++ b/packages/contentstack/package.json
@@ -27,7 +27,7 @@
     "@contentstack/cli-cm-bulk-publish": "~1.3.11",
     "@contentstack/cli-cm-clone": "~1.4.16",
     "@contentstack/cli-cm-export": "~1.8.1",
-    "@contentstack/cli-cm-export-to-csv": "~1.4.1",
+    "@contentstack/cli-cm-export-to-csv": "~1.4.2",
     "@contentstack/cli-cm-import": "~1.8.3",
     "@contentstack/cli-cm-migrate-rte": "~1.4.11",
     "@contentstack/cli-cm-seed": "~1.4.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ importers:
       '@contentstack/cli-cm-bulk-publish': ~1.3.11
       '@contentstack/cli-cm-clone': ~1.4.16
       '@contentstack/cli-cm-export': ~1.8.1
-      '@contentstack/cli-cm-export-to-csv': ~1.4.1
+      '@contentstack/cli-cm-export-to-csv': ~1.4.2
       '@contentstack/cli-cm-import': ~1.8.3
       '@contentstack/cli-cm-migrate-rte': ~1.4.11
       '@contentstack/cli-cm-seed': ~1.4.15


### PR DESCRIPTION
- sanitized entries against CSV injections and converted all entry data to string for writing to csv files
- updated `@contentstack/cli-cm-export-to-csv` to version `1.4.2`
- updated lock files

did not update core contentstack package