### PR TITLE
CS-44350 - Added support for removing the branches that are not being exported in the workflows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,9 +41,9 @@
       }
     },
     "node_modules/@apollo/client": {
-      "version": "3.9.6",
-      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.9.6.tgz",
-      "integrity": "sha512-+zpddcnZ4G2VZ0xIEnvIHFsLqeopNOnWuE2ZVbRuetLLpj/biLPNN719B/iofdd1/iHRclKfv0XaAmX6PBhYKA==",
+      "version": "3.9.7",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.9.7.tgz",
+      "integrity": "sha512-OEEwt55bkFhqihCT5d75KUxZt50JZ9MuIYwG7VZlyPPIAb9K+qzVWlXWlf3tB5DaV43yXkUSLQfNpdIBFOB55Q==",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
         "@wry/caches": "^1.0.0",
@@ -2068,12 +2068,12 @@
       }
     },
     "node_modules/@oclif/plugin-plugins": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@oclif/plugin-plugins/-/plugin-plugins-4.3.2.tgz",
-      "integrity": "sha512-PqnjKJPLJOLULLaT1Na9XhjY7MgVFxKcGRj0Pw5aRPXP1MADIwKDPUTdPzRHlGnnvEZc5eDX8TPOFoW7sx1vow==",
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/@oclif/plugin-plugins/-/plugin-plugins-4.3.5.tgz",
+      "integrity": "sha512-V5tivbXKZtibMVN4nqttUldMDNp2jb84QCZSsQr4hWTx8e5Tok+EXWXbh4HET1Ts3lxLbti1O0J6OE/Itf+haw==",
       "hasShrinkwrap": true,
       "dependencies": {
-        "@oclif/core": "^3.21.0",
+        "@oclif/core": "^3.23.0",
         "chalk": "^5.3.0",
         "debug": "^4.3.4",
         "npm": "10.2.4",
@@ -2123,9 +2123,9 @@
       }
     },
     "node_modules/@oclif/plugin-plugins/node_modules/@oclif/core": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-3.21.0.tgz",
-      "integrity": "sha512-xR7qGPOWtOnYmdYocSn6oEh2oTQLsPOXoj3HYGpb26V3WulwF8Cm33WPnMsSISv4ben3Rtc5i59u9O5NnuG42g==",
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-3.23.0.tgz",
+      "integrity": "sha512-giQ/8Ft8yXWg4IyPVtynPb7ihoQsa3A/1Q53UIJIhh+8k+EedE3lJ01yn6sq6Ha35IGqsG1WhkeHzlJIuldEaw==",
       "license": "MIT",
       "dependencies": {
         "@types/cli-progress": "^3.11.5",
@@ -2144,6 +2144,7 @@
         "indent-string": "^4.0.0",
         "is-wsl": "^2.2.0",
         "js-yaml": "^3.14.1",
+        "minimatch": "^9.0.3",
         "natural-orderby": "^2.0.3",
         "object-treeify": "^1.1.33",
         "password-prompt": "^1.1.3",
@@ -2210,6 +2211,12 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/@oclif/plugin-plugins/node_modules/@oclif/core/node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/@oclif/plugin-plugins/node_modules/@oclif/core/node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -2235,19 +2242,13 @@
       }
     },
     "node_modules/@oclif/plugin-plugins/node_modules/@types/cli-progress/node_modules/@types/node": {
-      "version": "20.8.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.6.tgz",
-      "integrity": "sha512-eWO4K2Ji70QzKUqRy6oyJWUeB7+g2cRagT3T/nxYibYcT4y2BDL8lqolRXjTHmkZCdJfIPaY73KbJAZmcryxTQ==",
+      "version": "20.11.25",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.25.tgz",
+      "integrity": "sha512-TBHyJxk2b7HceLVGFcpAUjsa5zIdsPWlR6XHfyGzd0SFu+/NFgQgMAl96MSDZgQDvJAvV6BKsFOrt6zIL09JDw==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.25.1"
+        "undici-types": "~5.26.4"
       }
-    },
-    "node_modules/@oclif/plugin-plugins/node_modules/@types/cli-progress/node_modules/undici-types": {
-      "version": "5.25.3",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.25.3.tgz",
-      "integrity": "sha512-Ga1jfYwRn7+cP9v8auvEXN1rX3sWqlayd4HP7OKk4mZWylEmu3KzXDUGrQUN6Ol7qo1gPvB2e5gX6udnyEPgdA==",
-      "license": "MIT"
     },
     "node_modules/@oclif/plugin-plugins/node_modules/ansi-escapes": {
       "version": "4.3.2",
@@ -2313,9 +2314,9 @@
       }
     },
     "node_modules/@oclif/plugin-plugins/node_modules/async": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
