### PR TITLE
CS-43272- GCP changes for branches plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23496,7 +23496,7 @@
         "@contentstack/cli-audit": "~1.3.2",
         "@contentstack/cli-auth": "~1.3.17",
         "@contentstack/cli-cm-bootstrap": "~1.7.1",
-        "@contentstack/cli-cm-branches": "~1.0.20",
+        "@contentstack/cli-cm-branches": "~1.0.21",
         "@contentstack/cli-cm-bulk-publish": "~1.4.0",
         "@contentstack/cli-cm-clone": "~1.9.0",
         "@contentstack/cli-cm-export": "~1.10.2",
@@ -23923,7 +23923,7 @@
     },
     "packages/contentstack-branches": {
       "name": "@contentstack/cli-cm-branches",
-      "version": "1.0.20",
+      "version": "1.0.21",
       "license": "MIT",
       "dependencies": {
         "@contentstack/cli-command": "~1.2.16",

--- a/packages/contentstack-branches/README.md
+++ b/packages/contentstack-branches/README.md
@@ -29,6 +29,16 @@ For switching to AZURE-NA region update the hosts at config/default.js
 }
 ```
 
+For switching to GCP-NA region update the hosts at config/default.js
+
+```js
+{
+  host:'https://gcp-na-api.contentstack.com/v3',
+  cdn: 'https://gcp-na-cdn.contentstack.com/v3',
+ ...
+}
+```
+
 # Usage
 
 <!-- usage -->
@@ -37,7 +47,7 @@ $ npm install -g @contentstack/cli-cm-branches
 $ csdx COMMAND
 running command...
 $ csdx (--version)
-@contentstack/cli-cm-branches/1.0.20 darwin-arm64 node-v20.8.0
+@contentstack/cli-cm-branches/1.0.20 darwin-arm64 node-v20.10.0
 $ csdx --help [COMMAND]
 USAGE
   $ csdx COMMAND

--- a/packages/contentstack-branches/package.json
+++ b/packages/contentstack-branches/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contentstack/cli-cm-branches",
   "description": "Contentstack CLI plugin to do branches operations",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "author": "Contentstack",
   "bugs": "https://github.com/contentstack/cli/issues",
   "dependencies": {

--- a/packages/contentstack-branches/src/utils/entry-create-script.ts
+++ b/packages/contentstack-branches/src/utils/entry-create-script.ts
@@ -182,7 +182,7 @@ export function entryCreateScript(contentType) {
         text = JSON.stringify(_entry);
       }
       markdownRegEx = new RegExp(
-        '(https://(assets|(eu-|azure-na-|azure-eu-)?images).contentstack.(io|com)/v3/assets/(.*?)/(.*?)/(.*?)/(.*?)(?="))',
+        '(https://(assets|(eu-|azure-na-|azure-eu-|gcp-na-)?images).contentstack.(io|com)/v3/assets/(.*?)/(.*?)/(.*?)/(.*?)(?="))',
         'g',
       );
       while ((markdownMatch = markdownRegEx.exec(text)) !== null) {

--- a/packages/contentstack-branches/src/utils/entry-create-update-script.ts
+++ b/packages/contentstack-branches/src/utils/entry-create-update-script.ts
@@ -204,7 +204,7 @@ export function entryCreateUpdateScript(contentType) {
         text = JSON.stringify(_entry);
       }
       markdownRegEx = new RegExp(
-        '(https://(assets|(eu-|azure-na-|azure-eu-)?images).contentstack.(io|com)/v3/assets/(.*?)/(.*?)/(.*?)/(.*?)(?="))',
+        '(https://(assets|(eu-|azure-na-|azure-eu-|gcp-na-)?images).contentstack.(io|com)/v3/assets/(.*?)/(.*?)/(.*?)/(.*?)(?="))',
         'g',
       );
       while ((markdownMatch = markdownRegEx.exec(text)) !== null) {

--- a/packages/contentstack-branches/src/utils/entry-update-script.ts
+++ b/packages/contentstack-branches/src/utils/entry-update-script.ts
@@ -204,7 +204,7 @@ export function entryUpdateScript(contentType) {
         text = JSON.stringify(_entry);
       }
       markdownRegEx = new RegExp(
-        '(https://(assets|(eu-|azure-na-|azure-eu-)?images).contentstack.(io|com)/v3/assets/(.*?)/(.*?)/(.*?)/(.*?)(?="))',
+        '(https://(assets|(eu-|azure-na-|azure-eu-|gcp-na-)?images).contentstack.(io|com)/v3/assets/(.*?)/(.*?)/(.*?)/(.*?)(?="))',
         'g',
       );
       while ((markdownMatch = markdownRegEx.exec(text)) !== null) {

--- a/packages/contentstack/package.json
+++ b/packages/contentstack/package.json
@@ -25,7 +25,7 @@
     "@contentstack/cli-audit": "~1.3.2",
     "@contentstack/cli-auth": "~1.3.17",
     "@contentstack/cli-cm-bootstrap": "~1.7.1",
-    "@contentstack/cli-cm-branches": "~1.0.20",
+    "@contentstack/cli-cm-branches": "~1.0.21",
     "@contentstack/cli-cm-bulk-publish": "~1.4.0",
     "@contentstack/cli-cm-clone": "~1.9.0",
     "@contentstack/cli-cm-export": "~1.10.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
       '@contentstack/cli-audit': ~1.3.2
       '@contentstack/cli-auth': ~1.3.17
       '@contentstack/cli-cm-bootstrap': ~1.7.1
-      '@contentstack/cli-cm-branches': ~1.0.20
+      '@contentstack/cli-cm-branches': ~1.0.21
       '@contentstack/cli-cm-bulk-publish': ~1.4.0
       '@contentstack/cli-cm-clone': ~1.9.0
       '@contentstack/cli-cm-export': ~1.10.2


### PR DESCRIPTION
version bump:
@contentstack/cli-cm-branches: 1.0.20 -> 1.0.21