### PR TITLE
version bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15158,13 +15158,6 @@
         "which",
         "write-file-atomic"
       ],
-      "workspaces": [
-        "docs",
-        "smoke-tests",
-        "mock-globals",
-        "mock-registry",
-        "workspaces/*"
-      ],
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
         "@npmcli/arborist": "^7.5.3",
@@ -23050,11 +23043,6 @@
         "browserslist": ">= 4.21.0"
       }
     },
-    "node_modules/upgrade": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/upgrade/-/upgrade-1.1.0.tgz",
-      "integrity": "sha512-NtkVvqVCqsJo5U3mYRum2Tw6uCltOxfIJ/AfTZeTmw6U39IB5X23xF+kRZ9aiPaORqeiQQ7Q209/ibhOvxzwHA=="
-    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -24918,7 +24906,7 @@
         "@contentstack/cli-config": "~1.6.4",
         "@contentstack/cli-launch": "~1.0.18",
         "@contentstack/cli-migration": "~1.5.6",
-        "@contentstack/cli-utilities": "~1.6.2",
+        "@contentstack/cli-utilities": "~1.6.3",
         "@contentstack/management": "~1.15.3",
         "@oclif/core": "^3.26.5",
         "@oclif/plugin-help": "^5",
@@ -24972,7 +24960,7 @@
       "license": "MIT",
       "dependencies": {
         "@contentstack/cli-command": "~1.2.18",
-        "@contentstack/cli-utilities": "~1.6.2",
+        "@contentstack/cli-utilities": "~1.6.3",
         "@oclif/plugin-help": "^5",
         "@oclif/plugin-plugins": "^5.0.0",
         "chalk": "^4.1.2",
@@ -25246,7 +25234,7 @@
       "license": "MIT",
       "dependencies": {
         "@contentstack/cli-command": "~1.2.18",
-        "@contentstack/cli-utilities": "~1.6.2",
+        "@contentstack/cli-utilities": "~1.6.3",
         "chalk": "^4.0.0",
         "debug": "^4.1.1",
         "inquirer": "8.2.4",
@@ -25288,7 +25276,7 @@
       "dependencies": {
         "@contentstack/cli-cm-seed": "~1.7.6",
         "@contentstack/cli-command": "~1.2.18",
-        "@contentstack/cli-utilities": "~1.6.2",
+        "@contentstack/cli-utilities": "~1.6.3",
         "inquirer": "8.2.4",
         "mkdirp": "^1.0.4",
         "tar": "^6.2.1 "
@@ -25366,7 +25354,7 @@
       "license": "MIT",
       "dependencies": {
         "@contentstack/cli-command": "~1.2.18",
-        "@contentstack/cli-utilities": "~1.6.2",
+        "@contentstack/cli-utilities": "~1.6.3",
         "@oclif/core": "^3.26.5",
         "async": "^3.2.4",
         "big-json": "^3.2.0",
@@ -25415,7 +25403,7 @@
       "license": "MIT",
       "dependencies": {
         "@contentstack/cli-command": "~1.2.18",
-        "@contentstack/cli-utilities": "~1.6.2",
+        "@contentstack/cli-utilities": "~1.6.3",
         "bluebird": "^3.7.2",
         "chalk": "^4.1.2",
         "dotenv": "^16.1.4",
@@ -25455,7 +25443,7 @@
         "@contentstack/cli-cm-export": "~1.11.4",
         "@contentstack/cli-cm-import": "~1.16.0",
         "@contentstack/cli-command": "~1.2.18",
-        "@contentstack/cli-utilities": "~1.6.2",
+        "@contentstack/cli-utilities": "~1.6.3",
         "async": "^3.2.4",
         "chalk": "^4.1.0",
         "child_process": "^1.0.2",
@@ -25561,7 +25549,7 @@
       "version": "1.2.18",
       "license": "MIT",
       "dependencies": {
-        "@contentstack/cli-utilities": "~1.6.2",
+        "@contentstack/cli-utilities": "~1.6.3",
         "contentstack": "^3.10.1"
       },
       "devDependencies": {
@@ -25636,7 +25624,7 @@
       "license": "MIT",
       "dependencies": {
         "@contentstack/cli-command": "~1.2.18",
-        "@contentstack/cli-utilities": "~1.6.2",
+        "@contentstack/cli-utilities": "~1.6.3",
         "chalk": "^4.0.0",
         "debug": "^4.1.1",
         "inquirer": "8.2.4",
@@ -26019,7 +26007,7 @@
       "license": "MIT",
       "dependencies": {
         "@contentstack/cli-command": "~1.2.18",
-        "@contentstack/cli-utilities": "~1.6.2",
+        "@contentstack/cli-utilities": "~1.6.3",
         "@oclif/core": "^3.26.5",
         "async": "^3.2.4",
         "big-json": "^3.2.0",
@@ -26069,7 +26057,7 @@
       "license": "MIT",
       "dependencies": {
         "@contentstack/cli-command": "~1.2.18",
-        "@contentstack/cli-utilities": "~1.6.2",
+        "@contentstack/cli-utilities": "~1.6.3",
         "chalk": "^4.1.0",
         "fast-csv": "^4.3.6",
         "inquirer": "8.2.4",
@@ -26543,7 +26531,7 @@
       "dependencies": {
         "@contentstack/cli-audit": "~1.6.2",
         "@contentstack/cli-command": "~1.2.18",
-        "@contentstack/cli-utilities": "~1.6.2",
+        "@contentstack/cli-utilities": "~1.6.3",
         "@contentstack/management": "~1.15.3",
         "@oclif/core": "^3.26.5",
         "big-json": "^3.2.0",
@@ -26657,7 +26645,7 @@
       "dependencies": {
         "@apollo/client": "^3.7.9",
         "@contentstack/cli-command": "~1.2.18",
-        "@contentstack/cli-utilities": "~1.6.2",
+        "@contentstack/cli-utilities": "~1.6.3",
         "@oclif/core": "^3.26.5",
         "@oclif/plugin-help": "^5",
         "@oclif/plugin-plugins": "^5.0.0",
@@ -26952,7 +26940,7 @@
       "license": "MIT",
       "dependencies": {
         "@contentstack/cli-command": "~1.2.18",
-        "@contentstack/cli-utilities": "~1.6.2",
+        "@contentstack/cli-utilities": "~1.6.3",
         "@contentstack/json-rte-serializer": "~2.0.4",
         "chalk": "^4.1.2",
         "collapse-whitespace": "^1.1.7",
@@ -26991,7 +26979,7 @@
       "license": "MIT",
       "dependencies": {
         "@contentstack/cli-command": "~1.2.18",
-        "@contentstack/cli-utilities": "~1.6.2",
+        "@contentstack/cli-utilities": "~1.6.3",
         "async": "^3.2.4",
         "callsites": "^3.1.0",
         "cardinal": "^2.1.1",
@@ -27025,7 +27013,7 @@
       "dependencies": {
         "@contentstack/cli-cm-import": "~1.16.0",
         "@contentstack/cli-command": "~1.2.18",
-        "@contentstack/cli-utilities": "~1.6.2",
+        "@contentstack/cli-utilities": "~1.6.3",
         "inquirer": "8.2.4",
         "mkdirp": "^1.0.4",
         "tar": "^6.1.13",
@@ -27101,7 +27089,7 @@
     },
     "packages/contentstack-utilities": {
       "name": "@contentstack/cli-utilities",
-      "version": "1.6.2",
+      "version": "1.6.3",
       "license": "MIT",
       "dependencies": {
         "@contentstack/management": "~1.15.3",
@@ -27126,7 +27114,6 @@
         "rxjs": "^6.6.7",
         "traverse": "^0.6.7",
         "unique-string": "^2.0.0",
-        "upgrade": "^1.1.0",
         "uuid": "^9.0.0",
         "winston": "^3.7.2",
         "xdg-basedir": "^4.0.0"

--- a/packages/contentstack-audit/package.json
+++ b/packages/contentstack-audit/package.json
@@ -19,7 +19,7 @@
   ],
   "dependencies": {
     "@contentstack/cli-command": "~1.2.18",
-    "@contentstack/cli-utilities": "~1.6.2",
+    "@contentstack/cli-utilities": "~1.6.3",
     "@oclif/plugin-help": "^5",
     "@oclif/plugin-plugins": "^5.0.0",
     "chalk": "^4.1.2",

--- a/packages/contentstack-auth/package.json
+++ b/packages/contentstack-auth/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@contentstack/cli-command": "~1.2.18",
-    "@contentstack/cli-utilities": "~1.6.2",
+    "@contentstack/cli-utilities": "~1.6.3",
     "chalk": "^4.0.0",
     "debug": "^4.1.1",
     "inquirer": "8.2.4",

--- a/packages/contentstack-bootstrap/package.json
+++ b/packages/contentstack-bootstrap/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@contentstack/cli-cm-seed": "~1.7.6",
     "@contentstack/cli-command": "~1.2.18",
-    "@contentstack/cli-utilities": "~1.6.2",
+    "@contentstack/cli-utilities": "~1.6.3",
     "inquirer": "8.2.4",
     "mkdirp": "^1.0.4",
     "tar": "^6.2.1 "

--- a/packages/contentstack-branches/package.json
+++ b/packages/contentstack-branches/package.json
@@ -6,7 +6,7 @@
   "bugs": "https://github.com/contentstack/cli/issues",
   "dependencies": {
     "@contentstack/cli-command": "~1.2.18",
-    "@contentstack/cli-utilities": "~1.6.2",
+    "@contentstack/cli-utilities": "~1.6.3",
     "@oclif/core": "^3.26.5",
     "async": "^3.2.4",
     "big-json": "^3.2.0",

--- a/packages/contentstack-bulk-publish/package.json
+++ b/packages/contentstack-bulk-publish/package.json
@@ -6,7 +6,7 @@
   "bugs": "https://github.com/contentstack/cli/issues",
   "dependencies": {
     "@contentstack/cli-command": "~1.2.18",
-    "@contentstack/cli-utilities": "~1.6.2",
+    "@contentstack/cli-utilities": "~1.6.3",
     "bluebird": "^3.7.2",
     "chalk": "^4.1.2",
     "dotenv": "^16.1.4",

--- a/packages/contentstack-clone/package.json
+++ b/packages/contentstack-clone/package.json
@@ -9,7 +9,7 @@
     "@contentstack/cli-cm-export": "~1.11.4",
     "@contentstack/cli-cm-import": "~1.16.0",
     "@contentstack/cli-command": "~1.2.18",
-    "@contentstack/cli-utilities": "~1.6.2",
+    "@contentstack/cli-utilities": "~1.6.3",
     "async": "^3.2.4",
     "chalk": "^4.1.0",
     "child_process": "^1.0.2",

--- a/packages/contentstack-command/package.json
+++ b/packages/contentstack-command/package.json
@@ -17,7 +17,7 @@
     "format": "eslint src/**/*.ts --fix"
   },
   "dependencies": {
-    "@contentstack/cli-utilities": "~1.6.2",
+    "@contentstack/cli-utilities": "~1.6.3",
     "contentstack": "^3.10.1"
   },
   "devDependencies": {

--- a/packages/contentstack-config/package.json
+++ b/packages/contentstack-config/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@contentstack/cli-command": "~1.2.18",
-    "@contentstack/cli-utilities": "~1.6.2",
+    "@contentstack/cli-utilities": "~1.6.3",
     "chalk": "^4.0.0",
     "debug": "^4.1.1",
     "inquirer": "8.2.4",

--- a/packages/contentstack-export-to-csv/package.json
+++ b/packages/contentstack-export-to-csv/package.json
@@ -6,7 +6,7 @@
   "bugs": "https://github.com/contentstack/cli/issues",
   "dependencies": {
     "@contentstack/cli-command": "~1.2.18",
-    "@contentstack/cli-utilities": "~1.6.2",
+    "@contentstack/cli-utilities": "~1.6.3",
     "chalk": "^4.1.0",
     "fast-csv": "^4.3.6",
     "inquirer": "8.2.4",

--- a/packages/contentstack-export/package.json
+++ b/packages/contentstack-export/package.json
@@ -6,7 +6,7 @@
   "bugs": "https://github.com/contentstack/cli/issues",
   "dependencies": {
     "@contentstack/cli-command": "~1.2.18",
-    "@contentstack/cli-utilities": "~1.6.2",
+    "@contentstack/cli-utilities": "~1.6.3",
     "@oclif/core": "^3.26.5",
     "async": "^3.2.4",
     "big-json": "^3.2.0",

--- a/packages/contentstack-import/package.json
+++ b/packages/contentstack-import/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@contentstack/cli-audit": "~1.6.2",
     "@contentstack/cli-command": "~1.2.18",
-    "@contentstack/cli-utilities": "~1.6.2",
+    "@contentstack/cli-utilities": "~1.6.3",
     "@contentstack/management": "~1.15.3",
     "@oclif/core": "^3.26.5",
     "big-json": "^3.2.0",

--- a/packages/contentstack-launch/package.json
+++ b/packages/contentstack-launch/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@apollo/client": "^3.7.9",
     "@contentstack/cli-command": "~1.2.18",
-    "@contentstack/cli-utilities": "~1.6.2",
+    "@contentstack/cli-utilities": "~1.6.3",
     "@oclif/core": "^3.26.5",
     "@oclif/plugin-help": "^5",
     "@oclif/plugin-plugins": "^5.0.0",

--- a/packages/contentstack-migrate-rte/package.json
+++ b/packages/contentstack-migrate-rte/package.json
@@ -6,7 +6,7 @@
   "bugs": "https://github.com/contentstack/cli/issues",
   "dependencies": {
     "@contentstack/cli-command": "~1.2.18",
-    "@contentstack/cli-utilities": "~1.6.2",
+    "@contentstack/cli-utilities": "~1.6.3",
     "@contentstack/json-rte-serializer": "~2.0.4",
     "collapse-whitespace": "^1.1.7",
     "chalk": "^4.1.2",

--- a/packages/contentstack-migration/package.json
+++ b/packages/contentstack-migration/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/contentstack/cli/issues",
   "dependencies": {
     "@contentstack/cli-command": "~1.2.18",
-    "@contentstack/cli-utilities": "~1.6.2",
+    "@contentstack/cli-utilities": "~1.6.3",
     "async": "^3.2.4",
     "callsites": "^3.1.0",
     "cardinal": "^2.1.1",

--- a/packages/contentstack-seed/package.json
+++ b/packages/contentstack-seed/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@contentstack/cli-cm-import": "~1.16.0",
     "@contentstack/cli-command": "~1.2.18",
-    "@contentstack/cli-utilities": "~1.6.2",
+    "@contentstack/cli-utilities": "~1.6.3",
     "inquirer": "8.2.4",
     "mkdirp": "^1.0.4",
     "tar": "^6.1.13",

--- a/packages/contentstack-utilities/package.json
+++ b/packages/contentstack-utilities/package.json
@@ -54,7 +54,6 @@
     "rxjs": "^6.6.7",
     "traverse": "^0.6.7",
     "unique-string": "^2.0.0",
-    "upgrade": "^1.1.0",
     "uuid": "^9.0.0",
     "winston": "^3.7.2",
     "xdg-basedir": "^4.0.0"

--- a/packages/contentstack/package.json
+++ b/packages/contentstack/package.json
@@ -37,7 +37,7 @@
     "@contentstack/cli-config": "~1.6.4",
     "@contentstack/cli-launch": "~1.0.18",
     "@contentstack/cli-migration": "~1.5.6",
-    "@contentstack/cli-utilities": "~1.6.2",
+    "@contentstack/cli-utilities": "~1.6.3",
     "@contentstack/management": "~1.15.3",
     "@oclif/core": "^3.26.5",
     "@oclif/plugin-help": "^5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,7 +25,7 @@ importers:
       '@contentstack/cli-config': ~1.6.4
       '@contentstack/cli-launch': ~1.0.18
       '@contentstack/cli-migration': ~1.5.6
-      '@contentstack/cli-utilities': ~1.6.2
+      '@contentstack/cli-utilities': ~1.6.3
       '@contentstack/management': ~1.15.3
       '@oclif/core': ^3.26.5
       '@oclif/plugin-help': ^5
@@ -123,7 +123,7 @@ importers:
     specifiers:
       '@contentstack/cli-command': ~1.2.18
       '@contentstack/cli-dev-dependencies': ^1.2.4
-      '@contentstack/cli-utilities': ~1.6.2
+      '@contentstack/cli-utilities': ~1.6.3
       '@oclif/plugin-help': ^5
       '@oclif/plugin-plugins': ^5.0.0
       '@oclif/test': ^2.5.6
@@ -187,7 +187,7 @@ importers:
   packages/contentstack-auth:
     specifiers:
       '@contentstack/cli-command': ~1.2.18
-      '@contentstack/cli-utilities': ~1.6.2
+      '@contentstack/cli-utilities': ~1.6.3
       '@fancy-test/nock': ^0.1.1
       '@oclif/plugin-help': ^5.1.19
       '@oclif/test': ^2.5.6
@@ -251,7 +251,7 @@ importers:
     specifiers:
       '@contentstack/cli-cm-seed': ~1.7.6
       '@contentstack/cli-command': ~1.2.18
-      '@contentstack/cli-utilities': ~1.6.2
+      '@contentstack/cli-utilities': ~1.6.3
       '@oclif/test': ^2.5.6
       '@types/inquirer': ^9.0.3
       '@types/mkdirp': ^1.0.1
@@ -304,7 +304,7 @@ importers:
       '@contentstack/cli-command': ~1.2.18
       '@contentstack/cli-config': ~1.6.4
       '@contentstack/cli-dev-dependencies': ~1.2.4
-      '@contentstack/cli-utilities': ~1.6.2
+      '@contentstack/cli-utilities': ~1.6.3
       '@oclif/core': ^3.26.5
       '@oclif/plugin-help': ^5.1.19
       '@oclif/test': ^2.5.6
@@ -380,7 +380,7 @@ importers:
   packages/contentstack-bulk-publish:
     specifiers:
       '@contentstack/cli-command': ~1.2.18
-      '@contentstack/cli-utilities': ~1.6.2
+      '@contentstack/cli-utilities': ~1.6.3
       '@oclif/test': ^2.5.6
       bluebird: ^3.7.2
       chai: ^4.2.0
@@ -426,7 +426,7 @@ importers:
       '@contentstack/cli-cm-export': ~1.11.4
       '@contentstack/cli-cm-import': ~1.16.0
       '@contentstack/cli-command': ~1.2.18
-      '@contentstack/cli-utilities': ~1.6.2
+      '@contentstack/cli-utilities': ~1.6.3
       '@oclif/test': ^2.5.6
       async: ^3.2.4
       chai: ^4.2.0
@@ -479,7 +479,7 @@ importers:
 
   packages/contentstack-command:
     specifiers:
-      '@contentstack/cli-utilities': ~1.6.2
+      '@contentstack/cli-utilities': ~1.6.3
       '@oclif/test': ^2.5.6
       '@types/chai': ^4.2.18
       '@types/mkdirp': ^1.0.1
@@ -521,7 +521,7 @@ importers:
   packages/contentstack-config:
     specifiers:
       '@contentstack/cli-command': ~1.2.18
-      '@contentstack/cli-utilities': ~1.6.2
+      '@contentstack/cli-utilities': ~1.6.3
       '@oclif/test': ^2.5.6
       '@types/chai': ^4.2.18
       '@types/inquirer': ^9.0.3
@@ -610,7 +610,7 @@ importers:
       '@contentstack/cli-command': ~1.2.18
       '@contentstack/cli-config': ~1.6.4
       '@contentstack/cli-dev-dependencies': ~1.2.4
-      '@contentstack/cli-utilities': ~1.6.2
+      '@contentstack/cli-utilities': ~1.6.3
       '@oclif/core': ^3.26.5
       '@oclif/plugin-help': ^5.1.19
       '@oclif/test': ^2.5.6
@@ -688,7 +688,7 @@ importers:
   packages/contentstack-export-to-csv:
     specifiers:
       '@contentstack/cli-command': ~1.2.18
-      '@contentstack/cli-utilities': ~1.6.2
+      '@contentstack/cli-utilities': ~1.6.3
       '@oclif/test': ^2.5.6
       '@types/chai': ^4.3.6
       '@types/mocha': ^10.0.1
@@ -732,7 +732,7 @@ importers:
     specifiers:
       '@contentstack/cli-audit': ~1.6.2
       '@contentstack/cli-command': ~1.2.18
-      '@contentstack/cli-utilities': ~1.6.2
+      '@contentstack/cli-utilities': ~1.6.3
       '@contentstack/management': ~1.15.3
       '@oclif/core': ^3.26.5
       '@oclif/test': ^2.5.6
@@ -821,7 +821,7 @@ importers:
     specifiers:
       '@apollo/client': ^3.7.9
       '@contentstack/cli-command': ~1.2.18
-      '@contentstack/cli-utilities': ~1.6.2
+      '@contentstack/cli-utilities': ~1.6.3
       '@oclif/core': ^3.26.5
       '@oclif/plugin-help': ^5
       '@oclif/plugin-plugins': ^5.0.0
@@ -897,7 +897,7 @@ importers:
   packages/contentstack-migrate-rte:
     specifiers:
       '@contentstack/cli-command': ~1.2.18
-      '@contentstack/cli-utilities': ~1.6.2
+      '@contentstack/cli-utilities': ~1.6.3
       '@contentstack/json-rte-serializer': ~2.0.4
       '@oclif/test': ^2.5.6
       chai: ^4.3.4
@@ -944,7 +944,7 @@ importers:
   packages/contentstack-migration:
     specifiers:
       '@contentstack/cli-command': ~1.2.18
-      '@contentstack/cli-utilities': ~1.6.2
+      '@contentstack/cli-utilities': ~1.6.3
       '@oclif/test': ^2.5.6
       async: ^3.2.4
       callsites: ^3.1.0
@@ -992,7 +992,7 @@ importers:
     specifiers:
       '@contentstack/cli-cm-import': ~1.16.0
       '@contentstack/cli-command': ~1.2.18
-      '@contentstack/cli-utilities': ~1.6.2
+      '@contentstack/cli-utilities': ~1.6.3
       '@oclif/plugin-help': ^5.1.19
       '@types/inquirer': ^9.0.3
       '@types/jest': ^26.0.15
@@ -1047,7 +1047,7 @@ importers:
     specifiers:
       '@contentstack/cli-dev-dependencies': ^1.2.4
       '@contentstack/management': ~1.15.3
-      '@contentstack/marketplace-sdk': ^1.0.1
+      '@contentstack/marketplace-sdk': ^1.1.1
       '@oclif/core': ^3.26.5
       '@oclif/test': ^2.5.6
       '@types/chai': ^4.2.18


### PR DESCRIPTION
- upgraded contentstack/cli-utilities in each plugin 1.6.2 -> 1.6.3
- removed 'upgrade'  dependency from contentstack/cli-utilities