-      "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
+      "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg==",
       "license": "MIT"
     },
     "node_modules/@oclif/plugin-plugins/node_modules/balanced-match": {
@@ -2564,9 +2565,9 @@
       }
     },
     "node_modules/@oclif/plugin-plugins/node_modules/fast-glob": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
-      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -2580,9 +2581,9 @@
       }
     },
     "node_modules/@oclif/plugin-plugins/node_modules/fastq": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
-      "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
+      "integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -2627,6 +2628,15 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "license": "ISC"
     },
+    "node_modules/@oclif/plugin-plugins/node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/@oclif/plugin-plugins/node_modules/get-package-type": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
@@ -2668,15 +2678,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@oclif/plugin-plugins/node_modules/has": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.4.tgz",
-      "integrity": "sha512-qdSAmqLF6209RFj4VVItywPMbm3vWylknmB3nvNiUIs72xAimcM8nVYxYr7ncvZq5qzk9MKIZR8ijqD/1QuYjQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
     "node_modules/@oclif/plugin-plugins/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -2684,6 +2685,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@oclif/plugin-plugins/node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/@oclif/plugin-plugins/node_modules/hyperlinker": {
@@ -2696,9 +2709,9 @@
       }
     },
     "node_modules/@oclif/plugin-plugins/node_modules/ignore": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
-      "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
+      "integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==",
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -2739,12 +2752,12 @@
       }
     },
     "node_modules/@oclif/plugin-plugins/node_modules/is-core-module": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.0.tgz",
-      "integrity": "sha512-Z7dk6Qo8pOCp3l4tsX2C5ZVas4V+UxwQodwZhLopL91TX8UyyHEXafPcyoeeWuLrwzHcr3igO78wNLwHJHsMCQ==",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
+      "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
       "license": "MIT",
       "dependencies": {
-        "has": "^1.0.3"
+        "hasown": "^2.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -2840,6 +2853,16 @@
         "node": ">=10"
       }
     },
