### PR TITLE
CLI | Error in the Entry Migration script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23135,12 +23135,12 @@
       "dependencies": {
         "@contentstack/cli-auth": "~1.3.13",
         "@contentstack/cli-cm-bootstrap": "~1.4.16",
-        "@contentstack/cli-cm-branches": "~1.0.12",
+        "@contentstack/cli-cm-branches": "~1.0.13",
         "@contentstack/cli-cm-bulk-publish": "~1.3.11",
         "@contentstack/cli-cm-clone": "~1.4.17",
         "@contentstack/cli-cm-export": "~1.8.1",
-        "@contentstack/cli-cm-import": "~1.8.4",
         "@contentstack/cli-cm-export-to-csv": "~1.4.2",
+        "@contentstack/cli-cm-import": "~1.8.4",
         "@contentstack/cli-cm-migrate-rte": "~1.4.11",
         "@contentstack/cli-cm-seed": "~1.4.16",
         "@contentstack/cli-command": "~1.2.12",
@@ -23317,7 +23317,7 @@
     },
     "packages/contentstack-branches": {
       "name": "@contentstack/cli-cm-branches",
-      "version": "1.0.12",
+      "version": "1.0.13",
       "license": "MIT",
       "dependencies": {
         "@contentstack/cli-command": "~1.2.12",
@@ -26542,12 +26542,12 @@
       "requires": {
         "@contentstack/cli-auth": "~1.3.13",
         "@contentstack/cli-cm-bootstrap": "~1.4.16",
-        "@contentstack/cli-cm-branches": "~1.0.12",
+        "@contentstack/cli-cm-branches": "~1.0.13",
         "@contentstack/cli-cm-bulk-publish": "~1.3.11",
         "@contentstack/cli-cm-clone": "~1.4.17",
         "@contentstack/cli-cm-export": "~1.8.1",
-        "@contentstack/cli-cm-import": "~1.8.4",
         "@contentstack/cli-cm-export-to-csv": "~1.4.2",
+        "@contentstack/cli-cm-import": "~1.8.4",
         "@contentstack/cli-cm-migrate-rte": "~1.4.11",
         "@contentstack/cli-cm-seed": "~1.4.16",
         "@contentstack/cli-command": "~1.2.12",

--- a/packages/contentstack-branches/package.json
+++ b/packages/contentstack-branches/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contentstack/cli-cm-branches",
   "description": "Contentstack CLI plugin to do branches operations",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "author": "Contentstack",
   "bugs": "https://github.com/contentstack/cli/issues",
   "dependencies": {

--- a/packages/contentstack-branches/src/utils/entry-create-script.ts
+++ b/packages/contentstack-branches/src/utils/entry-create-script.ts
@@ -465,7 +465,9 @@ export function entryCreateScript(contentType) {
                   .query({ query: { title: compareRefEntry.title } })
                   .find();
   
-                updateValueByPath(entryDetails, references[i], baseRefEntry.items[0].uid);
+                  if(baseRefEntry?.items?.length > 0 && baseRefEntry.items[0]?.uid){
+                    updateValueByPath(entryDetails, references[i], baseRefEntry.items[0].uid);
+                  }
               }
             }
           }

--- a/packages/contentstack-branches/src/utils/entry-create-update-script.ts
+++ b/packages/contentstack-branches/src/utils/entry-create-update-script.ts
@@ -484,7 +484,9 @@ export function entryCreateUpdateScript(contentType) {
                   .query({ query: { title: compareRefEntry.title } })
                   .find();
   
-                updateValueByPath(entryDetails, references[i], baseRefEntry.items[0].uid);
+                  if(baseRefEntry?.items?.length > 0 && baseRefEntry.items[0]?.uid){
+                    updateValueByPath(entryDetails, references[i], baseRefEntry.items[0].uid);
+                  }
               }
             }
           }

--- a/packages/contentstack-branches/src/utils/entry-update-script.ts
+++ b/packages/contentstack-branches/src/utils/entry-update-script.ts
@@ -483,7 +483,9 @@ export function entryUpdateScript(contentType) {
                   .query({ query: { title: compareRefEntry.title } })
                   .find();
   
-                updateValueByPath(entryDetails, references[i], baseRefEntry.items[0].uid);
+                  if(baseRefEntry?.items?.length > 0 && baseRefEntry.items[0]?.uid){
+                    updateValueByPath(entryDetails, references[i], baseRefEntry.items[0].uid);
+                  }
               }
             }
           }

--- a/packages/contentstack/package.json
+++ b/packages/contentstack/package.json
@@ -37,7 +37,7 @@
     "@contentstack/cli-migration": "~1.3.12",
     "@contentstack/cli-utilities": "~1.5.2",
     "@contentstack/management": "~1.10.0",
-    "@contentstack/cli-cm-branches": "~1.0.12",
+    "@contentstack/cli-cm-branches": "~1.0.13",
     "@oclif/plugin-help": "^5",
     "@oclif/plugin-not-found": "^2.4.0",
     "@oclif/plugin-plugins": "^3.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,12 +12,12 @@ importers:
     specifiers:
       '@contentstack/cli-auth': ~1.3.13
       '@contentstack/cli-cm-bootstrap': ~1.4.16
-      '@contentstack/cli-cm-branches': ~1.0.12
+      '@contentstack/cli-cm-branches': ~1.0.13
       '@contentstack/cli-cm-bulk-publish': ~1.3.11
       '@contentstack/cli-cm-clone': ~1.4.17
       '@contentstack/cli-cm-export': ~1.8.1
-      '@contentstack/cli-cm-import': ~1.8.4
       '@contentstack/cli-cm-export-to-csv': ~1.4.2
+      '@contentstack/cli-cm-import': ~1.8.4
       '@contentstack/cli-cm-migrate-rte': ~1.4.11
       '@contentstack/cli-cm-seed': ~1.4.16
       '@contentstack/cli-command': ~1.2.12


### PR DESCRIPTION
CS-41435

- [x] Handle Cannot read properties of undefined (reading 'uid')
- [x] Version bump cli-cm-branches 1.0.12 -> 1.0.13