### PR TITLE
fixed the issue of filtering entries using the content-type flag in both cross-publish and entries publish and version bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1998,9 +1998,9 @@
       }
     },
     "node_modules/@oclif/plugin-plugins": {
-      "version": "5.0.9",
-      "resolved": "https://registry.npmjs.org/@oclif/plugin-plugins/-/plugin-plugins-5.0.9.tgz",
-      "integrity": "sha512-uXmJ/Tz8XXuPWdbmoV7QIwKCjUkB9FcQeaKEYlWlWPDeGK92qkx+oHlEW4XfRwnWqGl/81fmJ0RdyCE6fStbmw==",
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/@oclif/plugin-plugins/-/plugin-plugins-5.0.10.tgz",
+      "integrity": "sha512-IfiiNvE06zIoU1VQVU/CSLF2IqKsyj1t7nFwY3xV0KRLymynl1H58jsiFdK7cqyqNFpJtW8afJtqms0dC1rlHA==",
       "hasShrinkwrap": true,
       "dependencies": {
         "@oclif/core": "^3.26.2",
@@ -8003,9 +8003,9 @@
       }
     },
     "node_modules/aws-sdk": {
-      "version": "2.1599.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1599.0.tgz",
-      "integrity": "sha512-jPb1LAN+s1TLTK+VR3TTJLr//sb3AhhT60Bm9jxB5G/fVeeRczXtBtixNpQ00gksQdkstILYLc9S6MuKMsksxA==",
+      "version": "2.1600.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1600.0.tgz",
+      "integrity": "sha512-WX+9KYCr6PtQT+3c4AdjEZYI6X2C+XPlLOSodhG9OBk0Qj2D5n5IWAImq2hGjQg9v60cw+DmyMh0Du/m3DVoCA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -10272,9 +10272,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.737",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.737.tgz",
-      "integrity": "sha512-QvLTxaLHKdy5YxvixAw/FfHq2eWLUL9KvsPjp0aHK1gI5d3EDuDgITkvj0nFO2c6zUY3ZqVAJQiBYyQP9tQpfw==",
+      "version": "1.4.738",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.738.tgz",
+      "integrity": "sha512-lwKft2CLFztD+vEIpesrOtCrko/TFnEJlHFdRhazU7Y/jx5qc4cqsocfVrBg4So4gGe9lvxnbLIoev47WMpg+A==",
       "dev": true
     },
     "node_modules/elegant-spinner": {
@@ -25386,14 +25386,14 @@
     },
     "packages/contentstack": {
       "name": "@contentstack/cli",
-      "version": "1.17.3",
+      "version": "1.17.4",
       "license": "MIT",
       "dependencies": {
         "@contentstack/cli-audit": "~1.5.3",
         "@contentstack/cli-auth": "~1.3.17",
         "@contentstack/cli-cm-bootstrap": "~1.9.0",
         "@contentstack/cli-cm-branches": "~1.0.24",
-        "@contentstack/cli-cm-bulk-publish": "~1.4.4",
+        "@contentstack/cli-cm-bulk-publish": "~1.4.5",
         "@contentstack/cli-cm-clone": "~1.10.3",
         "@contentstack/cli-cm-export": "~1.11.2",
         "@contentstack/cli-cm-export-to-csv": "~1.7.0",
@@ -25888,7 +25888,7 @@
     },
     "packages/contentstack-bulk-publish": {
       "name": "@contentstack/cli-cm-bulk-publish",
-      "version": "1.4.4",
+      "version": "1.4.5",
       "license": "MIT",
       "dependencies": {
         "@contentstack/cli-command": "~1.2.16",

--- a/packages/contentstack-bulk-publish/package.json
+++ b/packages/contentstack-bulk-publish/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contentstack/cli-cm-bulk-publish",
   "description": "Contentstack CLI plugin for bulk publish actions",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "author": "Contentstack",
   "bugs": "https://github.com/contentstack/cli/issues",
   "dependencies": {

--- a/packages/contentstack-bulk-publish/src/commands/cm/bulk-publish/cross-publish.js
+++ b/packages/contentstack-bulk-publish/src/commands/cm/bulk-publish/cross-publish.js
@@ -124,7 +124,7 @@ class CrossPublishCommand extends Command {
 
   flagsAdapter(_flags) {
     if ('content-type' in _flags) {
-      _flags.contentType = _flags['content-type'];
+      _flags.contentTypes = _flags['content-type'];
       delete _flags['content-type'];
     }
     if ('locales' in _flags) {
@@ -196,7 +196,7 @@ CrossPublishCommand.flags = {
     default: 'true',
   }),
   'api-version': flags.string({
-    description : "API Version to be used. Values [Default: 3, Nested Reference Publishing: 3.2].",
+    description: 'API Version to be used. Values [Default: 3, Nested Reference Publishing: 3.2].',
   }),
   contentType: flags.string({
     char: 't',

--- a/packages/contentstack-bulk-publish/src/producer/cross-publish.js
+++ b/packages/contentstack-bulk-publish/src/producer/cross-publish.js
@@ -247,7 +247,7 @@ async function start(
     bulkPublish,
     _filter,
     deliveryToken,
-    contentType,
+    contentTypes,
     environment,
     locale,
     onlyAssets,
@@ -292,8 +292,8 @@ async function start(
     };
     if (f_types) filter.type = f_types;
     // filter.type = (f_types) ? f_types : types // types mentioned in the config file (f_types) are given preference
-    if (contentType) {
-      filter.content_type_uid = contentType;
+    if (contentTypes) {
+      filter.content_type_uid = contentTypes;
       filter.type = 'entry_published';
     }
     if (onlyAssets) {

--- a/packages/contentstack/package.json
+++ b/packages/contentstack/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contentstack/cli",
   "description": "Command-line tool (CLI) to interact with Contentstack",
-  "version": "1.17.3",
+  "version": "1.17.4",
   "author": "Contentstack",
   "bin": {
     "csdx": "./bin/run"
@@ -26,7 +26,7 @@
     "@contentstack/cli-auth": "~1.3.17",
     "@contentstack/cli-cm-bootstrap": "~1.9.0",
     "@contentstack/cli-cm-branches": "~1.0.24",
-    "@contentstack/cli-cm-bulk-publish": "~1.4.4",
+    "@contentstack/cli-cm-bulk-publish": "~1.4.5",
     "@contentstack/cli-cm-export": "~1.11.2",
     "@contentstack/cli-cm-clone": "~1.10.3",
     "@contentstack/cli-cm-export-to-csv": "~1.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,7 +14,7 @@ importers:
       '@contentstack/cli-auth': ~1.3.17
       '@contentstack/cli-cm-bootstrap': ~1.9.0
       '@contentstack/cli-cm-branches': ~1.0.24
-      '@contentstack/cli-cm-bulk-publish': ~1.4.4
+      '@contentstack/cli-cm-bulk-publish': ~1.4.5
       '@contentstack/cli-cm-clone': ~1.10.3
       '@contentstack/cli-cm-export': ~1.11.2
       '@contentstack/cli-cm-export-to-csv': ~1.7.0


### PR DESCRIPTION
version bump:
@contentstack/cli: 1.17.3 -> 1.17.4
@contentstack/cli-cm-bulk-publish: 1.4.4 -> 1.4.5