+    "node_modules/@oclif/plugin-plugins/node_modules/jake/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/@oclif/plugin-plugins/node_modules/jake/node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2854,6 +2877,18 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@oclif/plugin-plugins/node_modules/jake/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/@oclif/plugin-plugins/node_modules/merge2": {
@@ -2879,25 +2914,18 @@
       }
     },
     "node_modules/@oclif/plugin-plugins/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^2.0.1"
       },
       "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/@oclif/plugin-plugins/node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@oclif/plugin-plugins/node_modules/natural-orderby": {
@@ -5902,6 +5930,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/@oclif/plugin-plugins/node_modules/shelljs/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/@oclif/plugin-plugins/node_modules/shelljs/node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -5920,6 +5958,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@oclif/plugin-plugins/node_modules/shelljs/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/@oclif/plugin-plugins/node_modules/simple-swizzle": {
@@ -5962,12 +6012,6 @@
       "funding": {
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
-    },
-    "node_modules/@oclif/plugin-plugins/node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/@oclif/plugin-plugins/node_modules/string-width": {
       "version": "4.2.3",
@@ -6056,6 +6100,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@oclif/plugin-plugins/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT"
+    },
     "node_modules/@oclif/plugin-plugins/node_modules/validate-npm-package-name": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.0.tgz",
@@ -6116,9 +6166,9 @@
       "license": "ISC"
     },
     "node_modules/@oclif/plugin-plugins/node_modules/yarn": {
-      "version": "1.22.21",
-      "resolved": "https://registry.npmjs.org/yarn/-/yarn-1.22.21.tgz",
-      "integrity": "sha512-ynXaJsADJ9JiZ84zU25XkPGOvVMmZ5b7tmTSpKURYwgELdjucAOydqIOrOfTxVYcNXe91xvLZwcRh68SR3liCg==",
+      "version": "1.22.22",
+      "resolved": "https://registry.npmjs.org/yarn/-/yarn-1.22.22.tgz",
+      "integrity": "sha512-prL3kGtyG7o9Z9Sv8IPfBNrWTDmXB4Qbes8A9rEzt6wkJV8mUvoirjU0Mp3GGAU06Y0XQyA3/2/RQFVuK7MTfg==",
       "hasInstallScript": true,
       "license": "BSD-2-Clause",
       "bin": {
@@ -6763,9 +6813,9 @@
       }
     },
     "node_modules/@slack/logger/node_modules/@types/node": {
-      "version": "20.11.25",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.25.tgz",
-      "integrity": "sha512-TBHyJxk2b7HceLVGFcpAUjsa5zIdsPWlR6XHfyGzd0SFu+/NFgQgMAl96MSDZgQDvJAvV6BKsFOrt6zIL09JDw==",
+      "version": "20.11.27",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.27.tgz",
+      "integrity": "sha512-qyUZfMnCg1KEz57r7pzFtSGt49f6RPkPBis3Vo4PbS7roQEDn22hiHzl/Lo1q4i4hDEgBJmBF/NTNg2XR0HbFg==",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -7296,9 +7346,9 @@
       "dev": true
     },
     "node_modules/@types/lodash": {
-      "version": "4.14.202",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.202.tgz",
-      "integrity": "sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ=="
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.0.tgz",
+      "integrity": "sha512-t7dhREVv6dbNj0q17X12j7yDG4bD/DHYX7o5/DbDxobP0HnGPgpRz2Ej77aL7TZT3DSw13fqUTj8J4mMnqa7WA=="
     },
     "node_modules/@types/markdown-it": {
       "version": "12.2.3",
@@ -7863,9 +7913,9 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.10",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.10.tgz",
-      "integrity": "sha512-x0HvcHqVJNTPk/Bw8JbLWlWoo6Wwnsug0fnYYro1HBrjxZ3G7/AZk7Ahv8JwDe1uIcz8eBqvu86FuF1POiG7vQ==",
+      "version": "0.5.11",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.11.tgz",
+      "integrity": "sha512-bSG/kcTQRVyCZ3aOWt3nu/KGIxkfSNi7MXzgKr/MHfKbqPakFESQvaujpUaAG8OQuSroxYMY5vLMpdE6+oND2Q==",
       "engines": {
         "node": ">=6.0"
       }
@@ -8388,9 +8438,9 @@
       }
     },
     "node_modules/aws-sdk": {
-      "version": "2.1573.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1573.0.tgz",
-      "integrity": "sha512-Bl+rTEnjKdJrd0NfrLRVQq4AbSgK1+7yoWQTnreZTHCbYhzndP/3HLxA/8x0a8NZSb9oPC+7paFaWW00Xz/Gtw==",
+      "version": "2.1577.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1577.0.tgz",
+      "integrity": "sha512-B9glJQaJ53XEUUgFe6653n1ImuLgxFUJVIbEvafRlYhEcPW+1mzn4DjDWG0r9bMxDEIhSjAgIT1YoaJrxxT1iw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -9131,9 +9181,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001596",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001596.tgz",
-      "integrity": "sha512-zpkZ+kEr6We7w63ORkoJ2pOfBwBkY/bJrG/UZ90qNb45Isblu8wzDgevEOrRL1r9dWayHjYiiyCMEXPn4DweGQ==",
+      "version": "1.0.30001597",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001597.tgz",
+      "integrity": "sha512-7LjJvmQU6Sj7bL0j5b5WY/3n7utXUJvAe1lxhsHDbLmwX9mdL86Yjtr+5SRCyf8qME4M7pU2hswj0FpyBVCv9w==",
       "dev": true,
       "funding": [
         {
@@ -10606,9 +10656,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.698",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.698.tgz",
-      "integrity": "sha512-f9iZD1t3CLy1AS6vzM5EKGa6p9pRcOeEFXRFbaG2Ta+Oe7MkfRQ3fsvPYidzHe1h4i0JvIvpcY55C+B6BZNGtQ==",
+      "version": "1.4.704",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.704.tgz",
+      "integrity": "sha512-OK01+86Qvby1V6cTiowVbhp25aX4DLZnwar+NocAOXdzKAByd+jq5156bmo4kHwevWMknznW18Y/Svfk2dU91A==",
       "dev": true
     },
     "node_modules/elegant-spinner": {
@@ -10680,9 +10730,9 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.15.1",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.15.1.tgz",
-      "integrity": "sha512-3d3JRbwsCLJsYgvb6NuWEG44jjPSOMuS73L/6+7BZuoKm3W+qXnSoIYVHi8dG7Qcg4inAY4jbzkZ7MnskePeDg==",
+      "version": "5.16.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.16.0.tgz",
+      "integrity": "sha512-O+QWCviPNSSLAD9Ucn8Awv+poAkqn3T1XY5/N7kR7rQO9yfSGWkYZDwpJ+iKF7B8rxaQKWngSqACpgzeapSyoA==",
       "dev": true,
       "dependencies": {
         "graceful-fs": "^4.2.4",
@@ -11020,9 +11070,9 @@
       }
     },
     "node_modules/eslint-config-oclif-typescript": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-oclif-typescript/-/eslint-config-oclif-typescript-3.1.0.tgz",
-      "integrity": "sha512-ojIN4lrmhVFJLLJN7clDCww4ZYNLUaH6p9unp8awz9oCoYNRB2QYD5D/CAy7HiX9ULkInNAD59NeOGQY56Un6A==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-config-oclif-typescript/-/eslint-config-oclif-typescript-3.1.2.tgz",
+      "integrity": "sha512-6dk2DBzI5UGAg5Pl7b1k3a6d2/UQNO/uEJm92EEJp09fX3+HOy1Rj2BzcOxNKgLjdBV021HXgj5X/c1r1GS3jQ==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^6.21.0",
@@ -11030,9 +11080,9 @@
         "eslint-config-xo-space": "^0.35.0",
         "eslint-import-resolver-typescript": "^3.6.1",
         "eslint-plugin-import": "^2.29.1",
-        "eslint-plugin-mocha": "^10.3.0",
+        "eslint-plugin-mocha": "^10.4.1",
         "eslint-plugin-n": "^15",
-        "eslint-plugin-perfectionist": "^2.5.0"
+        "eslint-plugin-perfectionist": "^2.6.0"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -13387,9 +13437,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.1.tgz",
-      "integrity": "sha512-1/th4MHjnwncwXsIW6QMzlvYL9kG5e/CpVvLRZe4XPa8TOUNbCELqmvhDmnkNsAjwaG4+I8gJJL0JBvTTLO9qA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -14797,9 +14847,12 @@
       "dev": true
     },
     "node_modules/is-map": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
-      "integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -14962,9 +15015,12 @@
       }
     },
     "node_modules/is-set": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
