### PR TITLE
fix: handle name conflict in case of custom extension

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24852,7 +24852,7 @@
     },
     "packages/contentstack": {
       "name": "@contentstack/cli",
-      "version": "1.21.0",
+      "version": "1.21.1",
       "license": "MIT",
       "dependencies": {
         "@contentstack/cli-audit": "~1.6.4",
@@ -24863,7 +24863,7 @@
         "@contentstack/cli-cm-clone": "~1.10.7",
         "@contentstack/cli-cm-export": "~1.11.6",
         "@contentstack/cli-cm-export-to-csv": "~1.7.2",
-        "@contentstack/cli-cm-import": "~1.16.2",
+        "@contentstack/cli-cm-import": "~1.16.3",
         "@contentstack/cli-cm-migrate-rte": "~1.4.18",
         "@contentstack/cli-cm-seed": "~1.7.7",
         "@contentstack/cli-command": "~1.2.19",
@@ -25421,7 +25421,7 @@
       "dependencies": {
         "@colors/colors": "^1.5.0",
         "@contentstack/cli-cm-export": "~1.11.6",
-        "@contentstack/cli-cm-import": "~1.16.2",
+        "@contentstack/cli-cm-import": "~1.16.3",
         "@contentstack/cli-command": "~1.2.19",
         "@contentstack/cli-utilities": "~1.7.0",
         "async": "^3.2.4",
@@ -26533,7 +26533,7 @@
     },
     "packages/contentstack-import": {
       "name": "@contentstack/cli-cm-import",
-      "version": "1.16.2",
+      "version": "1.16.3",
       "license": "MIT",
       "dependencies": {
         "@contentstack/cli-audit": "~1.6.3",
@@ -27029,7 +27029,7 @@
       "version": "1.7.7",
       "license": "MIT",
       "dependencies": {
-        "@contentstack/cli-cm-import": "~1.16.2",
+        "@contentstack/cli-cm-import": "~1.16.3",
         "@contentstack/cli-command": "~1.2.19",
         "@contentstack/cli-utilities": "~1.7.0",
         "inquirer": "8.2.4",

--- a/packages/contentstack-clone/package.json
+++ b/packages/contentstack-clone/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@colors/colors": "^1.5.0",
     "@contentstack/cli-cm-export": "~1.11.6",
-    "@contentstack/cli-cm-import": "~1.16.2",
+    "@contentstack/cli-cm-import": "~1.16.3",
     "@contentstack/cli-command": "~1.2.19",
     "@contentstack/cli-utilities": "~1.7.0",
     "async": "^3.2.4",

--- a/packages/contentstack-import/README.md
+++ b/packages/contentstack-import/README.md
@@ -47,7 +47,7 @@ $ npm install -g @contentstack/cli-cm-import
 $ csdx COMMAND
 running command...
 $ csdx (--version)
-@contentstack/cli-cm-import/1.16.2 darwin-arm64 node-v22.2.0
+@contentstack/cli-cm-import/1.16.3 darwin-arm64 node-v22.2.0
 $ csdx --help [COMMAND]
 USAGE
   $ csdx COMMAND

--- a/packages/contentstack-import/package.json
+++ b/packages/contentstack-import/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contentstack/cli-cm-import",
   "description": "Contentstack CLI plugin to import content into stack",
-  "version": "1.16.2",
+  "version": "1.16.3",
   "author": "Contentstack",
   "bugs": "https://github.com/contentstack/cli/issues",
   "dependencies": {

--- a/packages/contentstack-import/src/import/modules/marketplace-apps.ts
+++ b/packages/contentstack-import/src/import/modules/marketplace-apps.ts
@@ -19,7 +19,7 @@ import {
 } from '@contentstack/cli-utilities';
 
 import { trace } from '../../utils/log';
-import { askEncryptionKey, getAppName } from '../../utils/interactive';
+import { askEncryptionKey, getLocationName } from '../../utils/interactive';
 import { ModuleClassParams, MarketplaceAppsConfig, ImportConfig, Installation, Manifest } from '../../types';
 import {
   log,
@@ -51,6 +51,7 @@ export default class ImportMarketplaceApps {
   public developerHubBaseUrl: string;
   public nodeCrypto: NodeCrypto;
   public appSdk: ContentstackMarketplaceClient;
+  public existingNames: Set<string>;
 
   constructor({ importConfig }: ModuleClassParams) {
     this.importConfig = importConfig;
@@ -63,6 +64,7 @@ export default class ImportMarketplaceApps {
     this.appOriginalName = undefined;
     this.installedApps = [];
     this.installationUidMapping = {};
+    this.existingNames = new Set<string>();
   }
 
   /**
@@ -346,7 +348,7 @@ export default class ImportMarketplaceApps {
       if (location.meta) {
         location.meta = map(location.meta, (meta) => {
           if (meta.name && this.appOriginalName == meta.name) {
-            const name = getAppName(first(split(meta.name, '◈')), appSuffix);
+            const name = getLocationName(first(split(meta.name, '◈')), appSuffix, this.existingNames);
 
             if (!this.appNameMapping[this.appOriginalName]) {
               this.appNameMapping[this.appOriginalName] = name;
@@ -354,7 +356,7 @@ export default class ImportMarketplaceApps {
 
             meta.name = name;
           } else if (meta.name) {
-            meta.name = getAppName(first(split(meta.name, '◈')), appSuffix + (+index + 1));
+            meta.name = getLocationName(first(split(meta.name, '◈')), appSuffix + (+index + 1), this.existingNames);
           }
 
           return meta;

--- a/packages/contentstack-import/src/utils/interactive.ts
+++ b/packages/contentstack-import/src/utils/interactive.ts
@@ -53,6 +53,29 @@ export const getAppName= (name: string, appSuffix = 1) => {
   return name;
 }
 
+export const getLocationName= (name: string, appSuffix = 1, existingNames: Set<string>) => {
+  const maxLength = 50;
+  const suffixLength = appSuffix.toString().length + 1; // +1 for the '◈' character
+
+  let truncatedName = name;
+  if (name.length + suffixLength > maxLength) {
+    truncatedName = name.slice(0, maxLength - suffixLength);
+  }
+
+  let newName = `${first(split(truncatedName, '◈'))}◈${appSuffix}`;
+
+  // Ensure uniqueness
+  while (existingNames.has(newName)) {
+    appSuffix++;
+    newName = `${first(split(truncatedName, '◈'))}◈${appSuffix}`;
+  }
+
+  // Add the new name to the set of existing names
+  existingNames.add(newName);
+
+  return newName;
+}
+
 const validateAppName =(name: string ) =>{
   if (name.length < 3 || name.length > 20) {
     return 'The app name should be within 3-20 characters long.';

--- a/packages/contentstack-seed/package.json
+++ b/packages/contentstack-seed/package.json
@@ -5,7 +5,7 @@
   "author": "Contentstack",
   "bugs": "https://github.com/contentstack/cli/issues",
   "dependencies": {
-    "@contentstack/cli-cm-import": "~1.16.2",
+    "@contentstack/cli-cm-import": "~1.16.3",
     "@contentstack/cli-command": "~1.2.19",
     "@contentstack/cli-utilities": "~1.7.0",
     "inquirer": "8.2.4",

--- a/packages/contentstack/README.md
+++ b/packages/contentstack/README.md
@@ -18,7 +18,7 @@ $ npm install -g @contentstack/cli
 $ csdx COMMAND
 running command...
 $ csdx (--version|-v)
-@contentstack/cli/1.21.0 darwin-arm64 node-v22.2.0
+@contentstack/cli/1.21.1 darwin-arm64 node-v22.2.0
 $ csdx --help [COMMAND]
 USAGE
   $ csdx COMMAND
@@ -3498,7 +3498,7 @@ EXAMPLES
   $ csdx plugins
 ```
 
-_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v5.2.4/src/commands/plugins/index.ts)_
+_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v5.3.9/src/commands/plugins/index.ts)_
 
 ## `csdx plugins:add PLUGIN`
 
@@ -3572,7 +3572,7 @@ EXAMPLES
   $ csdx plugins:inspect myplugin
 ```
 
-_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v5.2.4/src/commands/plugins/inspect.ts)_
+_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v5.3.9/src/commands/plugins/inspect.ts)_
 
 ## `csdx plugins:install PLUGIN`
 
@@ -3621,7 +3621,7 @@ EXAMPLES
     $ csdx plugins:install someuser/someplugin
 ```
 
-_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v5.2.4/src/commands/plugins/install.ts)_
+_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v5.3.9/src/commands/plugins/install.ts)_
 
 ## `csdx plugins:link PATH`
 
@@ -3651,7 +3651,7 @@ EXAMPLES
   $ csdx plugins:link myplugin
 ```
 
-_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v5.2.4/src/commands/plugins/link.ts)_
+_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v5.3.9/src/commands/plugins/link.ts)_
 
 ## `csdx plugins:remove [PLUGIN]`
 
@@ -3692,7 +3692,7 @@ FLAGS
   --reinstall  Reinstall all plugins after uninstalling.
 ```
 
-_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v5.2.4/src/commands/plugins/reset.ts)_
+_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v5.3.9/src/commands/plugins/reset.ts)_
 
 ## `csdx plugins:uninstall [PLUGIN]`
 
@@ -3720,7 +3720,7 @@ EXAMPLES
   $ csdx plugins:uninstall myplugin
 ```
 
-_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v5.2.4/src/commands/plugins/uninstall.ts)_
+_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v5.3.9/src/commands/plugins/uninstall.ts)_
 
 ## `csdx plugins:unlink [PLUGIN]`
 
@@ -3764,7 +3764,7 @@ DESCRIPTION
   Update installed plugins.
 ```
 
-_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v5.2.4/src/commands/plugins/update.ts)_
+_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v5.3.9/src/commands/plugins/update.ts)_
 
 ## `csdx tokens`
 

--- a/packages/contentstack/package.json
+++ b/packages/contentstack/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contentstack/cli",
   "description": "Command-line tool (CLI) to interact with Contentstack",
-  "version": "1.21.0",
+  "version": "1.21.1",
   "author": "Contentstack",
   "bin": {
     "csdx": "./bin/run.js"
@@ -30,7 +30,7 @@
     "@contentstack/cli-cm-export": "~1.11.6",
     "@contentstack/cli-cm-clone": "~1.10.7",
     "@contentstack/cli-cm-export-to-csv": "~1.7.2",
-    "@contentstack/cli-cm-import": "~1.16.2",
+    "@contentstack/cli-cm-import": "~1.16.3",
     "@contentstack/cli-cm-migrate-rte": "~1.4.18",
     "@contentstack/cli-cm-seed": "~1.7.7",
     "@contentstack/cli-command": "~1.2.19",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,7 +18,7 @@ importers:
       '@contentstack/cli-cm-clone': ~1.10.7
       '@contentstack/cli-cm-export': ~1.11.6
       '@contentstack/cli-cm-export-to-csv': ~1.7.2
-      '@contentstack/cli-cm-import': ~1.16.2
+      '@contentstack/cli-cm-import': ~1.16.3
       '@contentstack/cli-cm-migrate-rte': ~1.4.18
       '@contentstack/cli-cm-seed': ~1.7.7
       '@contentstack/cli-command': ~1.2.19
@@ -424,7 +424,7 @@ importers:
     specifiers:
       '@colors/colors': ^1.5.0
       '@contentstack/cli-cm-export': ~1.11.6
-      '@contentstack/cli-cm-import': ~1.16.2
+      '@contentstack/cli-cm-import': ~1.16.3
       '@contentstack/cli-command': ~1.2.19
       '@contentstack/cli-utilities': ~1.7.0
       '@oclif/test': ^2.5.6
@@ -990,7 +990,7 @@ importers:
 
   packages/contentstack-seed:
     specifiers:
-      '@contentstack/cli-cm-import': ~1.16.2
+      '@contentstack/cli-cm-import': ~1.16.3
       '@contentstack/cli-command': ~1.2.19
       '@contentstack/cli-utilities': ~1.7.0
       '@oclif/plugin-help': ^5.1.19


### PR DESCRIPTION
- [x] handle name conflict in case of custom extension 
- [x] version bump 
    "@contentstack/cli-cm-import": 1.16.2 -> "~1.16.3",
    @contentstack/cli: 1.21.0 -> 1.21.1