### PR TITLE
CS-43546: Update in import command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23533,7 +23533,7 @@
         "@contentstack/cli-cm-clone": "~1.9.0",
         "@contentstack/cli-cm-export": "~1.10.2",
         "@contentstack/cli-cm-export-to-csv": "~1.6.2",
-        "@contentstack/cli-cm-import": "~1.13.0",
+        "@contentstack/cli-cm-import": "~1.13.1",
         "@contentstack/cli-cm-migrate-rte": "~1.4.15",
         "@contentstack/cli-cm-seed": "~1.7.1",
         "@contentstack/cli-command": "~1.2.17",
@@ -24249,7 +24249,7 @@
       "dependencies": {
         "@colors/colors": "^1.5.0",
         "@contentstack/cli-cm-export": "~1.10.2",
-        "@contentstack/cli-cm-import": "~1.13.0",
+        "@contentstack/cli-cm-import": "~1.13.1",
         "@contentstack/cli-command": "~1.2.16",
         "@contentstack/cli-utilities": "~1.5.10",
         "async": "^3.2.4",
@@ -25306,7 +25306,7 @@
     },
     "packages/contentstack-import": {
       "name": "@contentstack/cli-cm-import",
-      "version": "1.13.0",
+      "version": "1.13.1",
       "license": "MIT",
       "dependencies": {
         "@contentstack/cli-audit": "^1.3.2",
@@ -25881,7 +25881,7 @@
       "version": "1.7.1",
       "license": "MIT",
       "dependencies": {
-        "@contentstack/cli-cm-import": "~1.13.0",
+        "@contentstack/cli-cm-import": "~1.13.1",
         "@contentstack/cli-command": "~1.2.16",
         "@contentstack/cli-utilities": "~1.5.10",
         "inquirer": "8.2.4",

--- a/packages/contentstack-clone/package.json
+++ b/packages/contentstack-clone/package.json
@@ -6,7 +6,7 @@
   "bugs": "https://github.com/rohitmishra209/cli-cm-clone/issues",
   "dependencies": {
     "@contentstack/cli-cm-export": "~1.10.2",
-    "@contentstack/cli-cm-import": "~1.13.0",
+    "@contentstack/cli-cm-import": "~1.13.1",
     "@contentstack/cli-command": "~1.2.16",
     "@contentstack/cli-utilities": "~1.5.10",
     "@colors/colors": "^1.5.0",

--- a/packages/contentstack-import/package.json
+++ b/packages/contentstack-import/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contentstack/cli-cm-import",
   "description": "Contentstack CLI plugin to import content into stack",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "author": "Contentstack",
   "bugs": "https://github.com/contentstack/cli/issues",
   "dependencies": {

--- a/packages/contentstack-import/src/utils/common-helper.ts
+++ b/packages/contentstack-import/src/utils/common-helper.ts
@@ -249,3 +249,49 @@ export const formatDate = (date: Date = new Date()) => {
 
   return formattedDate;
 };
+
+// Get all the content types to validate whether all the content types are present in scope for the given extension
+export const getAllContentTypesFromStack:any = async (stackAPIClient:any) => {
+  try{
+    let contentTypes:any[] = []
+    const contentTypeCount:number = await getContentTypeCount(stackAPIClient);
+    for (let index = 0; index <= contentTypeCount / 100; index++) {
+      const contentTypesMap = await getContentTypes(stackAPIClient, index);
+      contentTypes = contentTypes.concat((Object.keys(contentTypesMap))); // prompt for content Type
+    }
+    return contentTypes
+  } catch (err) {
+    return err;
+  }
+}
+
+function getContentTypeCount(stackAPIClient:any):number|any {
+  return new Promise((resolve, reject) => {
+    stackAPIClient
+      .contentType()
+      .query()
+      .count()
+      .then((contentTypes:any) => resolve(contentTypes.content_types))
+      .catch((error:any) => reject(error));
+  });
+}
+
+
+function getContentTypes(stackAPIClient:any, skip:any) {
+  return new Promise((resolve, reject) => {
+    let result:any = {};
+    stackAPIClient
+      .contentType()
+      .query({ skip: skip * 100, include_branch: true })
+      .find()
+      .then((contentTypes:any) => {
+        contentTypes.items.forEach((contentType:any) => {
+          result[contentType.title] = contentType.uid;
+        });
+        resolve(result);
+      })
+      .catch((error:any) => {
+        reject(error);
+      });
+  });
+}

--- a/packages/contentstack-import/src/utils/content-type-helper.ts
+++ b/packages/contentstack-import/src/utils/content-type-helper.ts
@@ -147,6 +147,16 @@ export const removeReferenceFields = async function (
       flag.supressed = true;
       schema[i].reference_to = ['sys_assets'];
     }
+    else if (
+      // handling entry references in rte
+      schema[i].data_type === 'text' &&
+      schema[i].field_metadata.rich_text_type &&
+      schema[i].field_metadata.embed_entry &&
+      schema[i].reference_to.length >= 1
+    ) {
+      flag.supressed = true;
+      schema[i].reference_to = ['sys_assets'];
+    }
   }
 };
 

--- a/packages/contentstack-seed/package.json
+++ b/packages/contentstack-seed/package.json
@@ -5,7 +5,7 @@
   "author": "Contentstack",
   "bugs": "https://github.com/contentstack/cli/issues",
   "dependencies": {
-    "@contentstack/cli-cm-import": "~1.13.0",
+    "@contentstack/cli-cm-import": "~1.13.1",
     "@contentstack/cli-command": "~1.2.16",
     "@contentstack/cli-utilities": "~1.5.10",
     "inquirer": "8.2.4",

--- a/packages/contentstack/package.json
+++ b/packages/contentstack/package.json
@@ -30,7 +30,7 @@
     "@contentstack/cli-cm-clone": "~1.9.0",
     "@contentstack/cli-cm-export": "~1.10.2",
     "@contentstack/cli-cm-export-to-csv": "~1.6.2",
-    "@contentstack/cli-cm-import": "~1.13.0",
+    "@contentstack/cli-cm-import": "~1.13.1",
     "@contentstack/cli-cm-migrate-rte": "~1.4.15",
     "@contentstack/cli-cm-seed": "~1.7.1",
     "@contentstack/cli-command": "~1.2.17",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,7 +18,7 @@ importers:
       '@contentstack/cli-cm-clone': ~1.9.0
       '@contentstack/cli-cm-export': ~1.10.2
       '@contentstack/cli-cm-export-to-csv': ~1.6.2
-      '@contentstack/cli-cm-import': ~1.13.0
+      '@contentstack/cli-cm-import': ~1.13.1
       '@contentstack/cli-cm-migrate-rte': ~1.4.15
       '@contentstack/cli-cm-seed': ~1.7.1
       '@contentstack/cli-command': ~1.2.17
@@ -424,7 +424,7 @@ importers:
     specifiers:
       '@colors/colors': ^1.5.0
       '@contentstack/cli-cm-export': ~1.10.2
-      '@contentstack/cli-cm-import': ~1.13.0
+      '@contentstack/cli-cm-import': ~1.13.1
       '@contentstack/cli-command': ~1.2.16
       '@contentstack/cli-utilities': ~1.5.10
       '@oclif/test': ^1.2.7
@@ -986,7 +986,7 @@ importers:
 
   packages/contentstack-seed:
     specifiers:
-      '@contentstack/cli-cm-import': ~1.13.0
+      '@contentstack/cli-cm-import': ~1.13.1
       '@contentstack/cli-command': ~1.2.16
       '@contentstack/cli-utilities': ~1.5.10
       '@oclif/plugin-help': ^5.1.19


### PR DESCRIPTION
version bump: @contentstack/cli-cm-import
1.13.0 -> 1.13.1
1. Updated the global field to remove the references from RTE (Advanced and custom).
2. After the creation of content types add the create-extension so that the extensions which depend on content types are created

- Removed the extension from extensions which depend on the content type.
- Then once the content types are created then taking all the content types.
- If the title of the content type on which the extension is depending is there then adding the to the list of extensions that needed to be created.
- Creating the extension then and updating the mapper file