### PR TITLE
refactor: export marketplace apps HTTP adapter calls to SDK call migration [CS-42903]

### DIFF
--- a/packages/contentstack-export/src/types/index.ts
+++ b/packages/contentstack-export/src/types/index.ts
@@ -140,3 +140,4 @@ export interface TermsConfig{
 
 export { default as DefaultConfig } from './default-config';
 export { default as ExportConfig } from './export-config';
+export * from './marketplace-app'

--- a/packages/contentstack-export/src/types/marketplace-app.ts
+++ b/packages/contentstack-export/src/types/marketplace-app.ts
@@ -1,0 +1,65 @@
+type AppLocation =
+  | 'cs.cm.stack.config'
+  | 'cs.cm.stack.dashboard'
+  | 'cs.cm.stack.sidebar'
+  | 'cs.cm.stack.custom_field'
+  | 'cs.cm.stack.rte'
+  | 'cs.cm.stack.asset_sidebar'
+  | 'cs.org.config';
+
+interface ExtensionMeta {
+  uid?: string;
+  name?: string;
+  description?: string;
+  path?: string;
+  signed: boolean;
+  extension_uid?: string;
+  data_type?: string;
+  enabled?: boolean;
+  width?: number;
+  blur?: boolean;
+  default_width?: 'full' | 'half';
+}
+
+interface Extension {
+  type: AppLocation;
+  meta: ExtensionMeta[];
+}
+
+interface LocationConfiguration {
+  signed: boolean;
+  base_url: string;
+  locations: Extension[];
+}
+
+interface AnyProperty {
+  [propName: string]: any;
+}
+
+type Manifest = {
+  uid: string;
+  name: string;
+  icon?: string;
+  hosting?: any;
+  version?: number;
+  description: string;
+  organization_uid: string;
+  framework_version?: string;
+  oauth?: any;
+  webhook?: any;
+  ui_location: LocationConfiguration;
+  target_type: 'stack' | 'organization';
+  visibility: 'private' | 'public' | 'public_unlisted';
+} & AnyProperty;
+
+type Installation = {
+  uid: string;
+  status: string;
+  manifest: Manifest;
+  configuration: any;
+  server_configuration: any;
+  target: { type: string; uid: string };
+  ui_location: LocationConfiguration;
+} & AnyProperty;
+
+export { Installation, Manifest };

--- a/packages/contentstack-export/src/utils/marketplace-app-helper.ts
+++ b/packages/contentstack-export/src/utils/marketplace-app-helper.ts
@@ -48,22 +48,3 @@ export async function createNodeCryptoInstance(config: ExportConfig): Promise<No
 
   return new NodeCrypto(cryptoArgs);
 }
-
-export const getStackSpecificApps = async (params: {
-  developerHubBaseUrl: string;
-  config: ExportConfig;
-  skip: number;
-}) => {
-  const { developerHubBaseUrl, config, skip } = params;
-  const appSdkAxiosInstance = await managementSDKClient({
-    endpoint: developerHubBaseUrl,
-  });
-  return appSdkAxiosInstance.axiosInstance
-    .get(`${developerHubBaseUrl}/installations?target_uids=${config.source_stack}&skip=${skip}`, {
-      headers: {
-        organization_uid: config.org_uid,
-      },
-    })
-    .then((data: any) => data.data)
-    .catch((error: any) => log(config, `Failed to export marketplace-apps ${formatError(error)}`, 'error'));
-};

--- a/packages/contentstack-utilities/src/contentstack-marketplace-sdk.ts
+++ b/packages/contentstack-utilities/src/contentstack-marketplace-sdk.ts
@@ -4,9 +4,9 @@ import { client, ContentstackConfig, ContentstackClient, ContentstackToken } fro
 
 import authHandler from './auth-handler';
 import configStore from './config-handler';
+import { Installation } from '@contentstack/marketplace-sdk/types/marketplace/installation';
 
 type ConfigType = Pick<ContentstackConfig, 'host' | 'endpoint' | 'retryDelay' | 'retryLimit'> & {
-  management_token?: string;
   skipTokenValidity?: string;
 };
 type ContentstackMarketplaceConfig = ContentstackConfig;
@@ -25,6 +25,8 @@ class MarketplaceSDKInitiator {
       retryLimit: 3,
       timeout: 60000,
       maxRequests: 10,
+      authtoken: '',
+      authorization: '',
       // host: 'api.contentstack.io',
       maxContentLength: 100000000,
       maxBodyLength: 1000000000,
@@ -112,17 +114,12 @@ class MarketplaceSDKInitiator {
       option.headers['X-CS-CLI'] = this.analyticsInfo;
     }
 
-    if (!config.management_token) {
-      option.authtoken = '';
-      option.authorization = '';
-
-      if (authorizationType === 'BASIC') {
-        option.authtoken = configStore.get('authtoken');
-      } else if (authorizationType === 'OAUTH') {
-        if (!config.skipTokenValidity) {
-          await authHandler.compareOAuthExpiry();
-          option.authorization = `Bearer ${configStore.get('oauthAccessToken')}`;
-        }
+    if (authorizationType === 'BASIC') {
+      option.authtoken = configStore.get('authtoken');
+    } else if (authorizationType === 'OAUTH') {
+      if (!config.skipTokenValidity) {
+        await authHandler.compareOAuthExpiry();
+        option.authorization = `Bearer ${configStore.get('oauthAccessToken')}`;
       }
     }
 
@@ -133,6 +130,6 @@ class MarketplaceSDKInitiator {
 export const marketplaceSDKInitiator = new MarketplaceSDKInitiator();
 const marketplaceSDKClient: typeof marketplaceSDKInitiator.createAppSDKClient =
   marketplaceSDKInitiator.createAppSDKClient.bind(marketplaceSDKInitiator);
-export { App, MarketplaceSDKInitiator, ContentstackMarketplaceConfig, ContentstackMarketplaceClient };
+export { App, Installation, MarketplaceSDKInitiator, ContentstackMarketplaceConfig, ContentstackMarketplaceClient };
 
 export default marketplaceSDKClient;

--- a/packages/contentstack-utilities/src/index.ts
+++ b/packages/contentstack-utilities/src/index.ts
@@ -1,6 +1,7 @@
 import Logger from './logger';
 import marketplaceSDKClient, {
   App,
+  Installation,
   MarketplaceSDKInitiator,
   marketplaceSDKInitiator,
   ContentstackMarketplaceClient,
@@ -32,6 +33,7 @@ export * from './add-locale';
 // Marketplace SDK export
 export {
   App,
+  Installation,
   marketplaceSDKClient,
   MarketplaceSDKInitiator,
   marketplaceSDKInitiator,


### PR DESCRIPTION
**CS-42903**
- [x] refactor: export marketplace apps HTTP adapter calls to SDK call migration.
- [x] test: Unit test cases updated as per the HTTP calls to SDK Migration.

**NOTE**: As the new marketplace app SDK release is required, so version bump will be done later.