-      "integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -21414,12 +21470,12 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/safe-array-concat": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.0.tgz",
-      "integrity": "sha512-ZdQ0Jeb9Ofti4hbt5lX3T2JcAamT9hfzYU1MNB+z/jaEbB6wfFfPIR/zEORmZqobkCCJhSjodobH6WHNmJ97dg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.2.tgz",
+      "integrity": "sha512-vj6RsCsWBCf19jIeHEfkRMw8DPiBb+DMXklQ/1SGDHOMlHdPUkZXFQ2YdplS23zESTijAcurb1aSgJA3AgMu1Q==",
       "dependencies": {
-        "call-bind": "^1.0.5",
-        "get-intrinsic": "^1.2.2",
+        "call-bind": "^1.0.7",
+        "get-intrinsic": "^1.2.4",
         "has-symbols": "^1.0.3",
         "isarray": "^2.0.5"
       },
@@ -21624,16 +21680,16 @@
       "dev": true
     },
     "node_modules/set-function-length": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.1.tgz",
-      "integrity": "sha512-j4t6ccc+VsKwYHso+kElc5neZpjtq9EnRICFZtWyBsLojhmeF/ZBd/elqm22WJh/BziDe/SBiOeAt0m2mfLD0g==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
       "dependencies": {
-        "define-data-property": "^1.1.2",
+        "define-data-property": "^1.1.4",
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.3",
+        "get-intrinsic": "^1.2.4",
         "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.1"
+        "has-property-descriptors": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -22993,9 +23049,9 @@
       }
     },
     "node_modules/ts-api-utils": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.2.1.tgz",
