### PR TITLE
feat: add custom role support in audit plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26340,7 +26340,7 @@
       "version": "1.24.0",
       "license": "MIT",
       "dependencies": {
-        "@contentstack/cli-audit": "~1.6.5",
+        "@contentstack/cli-audit": "~1.7.0",
         "@contentstack/cli-auth": "~1.3.20",
         "@contentstack/cli-cm-bootstrap": "~1.10.0",
         "@contentstack/cli-cm-branches": "~1.1.2",
@@ -26348,7 +26348,7 @@
         "@contentstack/cli-cm-clone": "~1.10.7",
         "@contentstack/cli-cm-export": "~1.11.7",
         "@contentstack/cli-cm-export-to-csv": "~1.7.2",
-        "@contentstack/cli-cm-import": "~1.16.6",
+        "@contentstack/cli-cm-import": "~1.16.7",
         "@contentstack/cli-cm-migrate-rte": "~1.4.18",
         "@contentstack/cli-cm-seed": "~1.7.8",
         "@contentstack/cli-command": "~1.3.0",
@@ -26405,7 +26405,7 @@
     },
     "packages/contentstack-audit": {
       "name": "@contentstack/cli-audit",
-      "version": "1.6.5",
+      "version": "1.7.0",
       "license": "MIT",
       "dependencies": {
         "@contentstack/cli-command": "~1.3.0",
@@ -28104,10 +28104,10 @@
     },
     "packages/contentstack-import": {
       "name": "@contentstack/cli-cm-import",
-      "version": "1.16.6",
+      "version": "1.16.7",
       "license": "MIT",
       "dependencies": {
-        "@contentstack/cli-audit": "~1.6.5",
+        "@contentstack/cli-audit": "~1.7.0",
         "@contentstack/cli-command": "~1.3.0",
         "@contentstack/cli-utilities": "~1.7.1",
         "@contentstack/management": "~1.17.0",
@@ -28625,7 +28625,7 @@
       "version": "1.7.8",
       "license": "MIT",
       "dependencies": {
-        "@contentstack/cli-cm-import": "~1.16.6",
+        "@contentstack/cli-cm-import": "~1.16.7",
         "@contentstack/cli-command": "~1.3.0",
         "@contentstack/cli-utilities": "~1.7.1",
         "inquirer": "8.2.4",

--- a/packages/contentstack-audit/README.md
+++ b/packages/contentstack-audit/README.md
@@ -19,7 +19,7 @@ $ npm install -g @contentstack/cli-audit
 $ csdx COMMAND
 running command...
 $ csdx (--version|-v)
-@contentstack/cli-audit/1.6.5 darwin-arm64 node-v22.2.0
+@contentstack/cli-audit/1.7.0 darwin-arm64 node-v22.2.0
 $ csdx --help [COMMAND]
 USAGE
   $ csdx COMMAND
@@ -52,12 +52,13 @@ Perform audits and find possible errors in the exported Contentstack data
 
 ```
 USAGE
-  $ csdx audit [--report-path <value>] [--modules content-types|global-fields|entries|extensions|workflows]
-    [--columns <value> | ] [--sort <value>] [--filter <value>] [--csv | --no-truncate]
+  $ csdx audit [--report-path <value>] [--modules
+    content-types|global-fields|entries|extensions|workflows|custom-roles] [--columns <value> | ] [--sort <value>]
+    [--filter <value>] [--csv | --no-truncate]
 
 FLAGS
   --modules=<option>...  Provide the list of modules to be audited
-                         <options: content-types|global-fields|entries|extensions|workflows>
+                         <options: content-types|global-fields|entries|extensions|workflows|custom-roles>
   --report-path=<value>  Path to store the audit reports
 
 TABLE FLAGS
@@ -92,8 +93,8 @@ Perform audits and fix possible errors in the exported Contentstack data.
 
 ```
 USAGE
-  $ csdx audit:fix [--report-path <value>] [--modules content-types|global-fields|entries|extensions|workflows]
-    [--copy-path <value> --copy-dir] [--fix-only
+  $ csdx audit:fix [--report-path <value>] [--modules
+    content-types|global-fields|entries|extensions|workflows|custom-roles] [--copy-path <value> --copy-dir] [--fix-only
     reference|global_field|json:rte|json:extension|blocks|group|content_types] [--columns <value> | ] [--sort <value>]
     [--filter <value>] [--csv | --no-truncate]
 
@@ -103,7 +104,7 @@ FLAGS
   --fix-only=<option>...  Provide the list of fix options
                           <options: reference|global_field|json:rte|json:extension|blocks|group|content_types>
   --modules=<option>...   Provide the list of modules to be audited
-                          <options: content-types|global-fields|entries|extensions|workflows>
+                          <options: content-types|global-fields|entries|extensions|workflows|custom-roles>
   --report-path=<value>   Path to store the audit reports
 
 TABLE FLAGS
@@ -140,12 +141,13 @@ Perform audits and find possible errors in the exported Contentstack data
 
 ```
 USAGE
-  $ csdx cm:stacks:audit [--report-path <value>] [--modules content-types|global-fields|entries|extensions|workflows]
-    [--columns <value> | ] [--sort <value>] [--filter <value>] [--csv | --no-truncate]
+  $ csdx cm:stacks:audit [--report-path <value>] [--modules
+    content-types|global-fields|entries|extensions|workflows|custom-roles] [--columns <value> | ] [--sort <value>]
+    [--filter <value>] [--csv | --no-truncate]
 
 FLAGS
   --modules=<option>...  Provide the list of modules to be audited
-                         <options: content-types|global-fields|entries|extensions|workflows>
+                         <options: content-types|global-fields|entries|extensions|workflows|custom-roles>
   --report-path=<value>  Path to store the audit reports
 
 TABLE FLAGS
@@ -182,8 +184,8 @@ Perform audits and fix possible errors in the exported Contentstack data.
 
 ```
 USAGE
-  $ csdx cm:stacks:audit:fix [--report-path <value>] [--modules content-types|global-fields|entries|extensions|workflows]
-    [--copy-path <value> --copy-dir] [--fix-only
+  $ csdx cm:stacks:audit:fix [--report-path <value>] [--modules
+    content-types|global-fields|entries|extensions|workflows|custom-roles] [--copy-path <value> --copy-dir] [--fix-only
     reference|global_field|json:rte|json:extension|blocks|group|content_types] [--columns <value> | ] [--sort <value>]
     [--filter <value>] [--csv | --no-truncate]
 
@@ -193,7 +195,7 @@ FLAGS
   --fix-only=<option>...  Provide the list of fix options
                           <options: reference|global_field|json:rte|json:extension|blocks|group|content_types>
   --modules=<option>...   Provide the list of modules to be audited
-                          <options: content-types|global-fields|entries|extensions|workflows>
+                          <options: content-types|global-fields|entries|extensions|workflows|custom-roles>
   --report-path=<value>   Path to store the audit reports
 
 TABLE FLAGS

--- a/packages/contentstack-audit/package.json
+++ b/packages/contentstack-audit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentstack/cli-audit",
-  "version": "1.6.5",
+  "version": "1.7.0",
   "description": "Contentstack audit plugin",
   "author": "Contentstack CLI",
   "homepage": "https://github.com/contentstack/cli",

--- a/packages/contentstack-audit/src/audit-base-command.ts
+++ b/packages/contentstack-audit/src/audit-base-command.ts
@@ -20,6 +20,7 @@ import {
   RefErrorReturnType,
   WorkflowExtensionsRefErrorReturnType,
 } from './types';
+import CustomRoles from './modules/custom-roles';
 
 export abstract class AuditBaseCommand extends BaseCommand<typeof AuditBaseCommand> {
   private currentCommand!: CommandNames;
@@ -56,6 +57,7 @@ export abstract class AuditBaseCommand extends BaseCommand<typeof AuditBaseComma
       missingCtRefsInWorkflow,
       missingSelectFeild,
       missingMandatoryFields,
+      missingRefInCustomRoles
     } = await this.scanAndFix();
 
     this.showOutputOnScreen([
@@ -69,13 +71,15 @@ export abstract class AuditBaseCommand extends BaseCommand<typeof AuditBaseComma
     this.showOutputOnScreenWorkflowsAndExtension([
       { module: 'Entries Mandatory Field', missingRefs: missingMandatoryFields },
     ]);
+    this.showOutputOnScreenWorkflowsAndExtension([{ module: 'Custom Roles', missingRefs: missingRefInCustomRoles }]);
     if (
       !isEmpty(missingCtRefs) ||
       !isEmpty(missingGfRefs) ||
       !isEmpty(missingEntryRefs) ||
       !isEmpty(missingCtRefsInWorkflow) ||
       !isEmpty(missingCtRefsInExtensions) ||
-      !isEmpty(missingSelectFeild)
+      !isEmpty(missingSelectFeild) ||
+      !isEmpty(missingRefInCustomRoles) 
     ) {
       if (this.currentCommand === 'cm:stacks:audit') {
         this.log(this.$t(auditMsg.FINAL_REPORT_PATH, { path: this.sharedConfig.reportPath }), 'warn');
@@ -102,7 +106,8 @@ export abstract class AuditBaseCommand extends BaseCommand<typeof AuditBaseComma
       !isEmpty(missingEntryRefs) ||
       !isEmpty(missingCtRefsInWorkflow) ||
       !isEmpty(missingCtRefsInExtensions) ||
-      !isEmpty(missingSelectFeild)
+      !isEmpty(missingSelectFeild) || 
+      !isEmpty(missingRefInCustomRoles)
     );
   }
 
@@ -121,7 +126,8 @@ export abstract class AuditBaseCommand extends BaseCommand<typeof AuditBaseComma
       missingCtRefsInWorkflow,
       missingSelectFeild,
       missingEntry,
-      missingMandatoryFields;
+      missingMandatoryFields,
+      missingRefInCustomRoles;
 
     for (const module of this.sharedConfig.flags.modules || this.sharedConfig.modules) {
       print([
@@ -174,6 +180,10 @@ export abstract class AuditBaseCommand extends BaseCommand<typeof AuditBaseComma
           missingCtRefsInExtensions = await new Extensions(cloneDeep(constructorParam)).run();
           await this.prepareReport(module, missingCtRefsInExtensions);
           break;
+        case 'custom-roles':
+          missingRefInCustomRoles = await new CustomRoles(cloneDeep(constructorParam)).run();
+          await this.prepareReport(module, missingRefInCustomRoles);
+          break;
       }
 
       print([
@@ -198,6 +208,7 @@ export abstract class AuditBaseCommand extends BaseCommand<typeof AuditBaseComma
       missingCtRefsInWorkflow,
       missingSelectFeild,
       missingMandatoryFields,
+      missingRefInCustomRoles,
     };
   }
 

--- a/packages/contentstack-audit/src/config/index.ts
+++ b/packages/contentstack-audit/src/config/index.ts
@@ -2,7 +2,7 @@ const config = {
   showTerminalOutput: true,
   skipRefs: ['sys_assets'],
   skipFieldTypes: ['taxonomy', 'group'],
-  modules: ['content-types', 'global-fields', 'entries', 'extensions', 'workflows'],
+  modules: ['content-types', 'global-fields', 'entries', 'extensions', 'workflows', 'custom-roles'],
   'fix-fields': ['reference', 'global_field', 'json:rte', 'json:extension', 'blocks', 'group', 'content_types'],
   moduleConfig: {
     'content-types': {
@@ -34,6 +34,11 @@ const config = {
       name: 'extensions',
       dirName: 'extensions',
       fileName: 'extensions.json',
+    },
+    'custom-roles': {
+      name: 'custom-roles',
+      dirName: 'custom-roles',
+      fileName: 'custom-roles.json',
     },
   },
   entries: {

--- a/packages/contentstack-audit/src/messages/index.ts
+++ b/packages/contentstack-audit/src/messages/index.ts
@@ -19,6 +19,7 @@ const commonMsg = {
   EXTENSION_FIX_WARN: `The extension associated with UID {uid} and title '{title}' will be removed.`,
   EXTENSION_FIX_CONFIRMATION: `Would you like to overwrite existing file?`,
   WF_BRANCH_REMOVAL: `Removing the branch '{branch} from workflow with UID {uid} and name {name} will be removed.'`,
+  CR_BRANCH_REMOVAL: `Removing the branch '{branch} from custom role with UID {uid} and name {name} will be removed.'`,
 };
 
 const auditMsg = {
@@ -35,6 +36,7 @@ const auditMsg = {
   SCAN_EXT_SUCCESS_MSG: "Successfully completed scanning the {module} titled '{title}' with UID '{uid}'",
   AUDIT_CMD_DESCRIPTION: 'Perform audits and find possible errors in the exported Contentstack data',
   SCAN_WF_SUCCESS_MSG: 'Successfully completed the scanning of workflow with UID {uid} and name {name}.',
+  SCAN_CR_SUCCESS_MSG: 'Successfully completed the scanning of custom role with UID {uid} and name {name}.',
 };
 
 const auditFixMsg = {

--- a/packages/contentstack-audit/src/modules/custom-roles.ts
+++ b/packages/contentstack-audit/src/modules/custom-roles.ts
@@ -1,0 +1,168 @@
+import { join, resolve } from 'path';
+import { existsSync, readFileSync, writeFileSync } from 'fs';
+import { cloneDeep } from 'lodash';
+import { LogFn, ConfigType, CtConstructorParam, ModuleConstructorParam, CustomRole, Rule } from '../types';
+import { sanitizePath, ux } from '@contentstack/cli-utilities';
+
+import auditConfig from '../config';
+import { $t, auditMsg, commonMsg } from '../messages';
+import { values } from 'lodash';
+
+export default class CustomRoles {
+  public log: LogFn;
+  protected fix: boolean;
+  public fileName: any;
+  public config: ConfigType;
+  public folderPath: string;
+  public customRoleSchema: CustomRole[];
+  public moduleName: keyof typeof auditConfig.moduleConfig;
+  public missingFieldsInCustomRoles: CustomRole[];
+  public customRolePath: string;
+  public isBranchFixDone: boolean;
+
+  constructor({ log, fix, config, moduleName }: ModuleConstructorParam & Pick<CtConstructorParam, 'ctSchema'>) {
+    this.log = log;
+    this.config = config;
+    this.fix = fix ?? false;
+    this.customRoleSchema = [];
+    this.moduleName = this.validateModules(moduleName!, this.config.moduleConfig);
+    this.fileName = config.moduleConfig[this.moduleName].fileName;
+    this.folderPath = resolve(
+      sanitizePath(config.basePath),
+      sanitizePath(config.moduleConfig[this.moduleName].dirName),
+    );
+    this.missingFieldsInCustomRoles = [];
+    this.customRolePath = '';
+    this.isBranchFixDone = false;
+  }
+  validateModules(
+    moduleName: keyof typeof auditConfig.moduleConfig,
+    moduleConfig: Record<string, unknown>,
+  ): keyof typeof auditConfig.moduleConfig {
+    if (Object.keys(moduleConfig).includes(moduleName)) {
+      return moduleName;
+    }
+    return 'custom-roles';
+  }
+
+  /**
+   * Check whether the given path for the custom role exists or not
+   * If path exist read
+   * From the ctSchema add all the content type UID into ctUidSet to check whether the content-type is present or not
+   * @returns Array of object containing the custom role name, uid and content_types that are missing
+   */
+  async run() {
+    if (!existsSync(this.folderPath)) {
+      this.log(`Skipping ${this.moduleName} audit`, 'warn');
+      this.log($t(auditMsg.NOT_VALID_PATH, { path: this.folderPath }), { color: 'yellow' });
+      return {};
+    }
+
+    this.customRolePath = join(this.folderPath, this.fileName);
+    this.customRoleSchema = existsSync(this.customRolePath)
+      ? values(JSON.parse(readFileSync(this.customRolePath, 'utf8')) as CustomRole[])
+      : [];
+
+    for (let index = 0; index < this.customRoleSchema?.length; index++) {
+      const customRole = this.customRoleSchema[index];
+      let branchesToBeRemoved: string[] = [];
+      if (this.config?.branch) {
+        customRole?.rules?.filter((rule) => {
+          if (rule.module === 'branch') {
+            branchesToBeRemoved = rule?.branches?.filter((branch) => branch !== this.config?.branch) || [];
+          }
+        });
+      }
+
+      if (branchesToBeRemoved?.length) {
+        this.isBranchFixDone = true;
+        const tempCR = cloneDeep(customRole);
+
+        if (customRole?.rules && this.config?.branch) {
+          tempCR.rules.forEach((rule: Rule) => {
+            if (rule.module === 'branch') {
+              rule.branches = branchesToBeRemoved;
+            }
+          });
+        }
+
+        this.missingFieldsInCustomRoles.push(tempCR);
+      }
+
+      this.log(
+        $t(auditMsg.SCAN_CR_SUCCESS_MSG, {
+          name: customRole.name,
+          uid: customRole.uid,
+        }),
+        'info',
+      );
+    }
+
+    if (this.fix && (this.missingFieldsInCustomRoles.length || this.isBranchFixDone)) {
+      await this.fixCustomRoleSchema();
+      this.missingFieldsInCustomRoles.forEach((cr) => (cr.fixStatus = 'Fixed'));
+    }
+
+    return this.missingFieldsInCustomRoles;
+  }
+
+  async fixCustomRoleSchema() {
+    const newCustomRoleSchema: Record<string, CustomRole> = existsSync(this.customRolePath)
+      ? JSON.parse(readFileSync(this.customRolePath, 'utf8'))
+      : {};
+
+    if (Object.keys(newCustomRoleSchema).length === 0 || !this.customRoleSchema?.length) {
+      return;
+    }
+
+    this.customRoleSchema.forEach((customRole) => {
+      if (!this.config.branch) return;
+
+      const fixedBranches = customRole.rules
+        ?.filter((rule) => rule.module === 'branch' && rule.branches?.length)
+        ?.reduce((acc: string[], rule) => {
+          const relevantBranches =
+            rule.branches?.filter((branch) => {
+              if (branch !== this.config.branch) {
+                this.log(
+                  $t(commonMsg.CR_BRANCH_REMOVAL, {
+                    uid: customRole.uid,
+                    name: customRole.name,
+                    branch,
+                  }),
+                  { color: 'yellow' },
+                );
+                return false;
+              }
+              return true;
+            }) || [];
+          return [...acc, ...relevantBranches];
+        }, []);
+
+      if (fixedBranches?.length) {
+        newCustomRoleSchema[customRole.uid].rules
+          ?.filter((rule: Rule) => rule.module === 'branch')
+          ?.forEach((rule) => {
+            rule.branches = fixedBranches;
+          });
+      }
+    });
+
+    await this.writeFixContent(newCustomRoleSchema);
+  }
+
+  async writeFixContent(newCustomRoleSchema: Record<string, CustomRole>) {
+    if (
+      this.fix &&
+      (this.config.flags['copy-dir'] ||
+        this.config.flags['external-config']?.skipConfirm ||
+        this.config.flags.yes ||
+        (await ux.confirm(commonMsg.FIX_CONFIRMATION)))
+    ) {
+      writeFileSync(
+        join(this.folderPath, this.config.moduleConfig[this.moduleName].fileName),
+        JSON.stringify(newCustomRoleSchema),
+      );
+    }
+  }
+}

--- a/packages/contentstack-audit/src/types/custom-role.ts
+++ b/packages/contentstack-audit/src/types/custom-role.ts
@@ -1,0 +1,84 @@
+export interface CustomRole {
+  name: string;
+  description: string;
+  rules: Rule[];
+  users: string[];
+  uid: string;
+  created_by: string;
+  updated_by: string;
+  created_at: string;
+  updated_at: string;
+  owner: string;
+  stack: Stack;
+  permissions: Permissions;
+  SYS_ACL: Record<string, unknown>;
+  fixStatus?: string;
+  missingRefs?: any;
+}
+
+export interface Rule {
+  module: string;
+  environments?: string[];
+  locales?: string[];
+  branches?: string[];
+  acl: ACL;
+}
+
+interface ACL {
+  read: boolean;
+}
+
+interface Stack {
+  created_at: string;
+  updated_at: string;
+  uid: string;
+  name: string;
+  org_uid: string;
+  api_key: string;
+  master_locale: string;
+  is_asset_download_public: boolean;
+  owner_uid: string;
+  user_uids: string[];
+  settings: Settings;
+  master_key: string;
+}
+
+interface Settings {
+  version: string;
+  rte_version: number;
+  blockAuthQueryParams: boolean;
+  allowedCDNTokens: string[];
+  branches: boolean;
+  localesOptimization: boolean;
+  webhook_enabled: boolean;
+  stack_variables: Record<string, unknown>;
+  live_preview: Record<string, unknown>;
+  discrete_variables: DiscreteVariables;
+  language_fallback: boolean;
+}
+
+interface DiscreteVariables {
+  cms: boolean;
+  _version: number;
+  secret_key: string;
+}
+
+interface Permissions {
+  content_types: ContentType[];
+  environments: string[];
+  locales: Locale[];
+}
+
+interface ContentType {
+  uid: string;
+  SYS_ACL: SysACL;
+}
+
+interface SysACL {
+  sub_acl: Record<string, unknown>;
+}
+
+interface Locale {
+  uid: string;
+  SYS_ACL: ACL;
+}

--- a/packages/contentstack-audit/src/types/index.ts
+++ b/packages/contentstack-audit/src/types/index.ts
@@ -4,3 +4,4 @@ export * from './entries';
 export * from './content-types';
 export * from './workflow';
 export * from './extensions';
+export * from './custom-role';

--- a/packages/contentstack-import/README.md
+++ b/packages/contentstack-import/README.md
@@ -47,7 +47,7 @@ $ npm install -g @contentstack/cli-cm-import
 $ csdx COMMAND
 running command...
 $ csdx (--version)
-@contentstack/cli-cm-import/1.16.6 darwin-arm64 node-v22.2.0
+@contentstack/cli-cm-import/1.16.7 darwin-arm64 node-v22.2.0
 $ csdx --help [COMMAND]
 USAGE
   $ csdx COMMAND

--- a/packages/contentstack-import/package.json
+++ b/packages/contentstack-import/package.json
@@ -5,7 +5,7 @@
   "author": "Contentstack",
   "bugs": "https://github.com/contentstack/cli/issues",
   "dependencies": {
-    "@contentstack/cli-audit": "~1.6.5",
+    "@contentstack/cli-audit": "~1.7.0",
     "@contentstack/cli-command": "~1.3.0",
     "@contentstack/cli-utilities": "~1.7.1",
     "@contentstack/management": "~1.17.0",

--- a/packages/contentstack-import/package.json
+++ b/packages/contentstack-import/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contentstack/cli-cm-import",
   "description": "Contentstack CLI plugin to import content into stack",
-  "version": "1.16.6",
+  "version": "1.16.7",
   "author": "Contentstack",
   "bugs": "https://github.com/contentstack/cli/issues",
   "dependencies": {

--- a/packages/contentstack-import/src/import/module-importer.ts
+++ b/packages/contentstack-import/src/import/module-importer.ts
@@ -49,7 +49,9 @@ class ModuleImporter {
     if (
       !this.importConfig.skipAudit &&
       (!this.importConfig.moduleName ||
-        ['content-types', 'global-fields', 'entries', 'extensions', 'workflows', 'custom-roles'].includes(this.importConfig.moduleName))
+        ['content-types', 'global-fields', 'entries', 'extensions', 'workflows', 'custom-roles'].includes(
+          this.importConfig.moduleName,
+        ))
     ) {
       if (!(await this.auditImportData(logger))) {
         return { noSuccessMsg: true };
@@ -104,7 +106,11 @@ class ModuleImporter {
     // use the algorithm to determine the parallel and sequential execution of modules
     for (let moduleName of this.importConfig.modules.types) {
       if (this.importConfig.globalModules.includes(moduleName) && this.importConfig['exclude-global-modules']) {
-        log(this.importConfig, `Skipping the import of the global module '${moduleName}', as it already exists in the stack.`,'warn');
+        log(
+          this.importConfig,
+          `Skipping the import of the global module '${moduleName}', as it already exists in the stack.`,
+          'warn',
+        );
         continue;
       }
       await this.importByModuleByName(moduleName);
@@ -136,7 +142,9 @@ class ModuleImporter {
         args.push('--modules', this.importConfig.moduleName);
       } else if (this.importConfig.modules.types.length) {
         this.importConfig.modules.types
-          .filter((val) => ['content-types', 'global-fields', 'entries', 'extensions', 'workflows', 'custom-roles'].includes(val))
+          .filter((val) =>
+            ['content-types', 'global-fields', 'entries', 'extensions', 'workflows', 'custom-roles'].includes(val),
+          )
           .forEach((val) => {
             args.push('--modules', val);
           });

--- a/packages/contentstack-import/src/import/module-importer.ts
+++ b/packages/contentstack-import/src/import/module-importer.ts
@@ -49,7 +49,7 @@ class ModuleImporter {
     if (
       !this.importConfig.skipAudit &&
       (!this.importConfig.moduleName ||
-        ['content-types', 'global-fields', 'entries', 'extensions', 'workflows'].includes(this.importConfig.moduleName))
+        ['content-types', 'global-fields', 'entries', 'extensions', 'workflows', 'custom-roles'].includes(this.importConfig.moduleName))
     ) {
       if (!(await this.auditImportData(logger))) {
         return { noSuccessMsg: true };
@@ -136,7 +136,7 @@ class ModuleImporter {
         args.push('--modules', this.importConfig.moduleName);
       } else if (this.importConfig.modules.types.length) {
         this.importConfig.modules.types
-          .filter((val) => ['content-types', 'global-fields', 'entries', 'extensions', 'workflows'].includes(val))
+          .filter((val) => ['content-types', 'global-fields', 'entries', 'extensions', 'workflows', 'custom-roles'].includes(val))
           .forEach((val) => {
             args.push('--modules', val);
           });

--- a/packages/contentstack-import/src/utils/import-config-handler.ts
+++ b/packages/contentstack-import/src/utils/import-config-handler.ts
@@ -79,6 +79,8 @@ const setupConfig = async (importCmdFlags: any): Promise<ImportConfig> => {
   if (importCmdFlags['branch']) {
     config.branchName = importCmdFlags['branch'];
     config.branchDir = path.join(sanitizePath(config.contentDir), sanitizePath(config.branchName));
+  } else {
+    config.branchName = 'main';
   }
   if (importCmdFlags['module']) {
     config.moduleName = importCmdFlags['module'];

--- a/packages/contentstack-seed/package.json
+++ b/packages/contentstack-seed/package.json
@@ -5,7 +5,7 @@
   "author": "Contentstack",
   "bugs": "https://github.com/contentstack/cli/issues",
   "dependencies": {
-    "@contentstack/cli-cm-import": "~1.16.6",
+    "@contentstack/cli-cm-import": "~1.16.7",
     "@contentstack/cli-command": "~1.3.0",
     "@contentstack/cli-utilities": "~1.7.1",
     "inquirer": "8.2.4",

--- a/packages/contentstack/README.md
+++ b/packages/contentstack/README.md
@@ -123,12 +123,12 @@ Perform audits and find possible errors in the exported Contentstack data
 ```
 USAGE
   $ csdx audit [--report-path <value>] [--modules
-    content-types|global-fields|entries|extensions|workflows...] [--columns <value> | ] [--sort <value>] [--filter
-    <value>] [--csv | --no-truncate]
+    content-types|global-fields|entries|extensions|workflows|custom-roles...] [--columns <value> | ] [--sort <value>]
+    [--filter <value>] [--csv | --no-truncate]
 
 FLAGS
   --modules=<option>...  Provide the list of modules to be audited
-                         <options: content-types|global-fields|entries|extensions|workflows>
+                         <options: content-types|global-fields|entries|extensions|workflows|custom-roles>
   --report-path=<value>  Path to store the audit reports
 
 TABLE FLAGS
@@ -164,9 +164,9 @@ Perform audits and fix possible errors in the exported Contentstack data.
 ```
 USAGE
   $ csdx audit:fix [--report-path <value>] [--modules
-    content-types|global-fields|entries|extensions|workflows...] [--copy-path <value> --copy-dir] [--fix-only
-    reference|global_field|json:rte|json:extension|blocks|group|content_types...] [--columns <value> | ] [--sort
-    <value>] [--filter <value>] [--csv | --no-truncate]
+    content-types|global-fields|entries|extensions|workflows|custom-roles...] [--copy-path <value> --copy-dir]
+    [--fix-only reference|global_field|json:rte|json:extension|blocks|group|content_types...] [--columns <value> | ]
+    [--sort <value>] [--filter <value>] [--csv | --no-truncate]
 
 FLAGS
   --copy-dir              Create backup from the original data.
@@ -174,7 +174,7 @@ FLAGS
   --fix-only=<option>...  Provide the list of fix options
                           <options: reference|global_field|json:rte|json:extension|blocks|group|content_types>
   --modules=<option>...   Provide the list of modules to be audited
-                          <options: content-types|global-fields|entries|extensions|workflows>
+                          <options: content-types|global-fields|entries|extensions|workflows|custom-roles>
   --report-path=<value>   Path to store the audit reports
 
 TABLE FLAGS
@@ -2377,12 +2377,12 @@ Perform audits and find possible errors in the exported Contentstack data
 ```
 USAGE
   $ csdx cm:stacks:audit [--report-path <value>] [--modules
-    content-types|global-fields|entries|extensions|workflows...] [--columns <value> | ] [--sort <value>] [--filter
-    <value>] [--csv | --no-truncate]
+    content-types|global-fields|entries|extensions|workflows|custom-roles...] [--columns <value> | ] [--sort <value>]
+    [--filter <value>] [--csv | --no-truncate]
 
 FLAGS
   --modules=<option>...  Provide the list of modules to be audited
-                         <options: content-types|global-fields|entries|extensions|workflows>
+                         <options: content-types|global-fields|entries|extensions|workflows|custom-roles>
   --report-path=<value>  Path to store the audit reports
 
 TABLE FLAGS
@@ -2420,9 +2420,9 @@ Perform audits and fix possible errors in the exported Contentstack data.
 ```
 USAGE
   $ csdx cm:stacks:audit:fix [--report-path <value>] [--modules
-    content-types|global-fields|entries|extensions|workflows...] [--copy-path <value> --copy-dir] [--fix-only
-    reference|global_field|json:rte|json:extension|blocks|group|content_types...] [--columns <value> | ] [--sort
-    <value>] [--filter <value>] [--csv | --no-truncate]
+    content-types|global-fields|entries|extensions|workflows|custom-roles...] [--copy-path <value> --copy-dir]
+    [--fix-only reference|global_field|json:rte|json:extension|blocks|group|content_types...] [--columns <value> | ]
+    [--sort <value>] [--filter <value>] [--csv | --no-truncate]
 
 FLAGS
   --copy-dir              Create backup from the original data.
@@ -2430,7 +2430,7 @@ FLAGS
   --fix-only=<option>...  Provide the list of fix options
                           <options: reference|global_field|json:rte|json:extension|blocks|group|content_types>
   --modules=<option>...   Provide the list of modules to be audited
-                          <options: content-types|global-fields|entries|extensions|workflows>
+                          <options: content-types|global-fields|entries|extensions|workflows|custom-roles>
   --report-path=<value>   Path to store the audit reports
 
 TABLE FLAGS

--- a/packages/contentstack/package.json
+++ b/packages/contentstack/package.json
@@ -30,7 +30,7 @@
     "@contentstack/cli-cm-export": "~1.11.7",
     "@contentstack/cli-cm-clone": "~1.10.7",
     "@contentstack/cli-cm-export-to-csv": "~1.7.2",
-    "@contentstack/cli-cm-import": "~1.16.6",
+    "@contentstack/cli-cm-import": "~1.16.7",
     "@contentstack/cli-cm-migrate-rte": "~1.4.18",
     "@contentstack/cli-cm-seed": "~1.7.8",
     "@contentstack/cli-command": "~1.3.0",

--- a/packages/contentstack/package.json
+++ b/packages/contentstack/package.json
@@ -22,7 +22,7 @@
     "prepack": "pnpm compile && oclif manifest && oclif readme"
   },
   "dependencies": {
-    "@contentstack/cli-audit": "~1.6.5",
+    "@contentstack/cli-audit": "~1.7.0",
     "@contentstack/cli-auth": "~1.3.20",
     "@contentstack/cli-cm-bootstrap": "~1.10.0",
     "@contentstack/cli-cm-branches": "~1.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
 
   packages/contentstack:
     specifiers:
-      '@contentstack/cli-audit': ~1.6.5
+      '@contentstack/cli-audit': ~1.7.0
       '@contentstack/cli-auth': ~1.3.20
       '@contentstack/cli-cm-bootstrap': ~1.10.0
       '@contentstack/cli-cm-branches': ~1.1.2
@@ -18,7 +18,7 @@ importers:
       '@contentstack/cli-cm-clone': ~1.10.7
       '@contentstack/cli-cm-export': ~1.11.7
       '@contentstack/cli-cm-export-to-csv': ~1.7.2
-      '@contentstack/cli-cm-import': ~1.16.6
+      '@contentstack/cli-cm-import': ~1.16.7
       '@contentstack/cli-cm-migrate-rte': ~1.4.18
       '@contentstack/cli-cm-seed': ~1.7.8
       '@contentstack/cli-command': ~1.3.0
@@ -730,7 +730,7 @@ importers:
 
   packages/contentstack-import:
     specifiers:
-      '@contentstack/cli-audit': ~1.6.5
+      '@contentstack/cli-audit': ~1.7.0
       '@contentstack/cli-command': ~1.3.0
       '@contentstack/cli-utilities': ~1.7.1
       '@contentstack/management': ~1.17.0
@@ -990,7 +990,7 @@ importers:
 
   packages/contentstack-seed:
     specifiers:
-      '@contentstack/cli-cm-import': ~1.16.6
+      '@contentstack/cli-cm-import': ~1.16.7
       '@contentstack/cli-command': ~1.3.0
       '@contentstack/cli-utilities': ~1.7.1
       '@oclif/plugin-help': ^5.1.19


### PR DESCRIPTION
- [x] add custom role support in audit plugin
- [x] version bump
@contentstack/cli-audit": 1.6.5 -> "~1.7.0"
 @contentstack/cli-cm-import": 1.6.6 -> "~1.16.7",