-      "integrity": "sha512-RIYA36cJn2WiH9Hy77hdF9r7oEwxAtB/TS9/S4Qd90Ap4z5FSiin5zEiTL44OII1Y3IIlEvxwxFUVgrHSZ/UpA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.3.0.tgz",
+      "integrity": "sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==",
       "dev": true,
       "engines": {
         "node": ">=16"
@@ -24092,15 +24148,15 @@
       }
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.14.tgz",
-      "integrity": "sha512-VnXFiIW8yNn9kIHN88xvZ4yOWchftKDsRJ8fEPacX/wl1lOvBrhsJ/OeJCXq7B0AaijRuqgzSKalJoPk+D8MPg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.15.tgz",
+      "integrity": "sha512-oV0jmFtUky6CXfkqehVvBP/LSWJ2sy4vWMioiENyJLePrBO/yKyV9OyJySfAKosh+RYkIl5zJCNZ8/4JncrpdA==",
       "dependencies": {
-        "available-typed-arrays": "^1.0.6",
-        "call-bind": "^1.0.5",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.7",
         "for-each": "^0.3.3",
         "gopd": "^1.0.1",
-        "has-tostringtag": "^1.0.1"
+        "has-tostringtag": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -25624,7 +25680,7 @@
       "version": "1.16.0",
       "license": "MIT",
       "dependencies": {
-        "@contentstack/cli-audit": "~1.5.0",
+        "@contentstack/cli-audit": "~1.5.1",
         "@contentstack/cli-auth": "~1.3.17",
         "@contentstack/cli-cm-bootstrap": "~1.9.0",
         "@contentstack/cli-cm-branches": "~1.0.23",
@@ -25689,7 +25745,7 @@
     },
     "packages/contentstack-audit": {
       "name": "@contentstack/cli-audit",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "MIT",
       "dependencies": {
         "@contentstack/cli-command": "~1.2.16",
@@ -25748,9 +25804,9 @@
       "dev": true
     },
     "packages/contentstack-audit/node_modules/@types/node": {
-      "version": "20.11.25",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.25.tgz",
-      "integrity": "sha512-TBHyJxk2b7HceLVGFcpAUjsa5zIdsPWlR6XHfyGzd0SFu+/NFgQgMAl96MSDZgQDvJAvV6BKsFOrt6zIL09JDw==",
+      "version": "20.11.27",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.27.tgz",
+      "integrity": "sha512-qyUZfMnCg1KEz57r7pzFtSGt49f6RPkPBis3Vo4PbS7roQEDn22hiHzl/Lo1q4i4hDEgBJmBF/NTNg2XR0HbFg==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -27137,7 +27193,7 @@
       "version": "1.14.2",
       "license": "MIT",
       "dependencies": {
-        "@contentstack/cli-audit": "~1.5.0",
+        "@contentstack/cli-audit": "~1.5.1",
         "@contentstack/cli-command": "~1.2.16",
         "@contentstack/cli-utilities": "~1.6.0",
         "@contentstack/management": "~1.15.3",
@@ -27357,9 +27413,9 @@
       "dev": true
     },
     "packages/contentstack-launch/node_modules/@types/node": {
-      "version": "16.18.87",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.87.tgz",
-      "integrity": "sha512-+IzfhNirR/MDbXz6Om5eHV54D9mQlEMGag6AgEzlju0xH3M8baCXYwqQ6RKgGMpn9wSTx6Ltya/0y4Z8eSfdLw==",
+      "version": "16.18.89",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.89.tgz",
+      "integrity": "sha512-QlrE8QI5z62nfnkiUZysUsAaxWaTMoGqFVcB3PvK1WxJ0c699bacErV4Fabe9Hki6ZnaHalgzihLbTl2d34XfQ==",
       "dev": true
     },
     "packages/contentstack-launch/node_modules/acorn": {

--- a/packages/contentstack-audit/package.json
+++ b/packages/contentstack-audit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentstack/cli-audit",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Contentstack audit plugin",
   "author": "Contentstack CLI",
   "homepage": "https://github.com/contentstack/cli",

--- a/packages/contentstack-audit/src/audit-base-command.ts
+++ b/packages/contentstack-audit/src/audit-base-command.ts
@@ -119,7 +119,6 @@ export abstract class AuditBaseCommand extends BaseCommand<typeof AuditBaseComma
         config: this.sharedConfig,
         fix: this.currentCommand === 'cm:stacks:audit:fix',
       };
-      // console.log(this.sharedConfig);
       switch (module) {
         case 'content-types':
           missingCtRefs = await new ContentType(cloneDeep(constructorParam)).run();

--- a/packages/contentstack-audit/src/audit-base-command.ts
+++ b/packages/contentstack-audit/src/audit-base-command.ts
@@ -113,7 +113,7 @@ export abstract class AuditBaseCommand extends BaseCommand<typeof AuditBaseComma
         config: this.sharedConfig,
         fix: this.currentCommand === 'cm:stacks:audit:fix',
       };
-
+      // console.log(this.sharedConfig);
       switch (module) {
         case 'content-types':
           missingCtRefs = await new ContentType(cloneDeep(constructorParam)).run();
@@ -303,7 +303,7 @@ export abstract class AuditBaseCommand extends BaseCommand<typeof AuditBaseComma
 
       const tableKeys = Object.keys(missingRefs[0]);
       const arrayOfObjects = tableKeys.map((key) => {
-        if (['title', 'name', 'uid', 'content_types', 'fixStatus'].includes(key)) {
+        if (['title', 'name', 'uid', 'content_types', 'branches', 'fixStatus'].includes(key)) {
           return {
             [key]: {
               minWidth: 7,
@@ -311,7 +311,7 @@ export abstract class AuditBaseCommand extends BaseCommand<typeof AuditBaseComma
               get: (row: Record<string, unknown>) => {
                 if (key === 'fixStatus') {
                   return chalk.green(typeof row[key] === 'object' ? JSON.stringify(row[key]) : row[key]);
-                } else if (key === 'content_types') {
+                } else if (key === 'content_types' || key === 'branches') {
                   return chalk.red(typeof row[key] === 'object' ? JSON.stringify(row[key]) : row[key]);
                 } else {
                   return chalk.white(typeof row[key] === 'object' ? JSON.stringify(row[key]) : row[key]);

--- a/packages/contentstack-audit/src/messages/index.ts
+++ b/packages/contentstack-audit/src/messages/index.ts
@@ -19,6 +19,7 @@ const commonMsg = {
   WORKFLOW_FIX_CONFIRMATION: 'Would you like to overwrite existing file?',
   EXTENSION_FIX_WARN: `The extension associated with UID {uid} and title '{title}' will be removed.`,
   EXTENSION_FIX_CONFIRMATION: `Would you like to overwrite existing file?`,
+  WF_BRANCH_REMOVAL: `Removing the branch '{branch} from workflow with UID {uid} and name {name} will be removed.'`,
 };
 
 const auditMsg = {

--- a/packages/contentstack-audit/src/modules/workflows.ts
+++ b/packages/contentstack-audit/src/modules/workflows.ts
@@ -21,6 +21,7 @@ export default class Workflows {
   public missingCtInWorkflows: Workflow[];
   public missingCts: Set<string>;
   public workflowPath: string;
+  public isBranchFixDone: boolean;
 
   constructor({
     log,
@@ -41,6 +42,7 @@ export default class Workflows {
     this.missingCtInWorkflows = [];
     this.missingCts = new Set();
     this.workflowPath = '';
+    this.isBranchFixDone = false;
   }
   /**
    * Check whether the given path for the workflow exists or not
@@ -54,69 +56,97 @@ export default class Workflows {
       this.log($t(auditMsg.NOT_VALID_PATH, { path: this.folderPath }), { color: 'yellow' });
       return {};
     }
-  
+
     this.workflowPath = join(this.folderPath, this.fileName);
-    this.workflowSchema = existsSync(this.workflowPath) ? values(JSON.parse(readFileSync(this.workflowPath, 'utf8')) as Workflow[]) : [];
-  
+    this.workflowSchema = existsSync(this.workflowPath)
+      ? values(JSON.parse(readFileSync(this.workflowPath, 'utf8')) as Workflow[])
+      : [];
+
     this.ctSchema.forEach((ct) => this.ctUidSet.add(ct.uid));
-  
+
     for (const workflow of this.workflowSchema) {
       const ctNotPresent = workflow.content_types.filter((ct) => !this.ctUidSet.has(ct));
-      if (ctNotPresent.length) {
+      const branch = workflow?.branches?.filter((branch) => branch !== this.config?.branch);
+
+      if (ctNotPresent.length || branch?.length) {
         const tempwf = cloneDeep(workflow);
-        tempwf.content_types = ctNotPresent;
+        tempwf.content_types = ctNotPresent || [];
+
+        if (workflow?.branches) {
+          tempwf.branches = branch;
+        }
+
+        if (branch?.length) {
+          this.isBranchFixDone = true;
+        }
+
         ctNotPresent.forEach((ct) => this.missingCts.add(ct));
         this.missingCtInWorkflows.push(tempwf);
       }
-  
+
       this.log(
         $t(auditMsg.SCAN_WF_SUCCESS_MSG, {
           name: workflow.name,
           module: this.config.moduleConfig[this.moduleName].name,
         }),
-        'info'
+        'info',
       );
     }
-  
-    if (this.fix && this.missingCtInWorkflows.length) {
+
+    if (this.fix && (this.missingCtInWorkflows.length || this.isBranchFixDone)) {
       await this.fixWorkflowSchema();
       this.missingCtInWorkflows.forEach((wf) => (wf.fixStatus = 'Fixed'));
     }
-  
+
     return this.missingCtInWorkflows;
   }
 
-  async fixWorkflowSchema() {  
+  async fixWorkflowSchema() {
     const newWorkflowSchema: Record<string, Workflow> = existsSync(this.workflowPath)
       ? JSON.parse(readFileSync(this.workflowPath, 'utf8'))
       : {};
-    
+
     if (Object.keys(newWorkflowSchema).length !== 0) {
-      for (const workflow of this.workflowSchema) {  
+      for (const workflow of this.workflowSchema) {
         const fixedCts = workflow.content_types.filter((ct) => !this.missingCts.has(ct));
+        const fixedBranches: string[] = [];
+
+        workflow?.branches?.forEach((branch) => {
+          if (branch !== this.config?.branch) {
+            const { uid, name } = workflow;
+            this.log($t(commonMsg.WF_BRANCH_REMOVAL, { uid, name, branch }), { color: 'yellow' });
+          } else {
+            fixedBranches.push(branch);
+          }
+        });
+
+        if (fixedBranches.length > 0) {
+          newWorkflowSchema[workflow.uid].branches = fixedBranches;
+        }
+
         if (fixedCts.length) {
           newWorkflowSchema[workflow.uid].content_types = fixedCts;
         } else {
           const { name, uid } = workflow;
           const warningMessage = $t(commonMsg.WORKFLOW_FIX_WARN, { name, uid });
-  
+
           this.log(warningMessage, { color: 'yellow' });
-  
+
           if (this.config.flags.yes || (await ux.confirm(commonMsg.WORKFLOW_FIX_CONFIRMATION))) {
             delete newWorkflowSchema[workflow.uid];
           }
         }
       }
     }
-  
+
     await this.writeFixContent(newWorkflowSchema);
   }
 
   async writeFixContent(newWorkflowSchema: Record<string, Workflow>) {
     if (
       this.fix ||
-      !(this.config.flags['copy-dir'] || this.config.flags['external-config']?.skipConfirm) &&
-      (this.config.flags.yes || (await ux.confirm(commonMsg.FIX_CONFIRMATION)))
+      (!(this.config.flags['copy-dir'] || this.config.flags['external-config']?.skipConfirm) &&
+        (this.config.flags.yes || (await ux.confirm(commonMsg.FIX_CONFIRMATION))))
     ) {
       writeFileSync(
         join(this.folderPath, this.config.moduleConfig[this.moduleName].fileName),

--- a/packages/contentstack-audit/src/types/content-types.ts
+++ b/packages/contentstack-audit/src/types/content-types.ts
@@ -51,6 +51,7 @@ type RefErrorReturnType = {
   uid?: string;
   content_types?: string[];
   title?: string;
+  branches?: string[];
 };
 
 // NOTE Type 1
@@ -119,6 +120,7 @@ enum OutputColumn {
   title = 'title',
   'uid' = 'uid',
   'missingCts' = 'content_types',
+  'Missing Branches' = 'branches',
 }
 
 export {

--- a/packages/contentstack-audit/src/types/content-types.ts
+++ b/packages/contentstack-audit/src/types/content-types.ts
@@ -51,8 +51,9 @@ type RefErrorReturnType = {
   uid?: string;
   content_types?: string[];
   title?: string;
-  branches?: string[];
 };
+
+type WorkflowExtensionsRefErrorReturnType = RefErrorReturnType & { branches?: string[] };
 
 // NOTE Type 1
 type ReferenceFieldDataType = CommonDataTypeStruct & {
@@ -139,4 +140,5 @@ export {
   OutputColumn,
   ContentTypeSchemaType,
   GlobalFieldSchemaTypes,
+  WorkflowExtensionsRefErrorReturnType,
 };

--- a/packages/contentstack-audit/src/types/workflow.ts
+++ b/packages/contentstack-audit/src/types/workflow.ts
@@ -9,5 +9,6 @@ export interface Workflow {
   enabled?: boolean;
   deleted_at?: any;
   missingRefs?: any;
-  fixStatus?:string
+  fixStatus?: string;
+  branches?: string[];
 }

--- a/packages/contentstack-audit/test/unit/mock/contents/workflows/workflows.json
+++ b/packages/contentstack-audit/test/unit/mock/contents/workflows/workflows.json
@@ -5,7 +5,9 @@
         "org_uid": "org1",
         "api_key": "apiKey",
         "content_types": [
-            "ct1"
+            "ct1",
+            "ct45",
+            "ct14"
         ],
         "enabled": false,
         "deleted_at": false
@@ -16,7 +18,8 @@
         "org_uid": "org1",
         "api_key": "apiKey",
         "content_types": [
-            "ct2"
+            "ct2",
+            "ct6"
         ],
         "enabled": false,
         "deleted_at": false
@@ -40,6 +43,22 @@
         "api_key": "apiKey",
         "content_types": [
             "ct4"
+        ],
+        "enabled": false,
+        "deleted_at": false
+    },
+    "wf5": {
+        "name": "wf5",
+        "uid": "wf5",
+        "org_uid": "org1",
+        "api_key": "apiKey",
+        "content_types": [
+            "ct4"
+        ],
+        "branches": [
+            "main",
+            "development",
+            "stage"
         ],
         "enabled": false,
         "deleted_at": false

--- a/packages/contentstack-audit/test/unit/modules/workflow.test.ts
+++ b/packages/contentstack-audit/test/unit/modules/workflow.test.ts
@@ -46,6 +46,7 @@ describe('Workflows', () => {
       .it(
         'should expect missingRefs equal to workflow which has missing refs, missingCts equal to missing Cts',
         async () => {
+          wf.config.branch = 'development';
           const missingRefs = await wf.run();
           expect(wf.workflowSchema).eql(values(JSON.parse(fs.readFileSync(wf.workflowPath, 'utf8'))));
           expect(missingRefs).eql([
@@ -67,31 +68,20 @@ describe('Workflows', () => {
               enabled: false,
               deleted_at: false,
             },
+            {
+              api_key: 'apiKey',
+              branches: ['main', 'stage'],
+              content_types: [],
+              deleted_at: false,
+              enabled: false,
+              name: 'wf5',
+              org_uid: 'org1',
+              uid: 'wf5',
+            },
           ]);
           expect(wf.missingCts).eql(new Set(['ct45', 'ct14', 'ct6']));
         },
       );
-  });
-
-  describe('run method with valid path and empty ctSchema to check the missing references', () => {
-    const wf = new Workflows({
-      log: () => {},
-      moduleName: 'workflows',
-      ctSchema: [],
-      config: Object.assign(config, {
-        basePath: resolve(`./test/unit/mock/contents/`),
-        flags: {},
-      }),
-    });
-
-    fancy
-      .stdout({ print: process.env.PRINT === 'true' || true })
-      .stub(ux, 'confirm', async () => true)
-      .it('should expect missingRefs equal to all workflows', async () => {
-        const missingRefs = await wf.run();
-        wf.workflowSchema.pop();
-        expect(missingRefs).eql(wf.workflowSchema);
-      });
   });
 
   describe('run method with audit fix for workflows with valid path and empty ctSchema', () => {
@@ -111,6 +101,7 @@ describe('Workflows', () => {
       .stub(wf, 'log', async () => {})
       .stub(ux, 'confirm', async () => true)
       .stub(wf, 'WriteFileSync', () => {})
+      .stub(wf, 'writeFixContent', () => {})
       .it('the run function should run and flow should go till fixWorkflowSchema', async () => {
         const fixedReference = await wf.run();
         expect(fixedReference).eql([
@@ -136,13 +127,14 @@ describe('Workflows', () => {
           },
           {
             api_key: 'apiKey',
-            content_types: ['ct88'],
+            branches: ['main', 'stage'],
+            content_types: [],
             deleted_at: false,
             enabled: false,
             fixStatus: 'Fixed',
-            name: 'wf6',
+            name: 'wf5',
             org_uid: 'org1',
-            uid: 'wf6',
+            uid: 'wf5',
           },
         ]);
       });

--- a/packages/contentstack-import/package.json
+++ b/packages/contentstack-import/package.json
@@ -5,7 +5,7 @@
   "author": "Contentstack",
   "bugs": "https://github.com/contentstack/cli/issues",
   "dependencies": {
-    "@contentstack/cli-audit": "~1.5.0",
+    "@contentstack/cli-audit": "~1.5.1",
     "@contentstack/cli-command": "~1.2.16",
     "@contentstack/cli-utilities": "~1.6.0",
     "@contentstack/management": "~1.15.3",

--- a/packages/contentstack-import/src/import/module-importer.ts
+++ b/packages/contentstack-import/src/import/module-importer.ts
@@ -117,7 +117,7 @@ class ModuleImporter {
     const basePath = resolve(this.importConfig.backupDir, 'logs', 'audit');
     const auditConfig = this.importConfig.auditConfig;
     auditConfig.config.basePath = basePath;
-
+    auditConfig.config.branch = this.importConfig.branchName;
     try {
       const args = [
         '--data-dir',

--- a/packages/contentstack-import/src/types/default-config.ts
+++ b/packages/contentstack-import/src/types/default-config.ts
@@ -153,7 +153,8 @@ export default interface DefaultConfig {
     returnResponse?: boolean; // On process completion should return config used in the command
     noTerminalOutput?: boolean; // Skip final audit table output on terminal
     config?: {
-      basePath?: string
+      basePath?: string;
+      branch?: string;
     } & Record<string, any>; // To overwrite any build-in config. And this config is equal to --config flag.
   };
 }

--- a/packages/contentstack/package.json
+++ b/packages/contentstack/package.json
@@ -22,7 +22,7 @@
     "prepack": "pnpm compile && oclif manifest && oclif readme"
   },
   "dependencies": {
-    "@contentstack/cli-audit": "~1.5.0",
+    "@contentstack/cli-audit": "~1.5.1",
     "@contentstack/cli-auth": "~1.3.17",
     "@contentstack/cli-cm-bootstrap": "~1.9.0",
     "@contentstack/cli-cm-branches": "~1.0.23",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
 
   packages/contentstack:
     specifiers:
-      '@contentstack/cli-audit': ~1.5.0
+      '@contentstack/cli-audit': ~1.5.1
       '@contentstack/cli-auth': ~1.3.17
       '@contentstack/cli-cm-bootstrap': ~1.9.0
       '@contentstack/cli-cm-branches': ~1.0.23
@@ -730,7 +730,7 @@ importers:
 
   packages/contentstack-import:
     specifiers:
-      '@contentstack/cli-audit': ~1.5.0
+      '@contentstack/cli-audit': ~1.5.1
       '@contentstack/cli-command': ~1.2.16
       '@contentstack/cli-utilities': ~1.6.0
       '@contentstack/management': ~1.15.3


### PR DESCRIPTION
Added the check to remove all the other branches than the one mentioned in the import and while doing audit we can pass branch to be kept using config flag and version bump currently only for workflows

version bump:
@contentstack/cli-audit: 1.5.0 -> 1.5.1