### PR TITLE
feat: integrated v2Logger in export plugin

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -141,7 +141,7 @@ fileignoreconfig:
   - filename: packages/contentstack-utilities/src/interfaces/index.ts
     checksum: 70079d81524ae4c196ffc77f13306184a8944b2903b881947dd06120150f31b0
   - filename: packages/contentstack-export/src/commands/cm/stacks/export.ts
-    checksum: d826ec9fd7729ffcfd0f42399dad7560a8a881cabfdd95693511f5e6b1cb07c7
+    checksum: 4ea47b064ec18532da5fa7e5df47ad173fb7e878eb7899c934d4e1cdf1192956
   - filename: packages/contentstack-utilities/src/logger/logger.ts
     checksum: b56504c1e4fb31b676cc1931eb30afc7b9466f03890fe3c76977309e1fd066a6
 version: "1.0"

--- a/.talismanrc
+++ b/.talismanrc
@@ -134,4 +134,14 @@ fileignoreconfig:
     checksum: 023cf08f215cd0778599fb8478c94419373d4687f04421c4eb99d87de86a4a3e
   - filename: packages/contentstack-utilities/src/logger/logger.ts
     checksum: 09f3b73dd995bafc253265c676f06308513e6b1842d9bc01d39e6b6945a54c7d
+  - filename: packages/contentstack-export/src/export/modules/environments.ts
+    checksum: 71dd1965e4ba66cefca578838cba125da0c8e4ef02fd95276b8236f66c018dce
+  - filename: packages/contentstack-export/src/utils/basic-login.ts
+    checksum: f95d4c0976729bd17238bf64713b3851d8852dbf60591210412c12ddaddd60c9
+  - filename: packages/contentstack-utilities/src/interfaces/index.ts
+    checksum: 70079d81524ae4c196ffc77f13306184a8944b2903b881947dd06120150f31b0
+  - filename: packages/contentstack-export/src/commands/cm/stacks/export.ts
+    checksum: d826ec9fd7729ffcfd0f42399dad7560a8a881cabfdd95693511f5e6b1cb07c7
+  - filename: packages/contentstack-utilities/src/logger/logger.ts
+    checksum: b56504c1e4fb31b676cc1931eb30afc7b9466f03890fe3c76977309e1fd066a6
 version: "1.0"

--- a/.talismanrc
+++ b/.talismanrc
@@ -135,13 +135,13 @@ fileignoreconfig:
   - filename: packages/contentstack-utilities/src/logger/logger.ts
     checksum: 09f3b73dd995bafc253265c676f06308513e6b1842d9bc01d39e6b6945a54c7d
   - filename: packages/contentstack-export/src/export/modules/environments.ts
-    checksum: 71dd1965e4ba66cefca578838cba125da0c8e4ef02fd95276b8236f66c018dce
+    checksum: 10cb048a8f30e2645a4c949fd2a51d0c741b7fdacb377768d2c0cfe34bdaf4e2
   - filename: packages/contentstack-export/src/utils/basic-login.ts
     checksum: f95d4c0976729bd17238bf64713b3851d8852dbf60591210412c12ddaddd60c9
   - filename: packages/contentstack-utilities/src/interfaces/index.ts
     checksum: 70079d81524ae4c196ffc77f13306184a8944b2903b881947dd06120150f31b0
   - filename: packages/contentstack-export/src/commands/cm/stacks/export.ts
-    checksum: 4ea47b064ec18532da5fa7e5df47ad173fb7e878eb7899c934d4e1cdf1192956
+    checksum: 941c6a8d59ba58e2004030202ee6282cdd2a424cf8b089aef70a85198553fefe
   - filename: packages/contentstack-utilities/src/logger/logger.ts
     checksum: b56504c1e4fb31b676cc1931eb30afc7b9466f03890fe3c76977309e1fd066a6
 version: "1.0"

--- a/packages/contentstack-audit/README.md
+++ b/packages/contentstack-audit/README.md
@@ -19,7 +19,7 @@ $ npm install -g @contentstack/cli-audit
 $ csdx COMMAND
 running command...
 $ csdx (--version|-v)
-@contentstack/cli-audit/1.12.2 darwin-arm64 node-v22.14.0
+@contentstack/cli-audit/1.13.0 darwin-arm64 node-v22.14.0
 $ csdx --help [COMMAND]
 USAGE
   $ csdx COMMAND
@@ -305,7 +305,7 @@ EXAMPLES
   $ csdx plugins
 ```
 
-_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v5.4.38/src/commands/plugins/index.ts)_
+_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v5.4.39/src/commands/plugins/index.ts)_
 
 ## `csdx plugins:add PLUGIN`
 
@@ -379,7 +379,7 @@ EXAMPLES
   $ csdx plugins:inspect myplugin
 ```
 
-_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v5.4.38/src/commands/plugins/inspect.ts)_
+_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v5.4.39/src/commands/plugins/inspect.ts)_
 
 ## `csdx plugins:install PLUGIN`
 
@@ -428,7 +428,7 @@ EXAMPLES
     $ csdx plugins:install someuser/someplugin
 ```
 
-_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v5.4.38/src/commands/plugins/install.ts)_
+_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v5.4.39/src/commands/plugins/install.ts)_
 
 ## `csdx plugins:link PATH`
 
@@ -459,7 +459,7 @@ EXAMPLES
   $ csdx plugins:link myplugin
 ```
 
-_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v5.4.38/src/commands/plugins/link.ts)_
+_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v5.4.39/src/commands/plugins/link.ts)_
 
 ## `csdx plugins:remove [PLUGIN]`
 
@@ -500,7 +500,7 @@ FLAGS
   --reinstall  Reinstall all plugins after uninstalling.
 ```
 
-_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v5.4.38/src/commands/plugins/reset.ts)_
+_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v5.4.39/src/commands/plugins/reset.ts)_
 
 ## `csdx plugins:uninstall [PLUGIN]`
 
@@ -528,7 +528,7 @@ EXAMPLES
   $ csdx plugins:uninstall myplugin
 ```
 
-_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v5.4.38/src/commands/plugins/uninstall.ts)_
+_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v5.4.39/src/commands/plugins/uninstall.ts)_
 
 ## `csdx plugins:unlink [PLUGIN]`
 
@@ -572,5 +572,5 @@ DESCRIPTION
   Update installed plugins.
 ```
 
-_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v5.4.38/src/commands/plugins/update.ts)_
+_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v5.4.39/src/commands/plugins/update.ts)_
 <!-- commandsstop -->

--- a/packages/contentstack-export/messages/index.json
+++ b/packages/contentstack-export/messages/index.json
@@ -1,1 +1,68 @@
-{}
+{
+"ASSET_EXPORT_COMPLETE": "Asset export process completed successfully",
+"ASSET_FOLDERS_EXPORT_COMPLETE": "Asset folder structure exported successfully",
+"ASSET_METADATA_EXPORT_COMPLETE": "Asset metadata exported successfully",
+"ASSET_VERSIONED_METADATA_EXPORT_COMPLETE": "Versioned asset metadata exported successfully",
+"ASSET_DOWNLOAD_COMPLETE": "Asset download completed successfully",
+"ASSET_DOWNLOAD_SUCCESS": "Asset '%s' (UID: %s) downloaded successfully",
+"ASSET_DOWNLOAD_FAILED": "Failed to download asset '%s' (UID: %s)",
+"ASSET_WRITE_FAILED": "Failed to write asset file '%s' (UID: %s)",
+"ASSET_QUERY_FAILED": "Failed to query asset data from the API",
+"ASSET_VERSIONED_QUERY_FAILED": "Failed to query versioned asset data from the API",
+"ASSET_COUNT_QUERY_FAILED": "Failed to retrieve total asset count",
+
+"CONTENT_TYPE_EXPORT_COMPLETE": "Content types exported successfully",
+"CONTENT_TYPE_NO_TYPES": "No content types found",
+"CONTENT_TYPE_EXPORT_FAILED": "Failed to export content types",
+"CONTENT_TYPE_NO_TYPES_RETURNED": "API returned no content types for the given query",
+
+"ENVIRONMENT_EXPORT_COMPLETE": "Successfully exported %s environment(s)",
+"ENVIRONMENT_EXPORT_SUCCESS": "Environment '%s' exported successfully",
+"ENVIRONMENT_NOT_FOUND": "No environments found in the current stack",
+
+"EXTENSION_EXPORT_COMPLETE": "Successfully exported %s extension(s)",
+"EXTENSION_EXPORT_SUCCESS": "Extension '%s' exported successfully",
+"EXTENSION_NOT_FOUND": "No extensions found in the current stack",
+
+"GLOBAL_FIELDS_EXPORT_COMPLETE": "Successfully exported %s global field(s)",
+
+"LABELS_EXPORT_COMPLETE": "Successfully exported %s label(s)",
+"LABEL_EXPORT_SUCCESS": "Label '%s' exported successfully",
+"LABELS_NOT_FOUND": "No labels found in the current stack",
+
+"LOCALES_EXPORT_COMPLETE": "Successfully exported %s locale(s) including %s master locale(s)",
+
+"TAXONOMY_EXPORT_COMPLETE": "Successfully exported %s taxonomy entries",
+"TAXONOMY_EXPORT_SUCCESS": "Taxonomy '%s' exported successfully",
+"TAXONOMY_NOT_FOUND": "No taxonomies found in the current stack",
+
+"WEBHOOK_EXPORT_COMPLETE": "Successfully exported %s webhook(s)",
+"WEBHOOK_EXPORT_SUCCESS": "Webhook '%s' exported successfully",
+"WEBHOOK_NOT_FOUND": "No webhooks found in the current stack",
+
+"WORKFLOW_EXPORT_COMPLETE": "Successfully exported %s workflow(s)",
+"WORKFLOW_EXPORT_SUCCESS": "Workflow '%s' exported successfully",
+"WORKFLOW_NOT_FOUND": "No workflows found in the current stack",
+
+"PERSONALIZE_URL_NOT_SET": "Cannot export Personalize project: URL not configured",
+"PERSONALIZE_SKIPPING_WITH_MANAGEMENT_TOKEN": "Skipping Personalize project export: Management token not supported",
+"PERSONALIZE_MODULE_NOT_IMPLEMENTED": "Module '%s' implementation not found",
+"PERSONALIZE_NOT_ENABLED": "Personalize feature is not enabled for this organization",
+
+"MARKETPLACE_APPS_EXPORT_COMPLETE": "Successfully exported %s marketplace app(s)",
+"MARKETPLACE_APP_CONFIG_EXPORT": "Exporting configuration for app '%s'",
+"MARKETPLACE_APP_CONFIG_SUCCESS": "Successfully exported configuration for app '%s'",
+"MARKETPLACE_APP_EXPORT_SUCCESS": "Successfully exported app '%s'",
+"MARKETPLACE_APPS_NOT_FOUND": "No marketplace apps found in the current stack",
+"MARKETPLACE_APP_CONFIG_EXPORT_FAILED": "Failed to export configuration for app '%s'",
+"MARKETPLACE_APP_MANIFEST_EXPORT_FAILED": "Failed to export manifest for app '%s'",
+
+"ENTRIES_EXPORT_COMPLETE": "Successfully exported entries (Content Type: %s, Locale: %s)",
+"ENTRIES_EXPORT_SUCCESS": "All entries exported successfully",
+"ENTRIES_VERSIONED_EXPORT_SUCCESS": "Successfully exported versioned entry (Content Type: %s, UID: %s, Locale: %s)",
+"ENTRIES_EXPORT_VERSIONS_FAILED": "Failed to export versions for content type '%s' (UID: %s)",
+
+"BRANCH_EXPORT_FAILED": "Failed to export contents from branch (UID: %s)",
+
+"ROLES_NO_CUSTOM_ROLES": "No custom roles found in the current stack"
+}

--- a/packages/contentstack-export/messages/index.json
+++ b/packages/contentstack-export/messages/index.json
@@ -64,5 +64,6 @@
 
 "BRANCH_EXPORT_FAILED": "Failed to export contents from branch (UID: %s)",
 
-"ROLES_NO_CUSTOM_ROLES": "No custom roles found in the current stack"
+"ROLES_NO_CUSTOM_ROLES": "No custom roles found in the current stack",
+"ROLES_EXPORTING_ROLE": "Exporting role '%s'"
 }

--- a/packages/contentstack-export/src/commands/cm/stacks/export.ts
+++ b/packages/contentstack-export/src/commands/cm/stacks/export.ts
@@ -1,4 +1,3 @@
-import path from 'path';
 import { Command } from '@contentstack/cli-command';
 import {
   cliux,
@@ -12,11 +11,13 @@ import {
   sanitizePath,
   configHandler,
   v2Logger,
-  handleAndLogError
+  handleAndLogError,
+  getLogPath
 } from '@contentstack/cli-utilities';
+
 import { ModuleExporter } from '../../../export';
-import { setupExportConfig, writeExportMetaFile } from '../../../utils';
 import { Context, ExportConfig } from '../../../types';
+import { setupExportConfig, writeExportMetaFile } from '../../../utils';
 
 export default class ExportCommand extends Command {
   static description: string = messageHandler.parse('Export content from a stack');
@@ -112,7 +113,7 @@ export default class ExportCommand extends Command {
       const { flags } = await this.parse(ExportCommand);
       exportConfig = await setupExportConfig(flags);
       // Prepare the context object
-      const context = this.createExportContext();
+      const context = this.createExportContext(exportConfig.apiKey);
       exportConfig.context = context;
 
       // Assign exportConfig variables
@@ -126,14 +127,14 @@ export default class ExportCommand extends Command {
         writeExportMetaFile(exportConfig);
       }
       v2Logger.success(`The content of the stack ${exportConfig.apiKey} has been exported successfully!`,exportConfig.context)
-      v2Logger.success(`The log has been stored at '${pathValidator(path.join(process.cwd(), 'logs'))}'`, exportConfig.context)
+      v2Logger.info(`The log has been stored at '${getLogPath()}'`, exportConfig.context)
     } catch (error) {
       handleAndLogError(error, { ...exportConfig.context });
     }
   }
   
   // Create export context object
-  private createExportContext(): Context {
+  private createExportContext(apiKey: string): Context {
     return {
       command: this.context.info.command,
       module: '',
@@ -141,7 +142,7 @@ export default class ExportCommand extends Command {
       email: configHandler.get('email'),
       sessionId: this.context.sessionId,
       clientId: this.context.clientId,
-      apiKey: configHandler.get('apiKey') || '',
+      apiKey: apiKey || '',
       orgId: configHandler.get('organization_uid') || '',
     };
   }

--- a/packages/contentstack-export/src/commands/cm/stacks/export.ts
+++ b/packages/contentstack-export/src/commands/cm/stacks/export.ts
@@ -10,7 +10,7 @@ import {
   pathValidator,
   sanitizePath,
   configHandler,
-  v2Logger,
+  log,
   handleAndLogError,
   getLogPath
 } from '@contentstack/cli-utilities';
@@ -126,8 +126,8 @@ export default class ExportCommand extends Command {
       if (!exportConfig.branches?.length) {
         writeExportMetaFile(exportConfig);
       }
-      v2Logger.success(`The content of the stack ${exportConfig.apiKey} has been exported successfully!`,exportConfig.context)
-      v2Logger.info(`The log has been stored at '${getLogPath()}'`, exportConfig.context)
+      log.success(`The content of the stack ${exportConfig.apiKey} has been exported successfully!`,exportConfig.context)
+      log.success(`The log has been stored at '${getLogPath()}'`, exportConfig.context)
     } catch (error) {
       handleAndLogError(error, { ...exportConfig.context });
     }

--- a/packages/contentstack-export/src/export/module-exporter.ts
+++ b/packages/contentstack-export/src/export/module-exporter.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import { ContentstackClient } from '@contentstack/cli-utilities';
+import { ContentstackClient, handleAndLogError, messageHandler, v2Logger } from '@contentstack/cli-utilities';
 import { setupBranches, setupExportDir, log, formatError, writeExportMetaFile } from '../utils';
 import startModuleExport from './modules';
 import startJSModuleExport from './modules-js';
@@ -38,19 +38,29 @@ class ModuleExporter {
         this.exportConfig.branchName = branch.uid;
         this.stackAPIClient.stackHeaders.branch = branch.uid;
         this.exportConfig.branchDir = path.join(this.exportConfig.exportDir, branch.uid);
-        log(this.exportConfig, `Exporting content from branch ${branch.uid}`, 'success');
+        v2Logger.info(`Exporting content from branch ${branch.uid}`, this.exportConfig.context);
         writeExportMetaFile(this.exportConfig, this.exportConfig.branchDir);
         await this.export();
-        log(this.exportConfig, `The content of branch ${branch.uid} has been exported successfully!`, 'success');
+        v2Logger.success(
+          `The content of branch ${branch.uid} has been exported successfully!`,
+          this.exportConfig.context,
+        );
       } catch (error) {
-        log(this.exportConfig, formatError(error), 'error');
-        throw new Error(`Failed to export contents from branch ${branch.uid}`);
+        handleAndLogError(
+          error,
+          { ...this.exportConfig.context, branch: branch.uid },
+          messageHandler.parse('FAILED_EXPORT_CONTENT_BRANCH', { branch: branch.uid }),
+        );
+        throw new Error(messageHandler.parse('FAILED_EXPORT_CONTENT_BRANCH', { branch: branch.uid }));
       }
     }
   }
 
   async export() {
-    log(this.exportConfig, `Started to export content, version is ${this.exportConfig.contentVersion}`, 'info');
+    v2Logger.info(
+      `Started to export content, version is ${this.exportConfig.contentVersion}`,
+      this.exportConfig.context,
+    );
     // checks for single module or all modules
     if (this.exportConfig.singleModuleExport) {
       return this.exportSingleModule(this.exportConfig.moduleName);
@@ -59,7 +69,7 @@ class ModuleExporter {
   }
 
   async exportByModuleByName(moduleName: Modules) {
-    log(this.exportConfig, `Starting export of ${moduleName} module`, 'info');
+    v2Logger.info(`Exporting module: ${moduleName}`, this.exportConfig.context);
     // export the modules by name
     // calls the module runner which inturn calls the module itself
     let exportedModuleResponse;

--- a/packages/contentstack-export/src/export/module-exporter.ts
+++ b/packages/contentstack-export/src/export/module-exporter.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
-import { ContentstackClient, handleAndLogError, messageHandler, v2Logger } from '@contentstack/cli-utilities';
-import { setupBranches, setupExportDir, log, formatError, writeExportMetaFile } from '../utils';
+import { ContentstackClient, handleAndLogError, messageHandler, log } from '@contentstack/cli-utilities';
+import { setupBranches, setupExportDir, writeExportMetaFile } from '../utils';
 import startModuleExport from './modules';
 import startJSModuleExport from './modules-js';
 import { ExportConfig, Modules } from '../types';
@@ -38,10 +38,10 @@ class ModuleExporter {
         this.exportConfig.branchName = branch.uid;
         this.stackAPIClient.stackHeaders.branch = branch.uid;
         this.exportConfig.branchDir = path.join(this.exportConfig.exportDir, branch.uid);
-        v2Logger.info(`Exporting content from branch ${branch.uid}`, this.exportConfig.context);
+        log.info(`Exporting content from branch ${branch.uid}`, this.exportConfig.context);
         writeExportMetaFile(this.exportConfig, this.exportConfig.branchDir);
         await this.export();
-        v2Logger.success(
+        log.success(
           `The content of branch ${branch.uid} has been exported successfully!`,
           this.exportConfig.context,
         );
@@ -57,7 +57,7 @@ class ModuleExporter {
   }
 
   async export() {
-    v2Logger.info(
+    log.info(
       `Started to export content, version is ${this.exportConfig.contentVersion}`,
       this.exportConfig.context,
     );
@@ -69,7 +69,7 @@ class ModuleExporter {
   }
 
   async exportByModuleByName(moduleName: Modules) {
-    v2Logger.info(`Exporting module: ${moduleName}`, this.exportConfig.context);
+    log.info(`Exporting module: ${moduleName}`, this.exportConfig.context);
     // export the modules by name
     // calls the module runner which inturn calls the module itself
     let exportedModuleResponse;

--- a/packages/contentstack-export/src/export/modules/assets.ts
+++ b/packages/contentstack-export/src/export/modules/assets.ts
@@ -20,8 +20,8 @@ import {
   messageHandler,
 } from '@contentstack/cli-utilities';
 
-import { ModuleClassParams } from '../../types';
 import config from '../../config';
+import { ModuleClassParams } from '../../types';
 import BaseClass, { CustomPromiseHandler, CustomPromiseHandlerInput } from './base-class';
 
 export default class ExportAssets extends BaseClass {

--- a/packages/contentstack-export/src/export/modules/assets.ts
+++ b/packages/contentstack-export/src/export/modules/assets.ts
@@ -15,7 +15,7 @@ import {
   FsUtility,
   getDirectories,
   configHandler,
-  v2Logger,
+  log,
   handleAndLogError,
   messageHandler,
 } from '@contentstack/cli-utilities';
@@ -63,7 +63,7 @@ export default class ExportAssets extends BaseClass {
 
     // NOTE step 4: Download all assets
     await this.downloadAssets();
-    v2Logger.success(messageHandler.parse('ASSET_EXPORT_COMPLETE'), this.exportConfig.context);
+    log.success(messageHandler.parse('ASSET_EXPORT_COMPLETE'), this.exportConfig.context);
   }
 
   /**
@@ -103,7 +103,7 @@ export default class ExportAssets extends BaseClass {
           this.assetsFolder,
         );
       }
-      v2Logger.info(
+      log.info(
         messageHandler.parse('ASSET_FOLDERS_EXPORT_COMPLETE', this.assetsFolder.length),
         this.exportConfig.context,
       );
@@ -170,7 +170,7 @@ export default class ExportAssets extends BaseClass {
       concurrencyLimit: this.assetConfig.fetchConcurrency,
     }).then(() => {
       fs?.completeFile(true);
-      v2Logger.info(messageHandler.parse('ASSET_METADATA_EXPORT_COMPLETE'), this.exportConfig.context);
+      log.info(messageHandler.parse('ASSET_METADATA_EXPORT_COMPLETE'), this.exportConfig.context);
     });
   }
 
@@ -247,7 +247,7 @@ export default class ExportAssets extends BaseClass {
       promisifyHandler,
     ).then(() => {
       fs?.completeFile(true);
-      v2Logger.info(messageHandler.parse('ASSET_VERSIONED_METADATA_EXPORT_COMPLETE'), this.exportConfig.context);
+      log.info(messageHandler.parse('ASSET_VERSIONED_METADATA_EXPORT_COMPLETE'), this.exportConfig.context);
     });
   }
 
@@ -338,7 +338,7 @@ export default class ExportAssets extends BaseClass {
         data.pipe(assetWriterStream);
       }
 
-      v2Logger.success(
+      log.success(
         messageHandler.parse('ASSET_DOWNLOAD_SUCCESS', asset.filename, asset.uid),
         this.exportConfig.context,
       );
@@ -378,7 +378,7 @@ export default class ExportAssets extends BaseClass {
       },
       promisifyHandler,
     ).then(() => {
-      v2Logger.success(messageHandler.parse('ASSET_DOWNLOAD_COMPLETE'), this.exportConfig.context);
+      log.success(messageHandler.parse('ASSET_DOWNLOAD_COMPLETE'), this.exportConfig.context);
     });
   }
 }

--- a/packages/contentstack-export/src/export/modules/base-class.ts
+++ b/packages/contentstack-export/src/export/modules/base-class.ts
@@ -5,7 +5,7 @@ import chunk from 'lodash/chunk';
 import isEmpty from 'lodash/isEmpty';
 import entries from 'lodash/entries';
 import isEqual from 'lodash/isEqual';
-import { v2Logger } from '@contentstack/cli-utilities';
+import { log } from '@contentstack/cli-utilities';
 
 import { ExportConfig, ModuleClassParams } from '../../types';
 
@@ -134,7 +134,7 @@ export default abstract class BaseClass {
   async logMsgAndWaitIfRequired(module: string, start: number, batchNo: number): Promise<void> {
     const end = Date.now();
     const exeTime = end - start;
-    v2Logger.success(
+    log.success(
       `Batch No. ${batchNo} of ${module} is complete. Time taken: ${exeTime} milliseconds`,
       this.exportConfig.context,
     );

--- a/packages/contentstack-export/src/export/modules/base-class.ts
+++ b/packages/contentstack-export/src/export/modules/base-class.ts
@@ -5,8 +5,8 @@ import chunk from 'lodash/chunk';
 import isEmpty from 'lodash/isEmpty';
 import entries from 'lodash/entries';
 import isEqual from 'lodash/isEqual';
+import { v2Logger } from '@contentstack/cli-utilities';
 
-import { log } from '../../utils';
 import { ExportConfig, ModuleClassParams } from '../../types';
 
 export type ApiOptions = {
@@ -134,7 +134,10 @@ export default abstract class BaseClass {
   async logMsgAndWaitIfRequired(module: string, start: number, batchNo: number): Promise<void> {
     const end = Date.now();
     const exeTime = end - start;
-    log(this.exportConfig, `Batch No. ${batchNo} of ${module} is complete.`, 'success');
+    v2Logger.success(
+      `Batch No. ${batchNo} of ${module} is complete. Time taken: ${exeTime} milliseconds`,
+      this.exportConfig.context,
+    );
 
     if (this.exportConfig.modules.assets.displayExecutionTime) {
       console.log(

--- a/packages/contentstack-export/src/export/modules/content-types.ts
+++ b/packages/contentstack-export/src/export/modules/content-types.ts
@@ -3,7 +3,7 @@ import {
   ContentstackClient,
   handleAndLogError,
   messageHandler,
-  v2Logger,
+  log,
   sanitizePath,
 } from '@contentstack/cli-utilities';
 
@@ -63,7 +63,7 @@ export default class ContentTypesExport extends BaseClass {
       await fsUtil.makeDirectory(this.contentTypesDirPath);
       await this.getContentTypes();
       await this.writeContentTypes(this.contentTypes);
-      v2Logger.success(messageHandler.parse('CONTENT_TYPE_EXPORT_COMPLETE'), this.exportConfig.context);
+      log.success(messageHandler.parse('CONTENT_TYPE_EXPORT_COMPLETE'), this.exportConfig.context);
     } catch (error) {
       handleAndLogError(error, { ...this.exportConfig.context });
       throw new Error(messageHandler.parse('CONTENT_TYPE_EXPORT_FAILED'));
@@ -85,7 +85,7 @@ export default class ContentTypesExport extends BaseClass {
       }
       return await this.getContentTypes(skip);
     } else {
-      v2Logger.info(messageHandler.parse('CONTENT_TYPE_NO_TYPES'), this.exportConfig.context);
+      log.info(messageHandler.parse('CONTENT_TYPE_NO_TYPES'), this.exportConfig.context);
     }
   }
 

--- a/packages/contentstack-export/src/export/modules/content-types.ts
+++ b/packages/contentstack-export/src/export/modules/content-types.ts
@@ -1,9 +1,15 @@
 import * as path from 'path';
-import { ContentstackClient } from '@contentstack/cli-utilities';
-import { log, formatError, fsUtil, executeTask } from '../../utils';
-import { ExportConfig, ModuleClassParams } from '../../types';
+import {
+  ContentstackClient,
+  handleAndLogError,
+  messageHandler,
+  v2Logger,
+  sanitizePath,
+} from '@contentstack/cli-utilities';
+
 import BaseClass from './base-class';
-import { sanitizePath } from '@contentstack/cli-utilities';
+import { fsUtil, executeTask } from '../../utils';
+import { ExportConfig, ModuleClassParams } from '../../types';
 
 export default class ContentTypesExport extends BaseClass {
   private stackAPIClient: ReturnType<ContentstackClient['stack']>;
@@ -14,7 +20,7 @@ export default class ContentTypesExport extends BaseClass {
     skip?: number;
     limit?: number;
     include_global_field_schema: boolean;
-    uid?: Record<string, string[]>
+    uid?: Record<string, string[]>;
   };
   private contentTypesConfig: {
     dirName?: string;
@@ -38,29 +44,29 @@ export default class ContentTypesExport extends BaseClass {
       include_global_field_schema: true,
     };
 
-     // If content type id is provided then use it as part of query
-     if (Array.isArray(this.exportConfig.contentTypes) && this.exportConfig.contentTypes.length > 0) {
+    // If content type id is provided then use it as part of query
+    if (Array.isArray(this.exportConfig.contentTypes) && this.exportConfig.contentTypes.length > 0) {
       this.qs.uid = { $in: this.exportConfig.contentTypes };
-     }
-    
+    }
+
     this.contentTypesDirPath = path.resolve(
       sanitizePath(exportConfig.data),
       sanitizePath(exportConfig.branchName || ''),
       sanitizePath(this.contentTypesConfig.dirName),
     );
     this.contentTypes = [];
+    this.exportConfig.context.module = 'content-types';
   }
 
   async start() {
     try {
-      log(this.exportConfig, 'Starting content type export', 'success');
       await fsUtil.makeDirectory(this.contentTypesDirPath);
       await this.getContentTypes();
       await this.writeContentTypes(this.contentTypes);
-      log(this.exportConfig, 'Content type(s) exported successfully', 'success');
+      v2Logger.success(messageHandler.parse('CONTENT_TYPE_EXPORT_COMPLETE'), this.exportConfig.context);
     } catch (error) {
-      log(this.exportConfig, `Failed to export content types ${formatError(error)}`, 'error');
-      throw new Error('Failed to export content types');
+      handleAndLogError(error, { ...this.exportConfig.context });
+      throw new Error(messageHandler.parse('CONTENT_TYPE_EXPORT_FAILED'));
     }
   }
 
@@ -79,7 +85,7 @@ export default class ContentTypesExport extends BaseClass {
       }
       return await this.getContentTypes(skip);
     } else {
-      log(this.exportConfig, 'No content types returned for the given query', 'info');
+      v2Logger.info(messageHandler.parse('CONTENT_TYPE_NO_TYPES'), this.exportConfig.context);
     }
   }
 
@@ -99,7 +105,10 @@ export default class ContentTypesExport extends BaseClass {
   async writeContentTypes(contentTypes: Record<string, unknown>[]) {
     function write(contentType: Record<string, unknown>) {
       return fsUtil.writeFile(
-        path.join(sanitizePath(this.contentTypesDirPath), sanitizePath(`${contentType.uid === 'schema' ? 'schema|1' : contentType.uid}.json`)),
+        path.join(
+          sanitizePath(this.contentTypesDirPath),
+          sanitizePath(`${contentType.uid === 'schema' ? 'schema|1' : contentType.uid}.json`),
+        ),
         contentType,
       );
     }

--- a/packages/contentstack-export/src/export/modules/custom-roles.ts
+++ b/packages/contentstack-export/src/export/modules/custom-roles.ts
@@ -3,7 +3,7 @@ import find from 'lodash/find';
 import forEach from 'lodash/forEach';
 import values from 'lodash/values';
 import { resolve as pResolve } from 'node:path';
-import { handleAndLogError, messageHandler, v2Logger } from '@contentstack/cli-utilities';
+import { handleAndLogError, messageHandler, log } from '@contentstack/cli-utilities';
 
 import BaseClass from './base-class';
 import { fsUtil } from '../../utils';
@@ -51,12 +51,12 @@ export default class ExportCustomRoles extends BaseClass {
     const customRoles = roles.items.filter((role: any) => !this.existingRoles[role.name]);
 
     if (!customRoles.length) {
-      v2Logger.info(messageHandler.parse('ROLES_NO_CUSTOM_ROLES'), this.exportConfig.context);
+      log.info(messageHandler.parse('ROLES_NO_CUSTOM_ROLES'), this.exportConfig.context);
       return;
     }
 
     customRoles.forEach((role: any) => {
-      v2Logger.info(messageHandler.parse('ROLES_EXPORTING_ROLE', role.name), this.exportConfig.context);
+      log.info(messageHandler.parse('ROLES_EXPORTING_ROLE', role.name), this.exportConfig.context);
       this.customRoles[role.uid] = role;
     });
     fsUtil.writeFile(pResolve(this.rolesFolderPath, this.customRolesConfig.fileName), this.customRoles);

--- a/packages/contentstack-export/src/export/modules/custom-roles.ts
+++ b/packages/contentstack-export/src/export/modules/custom-roles.ts
@@ -56,7 +56,7 @@ export default class ExportCustomRoles extends BaseClass {
     }
 
     customRoles.forEach((role: any) => {
-      v2Logger.info(`Exporting role: ${role.name}`, this.exportConfig.context);
+      v2Logger.info(messageHandler.parse('ROLES_EXPORTING_ROLE', role.name), this.exportConfig.context);
       this.customRoles[role.uid] = role;
     });
     fsUtil.writeFile(pResolve(this.rolesFolderPath, this.customRolesConfig.fileName), this.customRoles);

--- a/packages/contentstack-export/src/export/modules/entries.ts
+++ b/packages/contentstack-export/src/export/modules/entries.ts
@@ -4,7 +4,7 @@ import {
   FsUtility,
   handleAndLogError,
   messageHandler,
-  v2Logger,
+  log,
 } from '@contentstack/cli-utilities';
 import { Export, ExportProjects } from '@contentstack/cli-variants';
 import { sanitizePath } from '@contentstack/cli-utilities';
@@ -66,7 +66,7 @@ export default class EntriesExport extends BaseClass {
       const locales = fsUtil.readFile(this.localesFilePath) as Array<Record<string, unknown>>;
       const contentTypes = fsUtil.readFile(this.schemaFilePath) as Array<Record<string, unknown>>;
       if (contentTypes.length === 0) {
-        v2Logger.info(messageHandler.parse('CONTENT_TYPE_NO_TYPES'), this.exportConfig.context);
+        log.info(messageHandler.parse('CONTENT_TYPE_NO_TYPES'), this.exportConfig.context);
         return;
       }
 
@@ -91,7 +91,7 @@ export default class EntriesExport extends BaseClass {
       for (let entryRequestOption of entryRequestOptions) {
         await this.getEntries(entryRequestOption);
         this.entriesFileHelper?.completeFile(true);
-        v2Logger.success(
+        log.success(
           messageHandler.parse(
             'ENTRIES_EXPORT_COMPLETE',
             entryRequestOption.contentType,
@@ -100,7 +100,7 @@ export default class EntriesExport extends BaseClass {
           this.exportConfig.context,
         );
       }
-      v2Logger.success(messageHandler.parse('ENTRIES_EXPORT_SUCCESS'), this.exportConfig.context);
+      log.success(messageHandler.parse('ENTRIES_EXPORT_SUCCESS'), this.exportConfig.context);
     } catch (error) {
       handleAndLogError(error, { ...this.exportConfig.context });
     }
@@ -216,7 +216,7 @@ export default class EntriesExport extends BaseClass {
         path.join(sanitizePath(options.versionedEntryPath), sanitizePath(`${entry.uid}.json`)),
         response,
       );
-      v2Logger.success(
+      log.success(
         messageHandler.parse('ENTRIES_VERSIONED_EXPORT_SUCCESS', options.contentType, entry.uid, options.locale),
         this.exportConfig.context,
       );

--- a/packages/contentstack-export/src/export/modules/environments.ts
+++ b/packages/contentstack-export/src/export/modules/environments.ts
@@ -1,7 +1,7 @@
 import { resolve as pResolve } from 'node:path';
 import omit from 'lodash/omit';
 import isEmpty from 'lodash/isEmpty';
-import { handleAndLogError, messageHandler, v2Logger } from '@contentstack/cli-utilities';
+import { handleAndLogError, messageHandler, log } from '@contentstack/cli-utilities';
 
 import BaseClass from './base-class';
 import { fsUtil } from '../../utils';
@@ -35,10 +35,10 @@ export default class ExportEnvironments extends BaseClass {
     await this.getEnvironments();
 
     if (this.environments === undefined || isEmpty(this.environments)) {
-      v2Logger.info(messageHandler.parse('ENVIRONMENT_NOT_FOUND'), this.exportConfig.context);
+      log.info(messageHandler.parse('ENVIRONMENT_NOT_FOUND'), this.exportConfig.context);
     } else {
       fsUtil.writeFile(pResolve(this.environmentsFolderPath, this.environmentConfig.fileName), this.environments);
-      v2Logger.success(
+      log.success(
         messageHandler.parse('ENVIRONMENT_EXPORT_COMPLETE', Object.keys(this.environments).length),
         this.exportConfig.context,
       );
@@ -74,7 +74,7 @@ export default class ExportEnvironments extends BaseClass {
       const extUid = environments[index].uid;
       const envName = environments[index]?.name;
       this.environments[extUid] = omit(environments[index], ['ACL']);
-      v2Logger.success(messageHandler.parse('ENVIRONMENT_EXPORT_SUCCESS', envName ), this.exportConfig.context);
+      log.success(messageHandler.parse('ENVIRONMENT_EXPORT_SUCCESS', envName ), this.exportConfig.context);
     }
   }
 }

--- a/packages/contentstack-export/src/export/modules/environments.ts
+++ b/packages/contentstack-export/src/export/modules/environments.ts
@@ -1,9 +1,10 @@
 import { resolve as pResolve } from 'node:path';
 import omit from 'lodash/omit';
 import isEmpty from 'lodash/isEmpty';
+import { handleAndLogError, messageHandler, v2Logger } from '@contentstack/cli-utilities';
 
 import BaseClass from './base-class';
-import { log, formatError, fsUtil } from '../../utils';
+import { fsUtil } from '../../utils';
 import { EnvironmentConfig, ModuleClassParams } from '../../types';
 
 export default class ExportEnvironments extends BaseClass {
@@ -20,12 +21,10 @@ export default class ExportEnvironments extends BaseClass {
     this.environments = {};
     this.environmentConfig = exportConfig.modules.environments;
     this.qs = { include_count: true };
+    this.exportConfig.context.module = 'environments';
   }
 
-
   async start(): Promise<void> {
-    log(this.exportConfig, 'Starting environment export', 'info');
-
     this.environmentsFolderPath = pResolve(
       this.exportConfig.data,
       this.exportConfig.branchName || '',
@@ -36,10 +35,13 @@ export default class ExportEnvironments extends BaseClass {
     await this.getEnvironments();
 
     if (this.environments === undefined || isEmpty(this.environments)) {
-      log(this.exportConfig, 'No environments found', 'info');
+      v2Logger.info(messageHandler.parse('ENVIRONMENT_NOT_FOUND'), this.exportConfig.context);
     } else {
       fsUtil.writeFile(pResolve(this.environmentsFolderPath, this.environmentConfig.fileName), this.environments);
-      log(this.exportConfig, 'All the environments have been exported successfully!', 'success');
+      v2Logger.success(
+        messageHandler.parse('ENVIRONMENT_EXPORT_COMPLETE', Object.keys(this.environments).length),
+        this.exportConfig.context,
+      );
     }
   }
 
@@ -63,8 +65,7 @@ export default class ExportEnvironments extends BaseClass {
         }
       })
       .catch((error: any) => {
-        log(this.exportConfig, `Failed to export environments. ${formatError(error)}`, 'error');
-        log(this.exportConfig, error, 'error');
+        handleAndLogError(error, { ...this.exportConfig.context });
       });
   }
 
@@ -73,7 +74,7 @@ export default class ExportEnvironments extends BaseClass {
       const extUid = environments[index].uid;
       const envName = environments[index]?.name;
       this.environments[extUid] = omit(environments[index], ['ACL']);
-      log(this.exportConfig, `'${envName}' environment was exported successfully`, 'success');
+      v2Logger.success(messageHandler.parse('ENVIRONMENT_EXPORT_SUCCESS', envName ), this.exportConfig.context);
     }
   }
 }

--- a/packages/contentstack-export/src/export/modules/extensions.ts
+++ b/packages/contentstack-export/src/export/modules/extensions.ts
@@ -1,7 +1,7 @@
 import omit from 'lodash/omit';
 import isEmpty from 'lodash/isEmpty';
 import { resolve as pResolve } from 'node:path';
-import { handleAndLogError, messageHandler, v2Logger } from '@contentstack/cli-utilities';
+import { handleAndLogError, messageHandler, log } from '@contentstack/cli-utilities';
 
 import BaseClass from './base-class';
 import { fsUtil } from '../../utils';
@@ -35,10 +35,10 @@ export default class ExportExtensions extends BaseClass {
     await this.getExtensions();
 
     if (this.extensions === undefined || isEmpty(this.extensions)) {
-      v2Logger.info(messageHandler.parse('EXTENSION_NOT_FOUND'), this.exportConfig.context);
+      log.info(messageHandler.parse('EXTENSION_NOT_FOUND'), this.exportConfig.context);
     } else {
       fsUtil.writeFile(pResolve(this.extensionsFolderPath, this.extensionConfig.fileName), this.extensions);
-      v2Logger.success(
+      log.success(
         messageHandler.parse('EXTENSION_EXPORT_COMPLETE', Object.keys(this.extensions).length ),
         this.exportConfig.context,
       );
@@ -74,7 +74,7 @@ export default class ExportExtensions extends BaseClass {
       const extUid = extensions[index].uid;
       const extTitle = extensions[index]?.title;
       this.extensions[extUid] = omit(extensions[index], ['SYS_ACL']);
-      v2Logger.info(messageHandler.parse('EXTENSION_EXPORT_SUCCESS', extTitle), this.exportConfig.context);
+      log.info(messageHandler.parse('EXTENSION_EXPORT_SUCCESS', extTitle), this.exportConfig.context);
     }
   }
 }

--- a/packages/contentstack-export/src/export/modules/global-fields.ts
+++ b/packages/contentstack-export/src/export/modules/global-fields.ts
@@ -1,9 +1,15 @@
 import * as path from 'path';
-import { ContentstackClient } from '@contentstack/cli-utilities';
-import { log, formatError, fsUtil } from '../../utils';
+import {
+  ContentstackClient,
+  handleAndLogError,
+  messageHandler,
+  v2Logger,
+  sanitizePath,
+} from '@contentstack/cli-utilities';
+
+import { fsUtil } from '../../utils';
 import { ExportConfig, ModuleClassParams } from '../../types';
 import BaseClass from './base-class';
-import { sanitizePath } from '@contentstack/cli-utilities';
 
 export default class GlobalFieldsExport extends BaseClass {
   private stackAPIClient: ReturnType<ContentstackClient['stack']>;
@@ -35,7 +41,7 @@ export default class GlobalFieldsExport extends BaseClass {
       asc: 'updated_at',
       include_count: true,
       limit: this.globalFieldsConfig.limit,
-      include_global_field_schema: true
+      include_global_field_schema: true,
     };
     this.globalFieldsDirPath = path.resolve(
       sanitizePath(exportConfig.data),
@@ -43,18 +49,20 @@ export default class GlobalFieldsExport extends BaseClass {
       sanitizePath(this.globalFieldsConfig.dirName),
     );
     this.globalFields = [];
+    this.exportConfig.context.module = 'global-fields';
   }
 
   async start() {
     try {
-      log(this.exportConfig, 'Starting global fields export', 'success');
       await fsUtil.makeDirectory(this.globalFieldsDirPath);
       await this.getGlobalFields();
       fsUtil.writeFile(path.join(this.globalFieldsDirPath, this.globalFieldsConfig.fileName), this.globalFields);
-      log(this.exportConfig, 'Completed global fields export', 'success');
+      v2Logger.success(
+        messageHandler.parse('GLOBAL_FIELDS_EXPORT_COMPLETE', this.globalFields.length),
+        this.exportConfig.context,
+      );
     } catch (error) {
-      log(this.exportConfig, `Failed to export global fields. ${formatError(error)}`, 'error');
-      throw new Error('Failed to export global fields');
+      handleAndLogError(error, { ...this.exportConfig.context });
     }
   }
 
@@ -62,7 +70,7 @@ export default class GlobalFieldsExport extends BaseClass {
     if (skip) {
       this.qs.skip = skip;
     }
-    let globalFieldsFetchResponse = await this.stackAPIClient.globalField({api_version: '3.2'}).query(this.qs).find();
+    let globalFieldsFetchResponse = await this.stackAPIClient.globalField({ api_version: '3.2' }).query(this.qs).find();
     if (Array.isArray(globalFieldsFetchResponse.items) && globalFieldsFetchResponse.items.length > 0) {
       this.sanitizeAttribs(globalFieldsFetchResponse.items);
       skip += this.globalFieldsConfig.limit || 100;

--- a/packages/contentstack-export/src/export/modules/global-fields.ts
+++ b/packages/contentstack-export/src/export/modules/global-fields.ts
@@ -3,7 +3,7 @@ import {
   ContentstackClient,
   handleAndLogError,
   messageHandler,
-  v2Logger,
+  log,
   sanitizePath,
 } from '@contentstack/cli-utilities';
 
@@ -57,7 +57,7 @@ export default class GlobalFieldsExport extends BaseClass {
       await fsUtil.makeDirectory(this.globalFieldsDirPath);
       await this.getGlobalFields();
       fsUtil.writeFile(path.join(this.globalFieldsDirPath, this.globalFieldsConfig.fileName), this.globalFields);
-      v2Logger.success(
+      log.success(
         messageHandler.parse('GLOBAL_FIELDS_EXPORT_COMPLETE', this.globalFields.length),
         this.exportConfig.context,
       );

--- a/packages/contentstack-export/src/export/modules/index.ts
+++ b/packages/contentstack-export/src/export/modules/index.ts
@@ -1,9 +1,18 @@
+import { handleAndLogError } from '@contentstack/cli-utilities';
 import { ModuleClassParams } from '../../types';
 
 export default async function startModuleExport(modulePayload: ModuleClassParams) {
-  const { default: ModuleRunner } = await import(`./${modulePayload.moduleName}`);
-  const moduleRunner = new ModuleRunner(modulePayload);
-  return moduleRunner.start();
+  try {
+    const { default: ModuleRunner } = await import(`./${modulePayload.moduleName}`);
+    const moduleRunner = new ModuleRunner(modulePayload);
+    return moduleRunner.start();
+  } catch (error) {
+    handleAndLogError(error, {
+      ...modulePayload.exportConfig.context,
+      module: modulePayload.moduleName,
+    });
+    throw error; 
+  }
 }
 
 export { default as ExportAssets } from './assets';

--- a/packages/contentstack-export/src/export/modules/labels.ts
+++ b/packages/contentstack-export/src/export/modules/labels.ts
@@ -1,7 +1,7 @@
 import omit from 'lodash/omit';
 import isEmpty from 'lodash/isEmpty';
 import { resolve as pResolve } from 'node:path';
-import { handleAndLogError, messageHandler, v2Logger } from '@contentstack/cli-utilities';
+import { handleAndLogError, messageHandler, log } from '@contentstack/cli-utilities';
 
 import BaseClass from './base-class';
 import { fsUtil } from '../../utils';
@@ -34,10 +34,10 @@ export default class ExportLabels extends BaseClass {
     await fsUtil.makeDirectory(this.labelsFolderPath);
     await this.getLabels();
     if (this.labels === undefined || isEmpty(this.labels)) {
-      v2Logger.info(messageHandler.parse('LABELS_NOT_FOUND'), this.exportConfig.context);
+      log.info(messageHandler.parse('LABELS_NOT_FOUND'), this.exportConfig.context);
     } else {
       fsUtil.writeFile(pResolve(this.labelsFolderPath, this.labelConfig.fileName), this.labels);
-      v2Logger.success(
+      log.success(
         messageHandler.parse('LABELS_EXPORT_COMPLETE', Object.keys(this.labels).length),
         this.exportConfig.context,
       );
@@ -73,7 +73,7 @@ export default class ExportLabels extends BaseClass {
       const labelUid = labels[index].uid;
       const labelName = labels[index]?.name;
       this.labels[labelUid] = omit(labels[index], this.labelConfig.invalidKeys);
-      v2Logger.info(messageHandler.parse('LABEL_EXPORT_SUCCESS', labelName), this.exportConfig.context);
+      log.info(messageHandler.parse('LABEL_EXPORT_SUCCESS', labelName), this.exportConfig.context);
     }
   }
 }

--- a/packages/contentstack-export/src/export/modules/labels.ts
+++ b/packages/contentstack-export/src/export/modules/labels.ts
@@ -1,9 +1,10 @@
 import omit from 'lodash/omit';
 import isEmpty from 'lodash/isEmpty';
 import { resolve as pResolve } from 'node:path';
+import { handleAndLogError, messageHandler, v2Logger } from '@contentstack/cli-utilities';
 
 import BaseClass from './base-class';
-import { log, formatError, fsUtil } from '../../utils';
+import { fsUtil } from '../../utils';
 import { LabelConfig, ModuleClassParams } from '../../types';
 
 export default class ExportLabels extends BaseClass {
@@ -20,11 +21,10 @@ export default class ExportLabels extends BaseClass {
     this.labels = {};
     this.labelConfig = exportConfig.modules.labels;
     this.qs = { include_count: true };
+    this.exportConfig.context.module = 'labels';
   }
 
   async start(): Promise<void> {
-    log(this.exportConfig, 'Starting labels export', 'info');
-
     this.labelsFolderPath = pResolve(
       this.exportConfig.data,
       this.exportConfig.branchName || '',
@@ -34,10 +34,13 @@ export default class ExportLabels extends BaseClass {
     await fsUtil.makeDirectory(this.labelsFolderPath);
     await this.getLabels();
     if (this.labels === undefined || isEmpty(this.labels)) {
-      log(this.exportConfig, 'No labels found', 'info');
+      v2Logger.info(messageHandler.parse('LABELS_NOT_FOUND'), this.exportConfig.context);
     } else {
       fsUtil.writeFile(pResolve(this.labelsFolderPath, this.labelConfig.fileName), this.labels);
-      log(this.exportConfig, 'All the labels have been exported successfully!', 'success');
+      v2Logger.success(
+        messageHandler.parse('LABELS_EXPORT_COMPLETE', Object.keys(this.labels).length),
+        this.exportConfig.context,
+      );
     }
   }
 
@@ -61,8 +64,7 @@ export default class ExportLabels extends BaseClass {
         }
       })
       .catch((error: any) => {
-        log(this.exportConfig, `Failed to export labels. ${formatError(error)}`, 'error');
-        log(this.exportConfig, error, 'error');
+        handleAndLogError(error, { ...this.exportConfig.context });
       });
   }
 
@@ -71,7 +73,7 @@ export default class ExportLabels extends BaseClass {
       const labelUid = labels[index].uid;
       const labelName = labels[index]?.name;
       this.labels[labelUid] = omit(labels[index], this.labelConfig.invalidKeys);
-      log(this.exportConfig, `'${labelName}' label was exported successfully`, 'success');
+      v2Logger.info(messageHandler.parse('LABEL_EXPORT_SUCCESS', labelName), this.exportConfig.context);
     }
   }
 }

--- a/packages/contentstack-export/src/export/modules/locales.ts
+++ b/packages/contentstack-export/src/export/modules/locales.ts
@@ -3,7 +3,7 @@ import {
   ContentstackClient,
   handleAndLogError,
   messageHandler,
-  v2Logger,
+  log,
   sanitizePath,
 } from '@contentstack/cli-utilities';
 
@@ -63,7 +63,7 @@ export default class LocaleExport extends BaseClass {
       await this.getLocales();
       fsUtil.writeFile(path.join(this.localesPath, this.localeConfig.fileName), this.locales);
       fsUtil.writeFile(path.join(this.localesPath, this.masterLocaleConfig.fileName), this.masterLocale);
-      v2Logger.success(
+      log.success(
         messageHandler.parse(
           'LOCALES_EXPORT_COMPLETE',
           Object.keys(this.locales).length,

--- a/packages/contentstack-export/src/export/modules/locales.ts
+++ b/packages/contentstack-export/src/export/modules/locales.ts
@@ -1,9 +1,15 @@
 import * as path from 'path';
-import { ContentstackClient } from '@contentstack/cli-utilities';
-import { log, formatError, fsUtil } from '../../utils';
-import { ExportConfig, ModuleClassParams } from '../../types';
+import {
+  ContentstackClient,
+  handleAndLogError,
+  messageHandler,
+  v2Logger,
+  sanitizePath,
+} from '@contentstack/cli-utilities';
+
+import { fsUtil } from '../../utils';
 import BaseClass from './base-class';
-import { sanitizePath } from '@contentstack/cli-utilities';
+import { ExportConfig, ModuleClassParams } from '../../types';
 
 export default class LocaleExport extends BaseClass {
   private stackAPIClient: ReturnType<ContentstackClient['stack']>;
@@ -41,22 +47,32 @@ export default class LocaleExport extends BaseClass {
         BASE: this.localeConfig.requiredKeys,
       },
     };
-    this.localesPath = path.resolve(sanitizePath(exportConfig.data), sanitizePath(exportConfig.branchName || ''),sanitizePath(this.localeConfig.dirName));
+    this.localesPath = path.resolve(
+      sanitizePath(exportConfig.data),
+      sanitizePath(exportConfig.branchName || ''),
+      sanitizePath(this.localeConfig.dirName),
+    );
     this.locales = {};
     this.masterLocale = {};
+    this.exportConfig.context.module = 'locales';
   }
 
   async start() {
     try {
-      log(this.exportConfig, 'Starting locale export', 'success');
       await fsUtil.makeDirectory(this.localesPath);
       await this.getLocales();
       fsUtil.writeFile(path.join(this.localesPath, this.localeConfig.fileName), this.locales);
       fsUtil.writeFile(path.join(this.localesPath, this.masterLocaleConfig.fileName), this.masterLocale);
-      log(this.exportConfig, 'Completed locale export', 'success');
+      v2Logger.success(
+        messageHandler.parse(
+          'LOCALES_EXPORT_COMPLETE',
+          Object.keys(this.locales).length,
+          Object.keys(this.masterLocale).length,
+        ),
+        this.exportConfig.context,
+      );
     } catch (error) {
-      log(this.exportConfig, `Failed to export locales. ${formatError(error)}`, 'error');
-      throw new Error('Failed to export locales');
+      handleAndLogError(error, { ...this.exportConfig.context });
     }
   }
 

--- a/packages/contentstack-export/src/export/modules/marketplace-apps.ts
+++ b/packages/contentstack-export/src/export/modules/marketplace-apps.ts
@@ -12,7 +12,7 @@ import {
   isAuthenticated,
   marketplaceSDKClient,
   ContentstackMarketplaceClient,
-  v2Logger,
+  log,
   messageHandler,
   handleAndLogError,
 } from '@contentstack/cli-utilities';
@@ -87,7 +87,7 @@ export default class ExportMarketplaceApps {
    */
   async getAppManifestAndAppConfig(): Promise<void> {
     if (isEmpty(this.installedApps)) {
-      v2Logger.info(messageHandler.parse('MARKETPLACE_APPS_NOT_FOUND'), this.exportConfig.context);
+      log.info(messageHandler.parse('MARKETPLACE_APPS_NOT_FOUND'), this.exportConfig.context);
     } else {
       for (const [index, app] of entries(this.installedApps)) {
         if (app.manifest.visibility === 'private') {
@@ -101,7 +101,7 @@ export default class ExportMarketplaceApps {
 
       fsUtil.writeFile(pResolve(this.marketplaceAppPath, this.marketplaceAppConfig.fileName), this.installedApps);
 
-      v2Logger.success(
+      log.success(
         messageHandler.parse('MARKETPLACE_APPS_EXPORT_COMPLETE', Object.keys(this.installedApps).length),
         this.exportConfig.context,
       );
@@ -151,7 +151,7 @@ export default class ExportMarketplaceApps {
     const appName = appInstallation?.manifest?.name;
     const appUid = appInstallation?.manifest?.uid;
     const app = appName || appUid;
-    v2Logger.info(messageHandler.parse('MARKETPLACE_APP_CONFIG_EXPORT', app), this.exportConfig.context);
+    log.info(messageHandler.parse('MARKETPLACE_APP_CONFIG_EXPORT', app), this.exportConfig.context);
 
     await this.appSdk
       .marketplace(this.exportConfig.org_uid)
@@ -171,9 +171,9 @@ export default class ExportMarketplaceApps {
 
           if (!isEmpty(data?.server_configuration)) {
             this.installedApps[index]['server_configuration'] = this.nodeCrypto.encrypt(data.server_configuration);
-            v2Logger.success(messageHandler.parse('MARKETPLACE_APP_CONFIG_SUCCESS', app), this.exportConfig.context);
+            log.success(messageHandler.parse('MARKETPLACE_APP_CONFIG_SUCCESS', app), this.exportConfig.context);
           } else {
-            v2Logger.success(messageHandler.parse('MARKETPLACE_APP_EXPORT_SUCCESS', app), this.exportConfig.context);
+            log.success(messageHandler.parse('MARKETPLACE_APP_EXPORT_SUCCESS', app), this.exportConfig.context);
           }
         } else if (error) {
           handleAndLogError(

--- a/packages/contentstack-export/src/export/modules/personalize.ts
+++ b/packages/contentstack-export/src/export/modules/personalize.ts
@@ -6,7 +6,7 @@ import {
   ExportAudiences,
   AnyProperty,
 } from '@contentstack/cli-variants';
-import { handleAndLogError, messageHandler, v2Logger } from '@contentstack/cli-utilities';
+import { handleAndLogError, messageHandler, log } from '@contentstack/cli-utilities';
 
 import { ModuleClassParams, ExportConfig } from '../../types';
 
@@ -22,12 +22,12 @@ export default class ExportPersonalize {
   async start(): Promise<void> {
     try {
       if (!this.personalizeConfig.baseURL[this.exportConfig.region.name]) {
-        v2Logger.info(messageHandler.parse('PERSONALIZE_URL_NOT_SET'), this.exportConfig.context);
+        log.info(messageHandler.parse('PERSONALIZE_URL_NOT_SET'), this.exportConfig.context);
         this.exportConfig.personalizationEnabled = false;
         return;
       }
       if (this.exportConfig.management_token) {
-        v2Logger.info(messageHandler.parse('PERSONALIZE_SKIPPING_WITH_MANAGEMENT_TOKEN'), this.exportConfig.context);
+        log.info(messageHandler.parse('PERSONALIZE_SKIPPING_WITH_MANAGEMENT_TOKEN'), this.exportConfig.context);
         this.exportConfig.personalizationEnabled = false;
         return;
       }
@@ -47,7 +47,7 @@ export default class ExportPersonalize {
           if (moduleMapper[module]) {
             await moduleMapper[module].start();
           } else {
-            v2Logger.info(
+            log.info(
               messageHandler.parse('PERSONALIZE_MODULE_NOT_IMPLEMENTED', module),
               this.exportConfig.context,
             );
@@ -56,7 +56,7 @@ export default class ExportPersonalize {
       }
     } catch (error) {
       if (error === 'Forbidden') {
-        v2Logger.info(messageHandler.parse('PERSONALIZE_NOT_ENABLED'), this.exportConfig.context);
+        log.info(messageHandler.parse('PERSONALIZE_NOT_ENABLED'), this.exportConfig.context);
       } else {
         handleAndLogError(error, { ...this.exportConfig.context });
       }

--- a/packages/contentstack-export/src/export/modules/stack.ts
+++ b/packages/contentstack-export/src/export/modules/stack.ts
@@ -1,6 +1,6 @@
 import find from 'lodash/find';
 import { resolve as pResolve } from 'node:path';
-import { handleAndLogError, isAuthenticated, managementSDKClient, v2Logger } from '@contentstack/cli-utilities';
+import { handleAndLogError, isAuthenticated, managementSDKClient, log } from '@contentstack/cli-utilities';
 
 import BaseClass from './base-class';
 import { fsUtil } from '../../utils';
@@ -66,7 +66,7 @@ export default class ExportStack extends BaseClass {
           if (masterLocalObj) {
             return masterLocalObj;
           } else if (skip >= count) {
-            v2Logger.error(
+            log.error(
               `Master locale not found in the stack ${this.exportConfig.source_stack}. Please ensure that the stack has a master locale.`,
               this.exportConfig.context,
             );
@@ -92,7 +92,7 @@ export default class ExportStack extends BaseClass {
       .fetch()
       .then((resp: any) => {
         fsUtil.writeFile(pResolve(this.stackFolderPath, this.stackConfig.fileName), resp);
-        v2Logger.success(
+        log.success(
           `Stack details exported successfully for stack ${this.exportConfig.source_stack}`,
           this.exportConfig.context,
         );

--- a/packages/contentstack-export/src/export/modules/stack.ts
+++ b/packages/contentstack-export/src/export/modules/stack.ts
@@ -1,9 +1,9 @@
 import find from 'lodash/find';
 import { resolve as pResolve } from 'node:path';
-import { isAuthenticated, managementSDKClient } from '@contentstack/cli-utilities';
+import { handleAndLogError, isAuthenticated, managementSDKClient, v2Logger } from '@contentstack/cli-utilities';
 
 import BaseClass from './base-class';
-import { log, formatError, fsUtil } from '../../utils';
+import { fsUtil } from '../../utils';
 import { StackConfig, ModuleClassParams } from '../../types';
 
 export default class ExportStack extends BaseClass {
@@ -19,6 +19,7 @@ export default class ExportStack extends BaseClass {
     this.stackConfig = exportConfig.modules.stack;
     this.qs = { include_count: true };
     this.stackFolderPath = pResolve(this.exportConfig.data, this.stackConfig.dirName);
+    this.exportConfig.context.module = 'stack';
   }
 
   async start(): Promise<void> {
@@ -65,7 +66,11 @@ export default class ExportStack extends BaseClass {
           if (masterLocalObj) {
             return masterLocalObj;
           } else if (skip >= count) {
-            log(this.exportConfig, 'Master locale not found', 'error');
+            v2Logger.error(
+              `Master locale not found in the stack ${this.exportConfig.source_stack}. Please ensure that the stack has a master locale.`,
+              this.exportConfig.context,
+            );
+
             return;
           } else {
             return await this.getLocales(skip);
@@ -73,23 +78,28 @@ export default class ExportStack extends BaseClass {
         }
       })
       .catch((error: any) => {
-        log(this.exportConfig, `Failed to export locales. ${formatError(error)}`, 'error');
-        log(this.exportConfig, error, 'error');
+        handleAndLogError(
+          error,
+          { ...this.exportConfig.context },
+          `Failed to fetch locales for stack ${this.exportConfig.source_stack}`,
+        );
       });
   }
 
   async exportStack(): Promise<any> {
-    log(this.exportConfig, 'Exporting stack details', 'success');
     await fsUtil.makeDirectory(this.stackFolderPath);
     return this.stack
       .fetch()
       .then((resp: any) => {
         fsUtil.writeFile(pResolve(this.stackFolderPath, this.stackConfig.fileName), resp);
-        log(this.exportConfig, 'Exported stack details successfully!', 'success');
+        v2Logger.success(
+          `Stack details exported successfully for stack ${this.exportConfig.source_stack}`,
+          this.exportConfig.context,
+        );
         return resp;
       })
       .catch((error: any) => {
-        log(this.exportConfig, `Failed to export stack. ${formatError(error)}`, 'error');
+        handleAndLogError(error, { ...this.exportConfig.context });
       });
   }
 }

--- a/packages/contentstack-export/src/export/modules/taxonomies.ts
+++ b/packages/contentstack-export/src/export/modules/taxonomies.ts
@@ -2,7 +2,7 @@ import omit from 'lodash/omit';
 import keys from 'lodash/keys';
 import isEmpty from 'lodash/isEmpty';
 import { resolve as pResolve } from 'node:path';
-import { handleAndLogError, messageHandler, v2Logger } from '@contentstack/cli-utilities';
+import { handleAndLogError, messageHandler, log } from '@contentstack/cli-utilities';
 
 import BaseClass from './base-class';
 import { fsUtil } from '../../utils';
@@ -39,13 +39,13 @@ export default class ExportTaxonomies extends BaseClass {
     //fetch all taxonomies and write into taxonomies folder
     await this.getAllTaxonomies();
     if (this.taxonomies === undefined || isEmpty(this.taxonomies)) {
-      v2Logger.info(messageHandler.parse('TAXONOMY_NOT_FOUND'), this.exportConfig.context);
+      log.info(messageHandler.parse('TAXONOMY_NOT_FOUND'), this.exportConfig.context);
       return;
     } else {
       fsUtil.writeFile(pResolve(this.taxonomiesFolderPath, 'taxonomies.json'), this.taxonomies);
       await this.exportTaxonomies();
     }
-    v2Logger.success(
+    log.success(
       messageHandler.parse('TAXONOMY_EXPORT_COMPLETE', keys(this.taxonomies).length ),
       this.exportConfig.context,
     );
@@ -104,7 +104,7 @@ export default class ExportTaxonomies extends BaseClass {
     const onSuccess = ({ response, uid }: any) => {
       const filePath = pResolve(this.taxonomiesFolderPath, `${uid}.json`);
       fsUtil.writeFile(filePath, response);
-      v2Logger.success(
+      log.success(
         messageHandler.parse('TAXONOMY_EXPORT_SUCCESS', uid),
         this.exportConfig.context,
       );

--- a/packages/contentstack-export/src/export/modules/taxonomies.ts
+++ b/packages/contentstack-export/src/export/modules/taxonomies.ts
@@ -2,9 +2,10 @@ import omit from 'lodash/omit';
 import keys from 'lodash/keys';
 import isEmpty from 'lodash/isEmpty';
 import { resolve as pResolve } from 'node:path';
+import { handleAndLogError, messageHandler, v2Logger } from '@contentstack/cli-utilities';
 
 import BaseClass from './base-class';
-import { log, fsUtil } from '../../utils';
+import { fsUtil } from '../../utils';
 import { ModuleClassParams, ExportConfig } from '../../types';
 
 export default class ExportTaxonomies extends BaseClass {
@@ -23,11 +24,10 @@ export default class ExportTaxonomies extends BaseClass {
     this.taxonomies = {};
     this.taxonomiesConfig = exportConfig.modules.taxonomies;
     this.qs = { include_count: true, limit: this.taxonomiesConfig.limit || 100, skip: 0 };
+    this.exportConfig.context.module = 'taxonomies';
   }
 
   async start(): Promise<void> {
-    log(this.exportConfig, 'Starting taxonomies export', 'info');
-
     //create taxonomies folder
     this.taxonomiesFolderPath = pResolve(
       this.exportConfig.data,
@@ -39,14 +39,16 @@ export default class ExportTaxonomies extends BaseClass {
     //fetch all taxonomies and write into taxonomies folder
     await this.getAllTaxonomies();
     if (this.taxonomies === undefined || isEmpty(this.taxonomies)) {
-      log(this.exportConfig, 'No taxonomies found!', 'info');
+      v2Logger.info(messageHandler.parse('TAXONOMY_NOT_FOUND'), this.exportConfig.context);
       return;
     } else {
       fsUtil.writeFile(pResolve(this.taxonomiesFolderPath, 'taxonomies.json'), this.taxonomies);
       await this.exportTaxonomies();
     }
-
-    log(this.exportConfig, `All taxonomies exported successfully!`, 'success');
+    v2Logger.success(
+      messageHandler.parse('TAXONOMY_EXPORT_COMPLETE', keys(this.taxonomies).length ),
+      this.exportConfig.context,
+    );
   }
 
   /**
@@ -76,7 +78,7 @@ export default class ExportTaxonomies extends BaseClass {
         }
       })
       .catch((error: any) => {
-        this.handleErrorMsg(error);
+        handleAndLogError(error, { ...this.exportConfig.context });
       });
   }
 
@@ -102,18 +104,14 @@ export default class ExportTaxonomies extends BaseClass {
     const onSuccess = ({ response, uid }: any) => {
       const filePath = pResolve(this.taxonomiesFolderPath, `${uid}.json`);
       fsUtil.writeFile(filePath, response);
-      log(this.exportConfig, `'${uid}' taxonomy exported successfully!`, 'success');
+      v2Logger.success(
+        messageHandler.parse('TAXONOMY_EXPORT_SUCCESS', uid),
+        this.exportConfig.context,
+      );
     };
 
     const onReject = ({ error, uid }: any) => {
-      if (error?.errorMessage) {
-        log(this.exportConfig, `Failed to export taxonomy - '${uid}'! ${error.errorMessage}`, 'error');
-      } else if (error?.message) {
-        const errorMsg = error?.errors?.taxonomy || error?.errors?.term || error?.message;
-        log(this.exportConfig, `Failed to export taxonomy - '${uid}'! ${errorMsg}`, 'error');
-      } else {
-        log(this.exportConfig, `Failed to export taxonomy - '${uid}'! ${error}`, 'error');
-      }
+      handleAndLogError(error, { ...this.exportConfig.context, uid });
     };
 
     for (let index = 0; index < taxonomiesUID?.length; index++) {
@@ -124,17 +122,6 @@ export default class ExportTaxonomies extends BaseClass {
         uid: taxonomyUID,
         module: 'export-taxonomy',
       });
-    }
-  }
-
-  handleErrorMsg(err: any) {
-    if (err?.errorMessage) {
-      log(this.exportConfig, `Failed to export! ${err.errorMessage}`, 'error');
-    } else if (err?.message) {
-      const errorMsg = err?.errors?.taxonomy || err?.errors?.term || err?.message;
-      log(this.exportConfig, `Failed to export! ${errorMsg}`, 'error');
-    } else {
-      log(this.exportConfig, `Failed to export! ${err}`, 'error');
     }
   }
 }

--- a/packages/contentstack-export/src/export/modules/webhooks.ts
+++ b/packages/contentstack-export/src/export/modules/webhooks.ts
@@ -1,7 +1,7 @@
 import omit from 'lodash/omit';
 import isEmpty from 'lodash/isEmpty';
 import { resolve as pResolve } from 'node:path';
-import { handleAndLogError, messageHandler, v2Logger } from '@contentstack/cli-utilities';
+import { handleAndLogError, messageHandler, log } from '@contentstack/cli-utilities';
 
 import BaseClass from './base-class';
 import { fsUtil } from '../../utils';
@@ -35,10 +35,10 @@ export default class ExportWebhooks extends BaseClass {
     await fsUtil.makeDirectory(this.webhooksFolderPath);
     await this.getWebhooks();
     if (this.webhooks === undefined || isEmpty(this.webhooks)) {
-      v2Logger.info(messageHandler.parse('WEBHOOK_NOT_FOUND'), this.exportConfig.context);
+      log.info(messageHandler.parse('WEBHOOK_NOT_FOUND'), this.exportConfig.context);
     } else {
       fsUtil.writeFile(pResolve(this.webhooksFolderPath, this.webhookConfig.fileName), this.webhooks);
-      v2Logger.success(
+      log.success(
         messageHandler.parse('WEBHOOK_EXPORT_COMPLETE', Object.keys(this.webhooks).length),
         this.exportConfig.context,
       );
@@ -74,7 +74,7 @@ export default class ExportWebhooks extends BaseClass {
       const webhookUid = webhooks[index].uid;
       const webhookName = webhooks[index]?.name;
       this.webhooks[webhookUid] = omit(webhooks[index], ['SYS_ACL']);
-      v2Logger.success(messageHandler.parse('WEBHOOK_EXPORT_SUCCESS', webhookName), this.exportConfig.context);
+      log.success(messageHandler.parse('WEBHOOK_EXPORT_SUCCESS', webhookName), this.exportConfig.context);
     }
   }
 }

--- a/packages/contentstack-export/src/export/modules/workflows.ts
+++ b/packages/contentstack-export/src/export/modules/workflows.ts
@@ -1,7 +1,7 @@
 import omit from 'lodash/omit';
 import isEmpty from 'lodash/isEmpty';
 import { resolve as pResolve } from 'node:path';
-import { handleAndLogError, messageHandler, v2Logger } from '@contentstack/cli-utilities';
+import { handleAndLogError, messageHandler, log } from '@contentstack/cli-utilities';
 
 import BaseClass from './base-class';
 import { fsUtil } from '../../utils';
@@ -35,10 +35,10 @@ export default class ExportWorkFlows extends BaseClass {
     await this.getWorkflows();
 
     if (this.workflows === undefined || isEmpty(this.workflows)) {
-      v2Logger.info(messageHandler.parse('WORKFLOW_NOT_FOUND'), this.exportConfig.context);
+      log.info(messageHandler.parse('WORKFLOW_NOT_FOUND'), this.exportConfig.context);
     } else {
       fsUtil.writeFile(pResolve(this.webhooksFolderPath, this.workflowConfig.fileName), this.workflows);
-      v2Logger.success(
+      log.success(
         messageHandler.parse('WORKFLOW_EXPORT_COMPLETE', Object.keys(this.workflows).length ),
         this.exportConfig.context,
       );
@@ -77,7 +77,7 @@ export default class ExportWorkFlows extends BaseClass {
       const workflowUid = workflows[index].uid;
       const workflowName = workflows[index]?.name || '';
       this.workflows[workflowUid] = omit(workflows[index], this.workflowConfig.invalidKeys);
-      v2Logger.success(
+      log.success(
         messageHandler.parse('WORKFLOW_EXPORT_SUCCESS', workflowName),
         this.exportConfig.context,
       );

--- a/packages/contentstack-export/src/types/export-config.ts
+++ b/packages/contentstack-export/src/types/export-config.ts
@@ -1,7 +1,8 @@
-import { Modules, Region } from '.';
+import { Context, Modules, Region } from '.';
 import DefaultConfig from './default-config';
 
 export default interface ExportConfig extends DefaultConfig {
+  context: Context;
   cliLogsPath: string;
   exportDir: string;
   data: string;

--- a/packages/contentstack-export/src/types/index.ts
+++ b/packages/contentstack-export/src/types/index.ts
@@ -129,6 +129,16 @@ export interface StackConfig {
   dependencies?: Modules[];
   limit?: number;
 }
+export interface Context {
+  command: string;
+  module: string;
+  userId: string | undefined;
+  email: string | undefined;
+  sessionId: string | undefined;
+  clientId: string | undefined;
+  apiKey: string;
+  orgId: string;
+}
 
 export { default as DefaultConfig } from './default-config';
 export { default as ExportConfig } from './export-config';

--- a/packages/contentstack-export/src/utils/basic-login.ts
+++ b/packages/contentstack-export/src/utils/basic-login.ts
@@ -7,7 +7,7 @@
  * MIT Licensed
  */
 
-import { v2Logger, managementSDKClient, authHandler } from '@contentstack/cli-utilities';
+import { log, managementSDKClient, authHandler } from '@contentstack/cli-utilities';
 import { ExternalConfig } from '../types';
 
 const login = async (config: ExternalConfig): Promise<any> => {
@@ -22,18 +22,18 @@ const login = async (config: ExternalConfig): Promise<any> => {
         'X-User-Agent': 'contentstack-export/v',
       };
       await authHandler.setConfigData('basicAuth', response.user);
-      v2Logger.success(`Contentstack account authenticated successfully!`, config.context);
+      log.success(`Contentstack account authenticated successfully!`, config.context);
       return config;
     } else {
-      v2Logger.error(`Failed to login, Invalid credentials`, config.context);
+      log.error(`Failed to login, Invalid credentials`, config.context);
       process.exit(1);
     }
   } else if (!config.email && !config.password && config.source_stack && config.access_token) {
-    v2Logger.info(
+    log.info(
       `Content types, entries, assets, labels, global fields, extensions modules will be exported`,
       config.context,
     );
-    v2Logger.info(
+    log.info(
       `Email, password, or management token is not set in the config, cannot export Webhook and label modules`,
       config.context,
     );

--- a/packages/contentstack-export/src/utils/basic-login.ts
+++ b/packages/contentstack-export/src/utils/basic-login.ts
@@ -7,15 +7,8 @@
  * MIT Licensed
  */
 
-import { ExportConfig, ExternalConfig } from '../types';
-import { log } from './logger';
-const {
-  managementSDKClient,
-  isAuthenticated,
-  cliux,
-  configHandler,
-  authHandler,
-} = require('@contentstack/cli-utilities');
+import { v2Logger, managementSDKClient, authHandler } from '@contentstack/cli-utilities';
+import { ExternalConfig } from '../types';
 
 const login = async (config: ExternalConfig): Promise<any> => {
   const client = await managementSDKClient(config);
@@ -29,22 +22,20 @@ const login = async (config: ExternalConfig): Promise<any> => {
         'X-User-Agent': 'contentstack-export/v',
       };
       await authHandler.setConfigData('basicAuth', response.user);
-      log(config, 'Contentstack account authenticated successfully!', 'success');
+      v2Logger.success(`Contentstack account authenticated successfully!`, config.context);
       return config;
     } else {
-      log(config, 'Failed to login, Invalid credentials', 'error');
+      v2Logger.error(`Failed to login, Invalid credentials`, config.context);
       process.exit(1);
     }
   } else if (!config.email && !config.password && config.source_stack && config.access_token) {
-    log(
-      config,
-      'Content types, entries, assets, labels, global fields, extensions modules will be exported',
-      'success',
+    v2Logger.info(
+      `Content types, entries, assets, labels, global fields, extensions modules will be exported`,
+      config.context,
     );
-    log(
-      config,
-      'Email, password, or management token is not set in the config, cannot export Webhook and label modules',
-      'success',
+    v2Logger.info(
+      `Email, password, or management token is not set in the config, cannot export Webhook and label modules`,
+      config.context,
     );
     config.headers = {
       api_key: config.source_stack,

--- a/packages/contentstack-export/src/utils/common-helper.ts
+++ b/packages/contentstack-export/src/utils/common-helper.ts
@@ -84,7 +84,7 @@ export const executeTask = function (
 export const writeExportMetaFile = (exportConfig: ExportConfig, metaFilePath?: string) => {
   const exportMeta = {
     contentVersion: exportConfig.contentVersion,
-    logsPath: path.join(sanitizePath(exportConfig.exportDir), 'logs', 'export'),
+    logsPath: path.join(process.cwd(), 'logs'),
   };
   fsUtil.writeFile(path.join(sanitizePath(metaFilePath || exportConfig.exportDir), 'export-info.json'), exportMeta);
 };

--- a/packages/contentstack-export/src/utils/common-helper.ts
+++ b/packages/contentstack-export/src/utils/common-helper.ts
@@ -4,12 +4,12 @@
  * MIT Licensed
  */
 
-import promiseLimit from 'promise-limit';
 import * as path from 'path';
-import { isAuthenticated } from '@contentstack/cli-utilities';
-import { ExternalConfig, ExportConfig } from '../types';
+import promiseLimit from 'promise-limit';
+import { isAuthenticated, getLogPath, sanitizePath } from '@contentstack/cli-utilities';
+
 import { fsUtil } from './file-helper';
-import { sanitizePath } from '@contentstack/cli-utilities';
+import { ExternalConfig, ExportConfig } from '../types';
 
 export const validateConfig = function (config: ExternalConfig) {
   if (!config.host || !config.cdn) {
@@ -84,7 +84,7 @@ export const executeTask = function (
 export const writeExportMetaFile = (exportConfig: ExportConfig, metaFilePath?: string) => {
   const exportMeta = {
     contentVersion: exportConfig.contentVersion,
-    logsPath: path.join(process.cwd(), 'logs'),
+    logsPath: getLogPath(),
   };
   fsUtil.writeFile(path.join(sanitizePath(metaFilePath || exportConfig.exportDir), 'export-info.json'), exportMeta);
 };

--- a/packages/contentstack-export/src/utils/marketplace-app-helper.ts
+++ b/packages/contentstack-export/src/utils/marketplace-app-helper.ts
@@ -1,6 +1,5 @@
-import { cliux, configHandler, NodeCrypto, managementSDKClient, createDeveloperHubUrl } from '@contentstack/cli-utilities';
+import { cliux, handleAndLogError, NodeCrypto, managementSDKClient, createDeveloperHubUrl } from '@contentstack/cli-utilities';
 
-import { formatError, log } from '../utils';
 import { ExportConfig } from '../types';
 
 export const getDeveloperHubUrl = async (exportConfig: ExportConfig) => {
@@ -13,7 +12,7 @@ export async function getOrgUid(config: ExportConfig): Promise<string> {
     .stack({ api_key: config.source_stack })
     .fetch()
     .catch((error: any) => {
-      log(config, formatError(error), 'error');
+      handleAndLogError(error, {...config.context});
     });
 
   return tempStackData?.org_uid;

--- a/packages/contentstack-export/src/utils/setup-branches.ts
+++ b/packages/contentstack-export/src/utils/setup-branches.ts
@@ -1,8 +1,8 @@
 import * as path from 'path';
-import { writeFileSync, makeDirectory } from './file-helper';
-import { isAuthenticated, configHandler } from '@contentstack/cli-utilities';
-import { ExportConfig } from '../types';
 import { sanitizePath } from '@contentstack/cli-utilities';
+
+import { ExportConfig } from '../types';
+import { writeFileSync, makeDirectory } from './file-helper';
 
 const setupBranches = async (config: ExportConfig, stackAPIClient: any) => {
   if (typeof config !== 'object') {

--- a/packages/contentstack-export/src/utils/setup-export-dir.ts
+++ b/packages/contentstack-export/src/utils/setup-export-dir.ts
@@ -1,7 +1,8 @@
 import path from 'path';
+import { sanitizePath } from '@contentstack/cli-utilities';
+
 import { ExportConfig } from '../types';
 import { makeDirectory } from './file-helper';
-import { sanitizePath } from '@contentstack/cli-utilities';
 
 export default async function setupExportDir(exportConfig: ExportConfig) {
   makeDirectory(exportConfig.exportDir);

--- a/packages/contentstack-utilities/src/constants/logging.ts
+++ b/packages/contentstack-utilities/src/constants/logging.ts
@@ -12,6 +12,6 @@ export const levelColors = {
   error: 'red',
   warn: 'yellow',
   success: 'green',  // Custom color for success
-  info: 'blue',
-  debug: 'white'
+  info: 'white',
+  debug: 'blue'
 };

--- a/packages/contentstack-utilities/src/index.ts
+++ b/packages/contentstack-utilities/src/index.ts
@@ -77,4 +77,4 @@ export { default as TablePrompt } from './inquirer-table-prompt';
 
 export { Logger };
 export { default as authenticationHandler } from './authentication-handler';
-export {v2Logger, cliErrorHandler, handleAndLogError, getLogPath} from './logger/log'
+export {v2Logger as log, cliErrorHandler, handleAndLogError, getLogPath} from './logger/log'

--- a/packages/contentstack-utilities/src/index.ts
+++ b/packages/contentstack-utilities/src/index.ts
@@ -77,3 +77,4 @@ export { default as TablePrompt } from './inquirer-table-prompt';
 
 export { Logger };
 export { default as authenticationHandler } from './authentication-handler';
+export {v2Logger, cliErrorHandler, handleAndLogError} from './logger/log'

--- a/packages/contentstack-utilities/src/index.ts
+++ b/packages/contentstack-utilities/src/index.ts
@@ -77,4 +77,4 @@ export { default as TablePrompt } from './inquirer-table-prompt';
 
 export { Logger };
 export { default as authenticationHandler } from './authentication-handler';
-export {v2Logger, cliErrorHandler, handleAndLogError} from './logger/log'
+export {v2Logger, cliErrorHandler, handleAndLogError, getLogPath} from './logger/log'

--- a/packages/contentstack-utilities/src/interfaces/index.ts
+++ b/packages/contentstack-utilities/src/interfaces/index.ts
@@ -88,7 +88,7 @@ export interface PrintOptions {
   color?: string;
 }
 
-export type LogType = 'info' | 'warn' | 'error' | 'debug';
+export type LogType = 'info' | 'warn' | 'error' | 'debug' | 'hidden' | 'success';
 export type LogsType = LogType | PrintOptions | undefined;
 export type MessageType = string | Error | Record<string, any> | Record<string, any>[];
 
@@ -102,9 +102,10 @@ export type ClassifiedError = {
   meta?: Record<string, string | undefined>;
   context?: string;
   hidden?: boolean;
+  stackTrace?: Record<string, any>;
 };
 
-export type ErrorContext = {
+export interface ErrorContextBase {
   operation?: string;
   component?: string;
   userId?: string;
@@ -113,5 +114,10 @@ export type ErrorContext = {
   sessionId?: string;
   orgId?: string;
   apiKey?: string;
+}
+
+// This allows both known keys and any custom key like `uid`, `filename`, etc.
+export type ErrorContext = ErrorContextBase & {
+  [key: string]: unknown;
 };
 

--- a/packages/contentstack-utilities/src/logger/cliErrorHandler.ts
+++ b/packages/contentstack-utilities/src/logger/cliErrorHandler.ts
@@ -60,7 +60,7 @@ export default class CLIErrorHandler {
    * @throws This method handles its own errors and will return a `ClassifiedError` with type
    *         `ERROR_TYPES.NORMALIZATION` if it fails to normalize or classify the input error.
    */
-  classifyError(error: unknown, context?: ErrorContext): ClassifiedError {
+  classifyError(error: unknown, context?: ErrorContext, errMessage?: string): ClassifiedError {
     try {
       const normalized = this.normalizeToError(error);
       const isApi = this.isApiError(normalized);
@@ -69,14 +69,14 @@ export default class CLIErrorHandler {
 
       const result: ClassifiedError = {
         type,
-        message: normalized.message || 'Unhandled error',
+        message: errMessage || normalized.message || 'Unhandled error',
         error: this.extractErrorPayload(normalized),
         context: context ? JSON.stringify(context) : undefined,
         meta: this.extractMeta(context),
         hidden,
       };
 
-      if (isApi || this.isDebug) {
+      if (this.isDebug) {
         result.debug = this.extractDebugPayload(normalized, context);
       }
 
@@ -113,8 +113,9 @@ export default class CLIErrorHandler {
   }
 
   private isApiError(error: Error): boolean {
+    if ((error as AxiosError).isAxiosError) return true;
+
     return (
-      (error as AxiosError).isAxiosError ||
       typeof (error as any).status === 'number' ||
       typeof (error as any).statusText === 'string' ||
       (error as any).request !== undefined
@@ -171,10 +172,6 @@ export default class CLIErrorHandler {
       endpoint,
     };
 
-    if (this.isDebug) {
-      payload.stack = error.stack;
-    }
-
     return payload;
   }
 
@@ -184,7 +181,7 @@ export default class CLIErrorHandler {
     const status = error.status || error.response?.status;
     const statusText = error.statusText || error.response?.statusText;
     const data = error.data || error.response?.data || error.errors || error.error;
-
+    
     return {
       command: context?.operation,
       module: context?.component,

--- a/packages/contentstack-utilities/src/logger/cliErrorHandler.ts
+++ b/packages/contentstack-utilities/src/logger/cliErrorHandler.ts
@@ -76,7 +76,7 @@ export default class CLIErrorHandler {
         hidden,
       };
 
-      if (this.isDebug) {
+      if (isApi || this.isDebug) {
         result.debug = this.extractDebugPayload(normalized, context);
       }
 

--- a/packages/contentstack-utilities/src/logger/log.ts
+++ b/packages/contentstack-utilities/src/logger/log.ts
@@ -3,7 +3,7 @@ import { default as Logger } from './logger';
 import { CLIErrorHandler } from './cliErrorHandler';
 import { ErrorContext } from '../interfaces';
 
-const v2Logger = new Logger({ basePath: process.env.CS_CLI_LOG_PATH || path.join(process.cwd(), 'logs') });
+const v2Logger = new Logger({ basePath: getLogPath() });
 const cliErrorHandler = new CLIErrorHandler(true); // Enable debug mode for error classification
 
 /**
@@ -51,4 +51,9 @@ function handleAndLogError(error: unknown, context?: ErrorContext, errorMessage?
   }
 }
 
-export { v2Logger, cliErrorHandler, handleAndLogError };
+function getLogPath(): string {
+  return process.env.CS_CLI_LOG_PATH || path.join(process.cwd(), 'logs');
+}
+
+
+export { v2Logger, cliErrorHandler, handleAndLogError, getLogPath };

--- a/packages/contentstack-utilities/src/logger/log.ts
+++ b/packages/contentstack-utilities/src/logger/log.ts
@@ -22,13 +22,13 @@ const cliErrorHandler = new CLIErrorHandler(true); // Enable debug mode for erro
  * - If debug information is available, it is logged separately with a more specific
  *   debug type and additional details.
  */
-function handleAndLogError(error: unknown, context?: ErrorContext): void {
-  const classified = cliErrorHandler.classifyError(error, context);
+function handleAndLogError(error: unknown, context?: ErrorContext, errorMessage?: string): void {
+  const classified = cliErrorHandler.classifyError(error, context, errorMessage);
 
   // Always log the error
   v2Logger.logError({
     type: classified.type,
-    message: classified.message,
+    message: errorMessage || classified.message,
     error: classified.error,
     context: classified.context,
     hidden: classified.hidden,
@@ -43,7 +43,7 @@ function handleAndLogError(error: unknown, context?: ErrorContext): void {
       debug: {
         ...classified.debug,
         // Ensure stack trace is included if not already there
-        stackTrace: classified.debug.stackTrace || classified.error.stack,
+        stackTrace: classified?.debug?.stackTrace || classified.error.stack,
       },
       context: classified.context,
       meta: classified.meta,

--- a/packages/contentstack-utilities/src/logger/logger.ts
+++ b/packages/contentstack-utilities/src/logger/logger.ts
@@ -66,14 +66,15 @@ export default class Logger {
           format: winston.format.combine(
             winston.format.timestamp({ format: 'YYYY-MM-DD HH:mm:ss' }),
             winston.format.printf((info) => {
+              const redactedInfo = this.redact(info); // Apply redaction here
               const colorizer = winston.format.colorize();
 
               // Handle success type specifically
-              const levelToColorize = info.level;
+              const levelToColorize = redactedInfo.level;
               const levelText = levelToColorize.toUpperCase();
 
-              const timestamp = info.timestamp;
-              const message = info.message;
+              const timestamp = redactedInfo.timestamp;
+              const message = redactedInfo.message;
 
               let fullLine = `[${timestamp}] ${levelText}: ${message}`;
               return colorizer.colorize(levelToColorize, fullLine);
@@ -109,10 +110,6 @@ export default class Logger {
     } catch (error) {
       return info;
     }
-  }
-
-  private isLogEntry(obj: any): obj is LogEntry {
-    return typeof obj === 'object' && 'level' in obj && 'message' in obj;
   }
 
   private shouldLog(level: LogType, target: 'console' | 'file'): boolean {

--- a/packages/contentstack-utilities/src/logger/logger.ts
+++ b/packages/contentstack-utilities/src/logger/logger.ts
@@ -3,7 +3,7 @@ import { klona } from 'klona/full';
 import { normalize } from 'path';
 import * as winston from 'winston';
 import { LogEntry } from 'winston';
-import { logLevels } from '../constants/logging';
+import { levelColors, logLevels } from '../constants/logging';
 import { LoggerConfig, LogLevel, LogType } from '../interfaces/index';
 
 export default class Logger {
@@ -24,6 +24,8 @@ export default class Logger {
 
   constructor(config: LoggerConfig) {
     this.config = config;
+    // Add the custom colors first
+    winston.addColors(levelColors);
     this.loggers = {
       error: this.getLoggerInstance('error'),
       warn: this.getLoggerInstance('warn'),
@@ -58,28 +60,23 @@ export default class Logger {
         new winston.transports.File({
           ...this.loggerOptions,
           filename: `${filePath}/${level}.log`,
-          format: winston.format.combine(
-            winston.format.timestamp(),
-            winston.format.json()
-          ),
+          format: winston.format.combine(winston.format.timestamp(), winston.format.json()),
         }),
         new winston.transports.Console({
           format: winston.format.combine(
             winston.format.timestamp({ format: 'YYYY-MM-DD HH:mm:ss' }),
             winston.format.printf((info) => {
               const colorizer = winston.format.colorize();
-              const levelText = info.level.toUpperCase();
+
+              // Handle success type specifically
+              const levelToColorize = info.level;
+              const levelText = levelToColorize.toUpperCase();
+
               const timestamp = info.timestamp;
               const message = info.message;
-              const meta = info.meta;
 
               let fullLine = `[${timestamp}] ${levelText}: ${message}`;
-              if (meta && (info.level !== 'info' && info.level !== 'success')) {
-                const redactedMeta = this.isLogEntry(meta) ? JSON.stringify(this.redact(meta)) : JSON.stringify(this.redact(meta));
-                fullLine += ` - ${redactedMeta}`;
-              }
-
-              return colorizer.colorize(info.level, fullLine);
+              return colorizer.colorize(levelToColorize, fullLine);
             }),
           ),
         }),
@@ -88,9 +85,7 @@ export default class Logger {
   }
 
   private isSensitiveKey(keyStr: string): boolean {
-    return keyStr && typeof keyStr === 'string'
-      ? this.sensitiveKeys.some((regex) => regex.test(keyStr))
-      : false;
+    return keyStr && typeof keyStr === 'string' ? this.sensitiveKeys.some((regex) => regex.test(keyStr)) : false;
   }
 
   private redactObject(obj: any): void {
@@ -131,31 +126,31 @@ export default class Logger {
 
   public error(message: string, meta?: any): void {
     if (this.shouldLog('error', 'console') || this.shouldLog('error', 'file')) {
-      this.loggers.error.error(message, meta);
+      this.loggers.error.error(message, { ...meta, level: 'error' });
     }
   }
 
   public warn(message: string, meta?: any): void {
     if (this.shouldLog('warn', 'console') || this.shouldLog('warn', 'file')) {
-      this.loggers.warn.warn(message, meta);
+      this.loggers.warn.warn(message, { ...meta, level: 'warn' });
     }
   }
 
   public info(message: string, meta?: any): void {
     if (this.shouldLog('info', 'console') || this.shouldLog('info', 'file')) {
-      this.loggers.info.info(message, meta);
+      this.loggers.info.info(message, { ...meta, level: 'info' });
     }
   }
 
   public success(message: string, meta?: any): void {
-    if (this.shouldLog('info', 'console') || this.shouldLog('info', 'file')) {
-      this.loggers.success.info(message, { ...meta, type: 'success' });
+    if (this.shouldLog('success', 'console') || this.shouldLog('success', 'file')) {
+      this.loggers.success.log('success', message, { ...meta });
     }
   }
 
   public debug(message: string, meta?: any): void {
     if (this.shouldLog('debug', 'console') || this.shouldLog('debug', 'file')) {
-      this.loggers.debug.debug(message, meta);
+      this.loggers.debug.debug(message, { ...meta, level: 'debug' });
     }
   }
 
@@ -240,7 +235,7 @@ export default class Logger {
     meta?: Record<string, any>;
   }): void {
     const logPayload = {
-      level: logLevels.success,
+      level: 'success',
       message: params.message,
       timestamp: new Date(),
       meta: {
@@ -250,8 +245,8 @@ export default class Logger {
         ...params.meta,
       },
     };
-    if (this.shouldLog('info', 'console') || this.shouldLog('info', 'file')) {
-      this.loggers.success.info(logPayload);
+    if (this.shouldLog('success', 'console') || this.shouldLog('success', 'file')) {
+      this.loggers.success.log(logPayload);
     }
   }
 

--- a/packages/contentstack-variants/src/export/attributes.ts
+++ b/packages/contentstack-variants/src/export/attributes.ts
@@ -1,6 +1,6 @@
 import omit from 'lodash/omit';
 import { resolve as pResolve } from 'node:path';
-import { sanitizePath, v2Logger, handleAndLogError } from '@contentstack/cli-utilities';
+import { sanitizePath, log, handleAndLogError } from '@contentstack/cli-utilities';
 import { formatError, fsUtil, PersonalizationAdapter } from '../utils';
 import { PersonalizeConfig, ExportConfig, AttributesConfig, AttributeStruct } from '../types';
 
@@ -29,20 +29,20 @@ export default class ExportAttributes extends PersonalizationAdapter<ExportConfi
 
   async start() {
     try {
-      v2Logger.info('Starting attributes export', this.exportConfig.context);
+      log.info('Starting attributes export', this.exportConfig.context);
       await this.init();
       await fsUtil.makeDirectory(this.attributesFolderPath);
       this.attributes = (await this.getAttributes()) as AttributeStruct[];
 
       if (!this.attributes?.length) {
-        v2Logger.info('No Attributes found with the given project!', this.exportConfig.context);
+        log.info('No Attributes found with the given project!', this.exportConfig.context);
       } else {
         this.sanitizeAttribs();
         fsUtil.writeFile(
           pResolve(sanitizePath(this.attributesFolderPath), sanitizePath(this.attributesConfig.fileName)),
           this.attributes,
         );
-        v2Logger.success(
+        log.success(
           `Attributes exported successfully! Total attributes: ${this.attributes.length}`,
           this.exportConfig.context,
         );

--- a/packages/contentstack-variants/src/export/attributes.ts
+++ b/packages/contentstack-variants/src/export/attributes.ts
@@ -1,7 +1,7 @@
 import omit from 'lodash/omit';
 import { resolve as pResolve } from 'node:path';
 import { sanitizePath, v2Logger, handleAndLogError } from '@contentstack/cli-utilities';
-import { formatError, fsUtil, PersonalizationAdapter, log } from '../utils';
+import { formatError, fsUtil, PersonalizationAdapter } from '../utils';
 import { PersonalizeConfig, ExportConfig, AttributesConfig, AttributeStruct } from '../types';
 
 export default class ExportAttributes extends PersonalizationAdapter<ExportConfig> {

--- a/packages/contentstack-variants/src/export/attributes.ts
+++ b/packages/contentstack-variants/src/export/attributes.ts
@@ -1,6 +1,6 @@
 import omit from 'lodash/omit';
 import { resolve as pResolve } from 'node:path';
-import { sanitizePath } from '@contentstack/cli-utilities';
+import { sanitizePath, v2Logger, handleAndLogError } from '@contentstack/cli-utilities';
 import { formatError, fsUtil, PersonalizationAdapter, log } from '../utils';
 import { PersonalizeConfig, ExportConfig, AttributesConfig, AttributeStruct } from '../types';
 
@@ -29,24 +29,26 @@ export default class ExportAttributes extends PersonalizationAdapter<ExportConfi
 
   async start() {
     try {
-      log(this.exportConfig, 'Starting attributes export', 'info');
+      v2Logger.info('Starting attributes export', this.exportConfig.context);
       await this.init();
       await fsUtil.makeDirectory(this.attributesFolderPath);
       this.attributes = (await this.getAttributes()) as AttributeStruct[];
 
       if (!this.attributes?.length) {
-        log(this.exportConfig, 'No Attributes found with the given project!', 'info');
+        v2Logger.info('No Attributes found with the given project!', this.exportConfig.context);
       } else {
         this.sanitizeAttribs();
         fsUtil.writeFile(
           pResolve(sanitizePath(this.attributesFolderPath), sanitizePath(this.attributesConfig.fileName)),
           this.attributes,
         );
-        log(this.exportConfig, 'All the attributes have been exported successfully!', 'success');
+        v2Logger.success(
+          `Attributes exported successfully! Total attributes: ${this.attributes.length}`,
+          this.exportConfig.context,
+        );
       }
     } catch (error) {
-      log(this.exportConfig, `Failed to export attributes!`, 'error');
-      log(this.config, error, 'error');
+      handleAndLogError(error, { ...this.exportConfig.context });
     }
   }
 

--- a/packages/contentstack-variants/src/export/audiences.ts
+++ b/packages/contentstack-variants/src/export/audiences.ts
@@ -1,5 +1,6 @@
 import omit from 'lodash/omit';
 import { resolve as pResolve } from 'node:path';
+import { v2Logger, handleAndLogError } from '@contentstack/cli-utilities';
 
 import { formatError, fsUtil, PersonalizationAdapter, log } from '../utils';
 import { PersonalizeConfig, ExportConfig, AudienceStruct, AudiencesConfig } from '../types';
@@ -29,23 +30,25 @@ export default class ExportAudiences extends PersonalizationAdapter<ExportConfig
 
   async start() {
     try {
-      log(this.exportConfig, 'Starting audiences export', 'info');
+      v2Logger.info('Starting audiences export', this.exportConfig.context);
       await this.init();
       await fsUtil.makeDirectory(this.audiencesFolderPath);
       this.audiences = (await this.getAudiences()) as AudienceStruct[];
 
       if (!this.audiences?.length) {
-        log(this.exportConfig, 'No Audiences found with the given project!', 'info');
+        v2Logger.info('No Audiences found with the given project!', this.exportConfig.context);
         return;
       } else {
         this.sanitizeAttribs();
         fsUtil.writeFile(pResolve(this.audiencesFolderPath, this.audiencesConfig.fileName), this.audiences);
-        log(this.exportConfig, 'All the audiences have been exported successfully!', 'success');
+        v2Logger.success(
+          `Audiences exported successfully! Total audiences: ${this.audiences.length}`,
+          this.exportConfig.context,
+        );
         return;
       }
     } catch (error) {
-      log(this.exportConfig, `Failed to export audiences!`, 'error');
-      log(this.config, error, 'error');
+      handleAndLogError(error, { ...this.exportConfig.context });
     }
   }
 

--- a/packages/contentstack-variants/src/export/audiences.ts
+++ b/packages/contentstack-variants/src/export/audiences.ts
@@ -2,7 +2,7 @@ import omit from 'lodash/omit';
 import { resolve as pResolve } from 'node:path';
 import { v2Logger, handleAndLogError } from '@contentstack/cli-utilities';
 
-import { formatError, fsUtil, PersonalizationAdapter, log } from '../utils';
+import { fsUtil, PersonalizationAdapter } from '../utils';
 import { PersonalizeConfig, ExportConfig, AudienceStruct, AudiencesConfig } from '../types';
 
 export default class ExportAudiences extends PersonalizationAdapter<ExportConfig> {

--- a/packages/contentstack-variants/src/export/audiences.ts
+++ b/packages/contentstack-variants/src/export/audiences.ts
@@ -1,6 +1,6 @@
 import omit from 'lodash/omit';
 import { resolve as pResolve } from 'node:path';
-import { v2Logger, handleAndLogError } from '@contentstack/cli-utilities';
+import { log, handleAndLogError } from '@contentstack/cli-utilities';
 
 import { fsUtil, PersonalizationAdapter } from '../utils';
 import { PersonalizeConfig, ExportConfig, AudienceStruct, AudiencesConfig } from '../types';
@@ -30,18 +30,18 @@ export default class ExportAudiences extends PersonalizationAdapter<ExportConfig
 
   async start() {
     try {
-      v2Logger.info('Starting audiences export', this.exportConfig.context);
+      log.info('Starting audiences export', this.exportConfig.context);
       await this.init();
       await fsUtil.makeDirectory(this.audiencesFolderPath);
       this.audiences = (await this.getAudiences()) as AudienceStruct[];
 
       if (!this.audiences?.length) {
-        v2Logger.info('No Audiences found with the given project!', this.exportConfig.context);
+        log.info('No Audiences found with the given project!', this.exportConfig.context);
         return;
       } else {
         this.sanitizeAttribs();
         fsUtil.writeFile(pResolve(this.audiencesFolderPath, this.audiencesConfig.fileName), this.audiences);
-        v2Logger.success(
+        log.success(
           `Audiences exported successfully! Total audiences: ${this.audiences.length}`,
           this.exportConfig.context,
         );

--- a/packages/contentstack-variants/src/export/events.ts
+++ b/packages/contentstack-variants/src/export/events.ts
@@ -1,6 +1,6 @@
 import omit from 'lodash/omit';
 import { resolve as pResolve } from 'node:path';
-import { v2Logger, handleAndLogError } from '@contentstack/cli-utilities';
+import { log, handleAndLogError } from '@contentstack/cli-utilities';
 
 import { fsUtil, PersonalizationAdapter } from '../utils';
 import { PersonalizeConfig, ExportConfig, EventStruct, EventsConfig } from '../types';
@@ -30,18 +30,18 @@ export default class ExportEvents extends PersonalizationAdapter<ExportConfig> {
 
   async start() {
     try {
-      v2Logger.info('Starting events export', this.exportConfig.context);
+      log.info('Starting events export', this.exportConfig.context);
       await this.init();
       await fsUtil.makeDirectory(this.eventsFolderPath);
       this.events = (await this.getEvents()) as EventStruct[];
 
       if (!this.events?.length) {
-        v2Logger.info('No Events found with the given project!', this.exportConfig.context);
+        log.info('No Events found with the given project!', this.exportConfig.context);
         return;
       } else {
         this.sanitizeAttribs();
         fsUtil.writeFile(pResolve(this.eventsFolderPath, this.eventsConfig.fileName), this.events);
-        v2Logger.success(
+        log.success(
           `Events exported successfully! Total events: ${this.events.length}`,
           this.exportConfig.context,
         );

--- a/packages/contentstack-variants/src/export/events.ts
+++ b/packages/contentstack-variants/src/export/events.ts
@@ -1,7 +1,8 @@
 import omit from 'lodash/omit';
 import { resolve as pResolve } from 'node:path';
+import { v2Logger, handleAndLogError } from '@contentstack/cli-utilities';
 
-import { formatError, fsUtil, PersonalizationAdapter, log } from '../utils';
+import { fsUtil, PersonalizationAdapter } from '../utils';
 import { PersonalizeConfig, ExportConfig, EventStruct, EventsConfig } from '../types';
 
 export default class ExportEvents extends PersonalizationAdapter<ExportConfig> {
@@ -29,23 +30,25 @@ export default class ExportEvents extends PersonalizationAdapter<ExportConfig> {
 
   async start() {
     try {
-      log(this.exportConfig, 'Starting events export', 'info');
+      v2Logger.info('Starting events export', this.exportConfig.context);
       await this.init();
       await fsUtil.makeDirectory(this.eventsFolderPath);
       this.events = (await this.getEvents()) as EventStruct[];
 
       if (!this.events?.length) {
-        log(this.exportConfig, 'No Events found with the given project!', 'info');
+        v2Logger.info('No Events found with the given project!', this.exportConfig.context);
         return;
       } else {
         this.sanitizeAttribs();
         fsUtil.writeFile(pResolve(this.eventsFolderPath, this.eventsConfig.fileName), this.events);
-        log(this.exportConfig, 'All the events have been exported successfully!', 'success');
+        v2Logger.success(
+          `Events exported successfully! Total events: ${this.events.length}`,
+          this.exportConfig.context,
+        );
         return;
       }
     } catch (error) {
-      log(this.exportConfig, `Failed to export events!`, 'error');
-      log(this.config, error, 'error');
+      handleAndLogError(error, { ...this.exportConfig.context });
     }
   }
 

--- a/packages/contentstack-variants/src/export/experiences.ts
+++ b/packages/contentstack-variants/src/export/experiences.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import { sanitizePath } from '@contentstack/cli-utilities';
+import { sanitizePath, v2Logger, handleAndLogError } from '@contentstack/cli-utilities';
 import { PersonalizeConfig, ExportConfig, ExperienceStruct } from '../types';
 import { formatError, fsUtil, log, PersonalizationAdapter } from '../utils';
 
@@ -32,13 +32,13 @@ export default class ExportExperiences extends PersonalizationAdapter<ExportConf
       // get all experiences
       // loop through experiences and get content types attached to it
       // write experiences in to a file
-      log(this.exportConfig, 'Starting experiences export', 'info');
+      v2Logger.info('Starting experiences export', this.exportConfig.context);
       await this.init();
       await fsUtil.makeDirectory(this.experiencesFolderPath);
       await fsUtil.makeDirectory(path.resolve(sanitizePath(this.experiencesFolderPath), 'versions'));
       const experiences: Array<ExperienceStruct> = (await this.getExperiences()) || [];
       if (!experiences || experiences?.length < 1) {
-        log(this.exportConfig, 'No Experiences found with the give project', 'info');
+        v2Logger.info('No Experiences found with the given project!', this.exportConfig.context);
         return;
       }
       fsUtil.writeFile(path.resolve(sanitizePath(this.experiencesFolderPath), 'experiences.json'), experiences);
@@ -62,10 +62,17 @@ export default class ExportExperiences extends PersonalizationAdapter<ExportConf
               experienceVersions,
             );
           } else {
-            log(this.exportConfig, `No versions found for experience ${experience.name}`, 'info');
+            v2Logger.info(
+              `No versions found for experience '${experience.name}'`,
+              this.exportConfig.context,
+            );
           }
         } catch (error) {
-          log(this.exportConfig, `Failed to fetch versions of experience ${experience.name}`, 'error');
+          handleAndLogError(
+            error,
+            {...this.exportConfig.context},
+            `Failed to fetch versions of experience ${experience.name}`
+          );
         }
 
         try {
@@ -76,7 +83,11 @@ export default class ExportExperiences extends PersonalizationAdapter<ExportConf
             experienceToContentTypesMap[experience.uid] = variantGroup.content_types;
           }
         } catch (error) {
-          log(this.exportConfig, `Failed to fetch content types of experience ${experience.name}`, 'error');
+          handleAndLogError(
+            error,
+            {...this.exportConfig.context},
+            `Failed to fetch content types of experience ${experience.name}`
+          );
         }
       }
       fsUtil.writeFile(
@@ -88,10 +99,9 @@ export default class ExportExperiences extends PersonalizationAdapter<ExportConf
         path.resolve(sanitizePath(this.experiencesFolderPath), 'experiences-content-types.json'),
         experienceToContentTypesMap,
       );
-      log(this.exportConfig, 'All the experiences have been exported successfully!', 'success');
+      v2Logger.success('Experiences exported successfully!', this.exportConfig.context);
     } catch (error) {
-      log(this.exportConfig, `Failed to export experiences!`, 'error');
-      log(this.config, error, 'error');
+      handleAndLogError(error, {...this.exportConfig.context});
     }
   }
 }

--- a/packages/contentstack-variants/src/export/experiences.ts
+++ b/packages/contentstack-variants/src/export/experiences.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import { sanitizePath, v2Logger, handleAndLogError } from '@contentstack/cli-utilities';
 import { PersonalizeConfig, ExportConfig, ExperienceStruct } from '../types';
-import { formatError, fsUtil, log, PersonalizationAdapter } from '../utils';
+import { fsUtil, PersonalizationAdapter } from '../utils';
 
 export default class ExportExperiences extends PersonalizationAdapter<ExportConfig> {
   private experiencesFolderPath: string;

--- a/packages/contentstack-variants/src/export/experiences.ts
+++ b/packages/contentstack-variants/src/export/experiences.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import { sanitizePath, v2Logger, handleAndLogError } from '@contentstack/cli-utilities';
+import { sanitizePath, log, handleAndLogError } from '@contentstack/cli-utilities';
 import { PersonalizeConfig, ExportConfig, ExperienceStruct } from '../types';
 import { fsUtil, PersonalizationAdapter } from '../utils';
 
@@ -32,13 +32,13 @@ export default class ExportExperiences extends PersonalizationAdapter<ExportConf
       // get all experiences
       // loop through experiences and get content types attached to it
       // write experiences in to a file
-      v2Logger.info('Starting experiences export', this.exportConfig.context);
+      log.info('Starting experiences export', this.exportConfig.context);
       await this.init();
       await fsUtil.makeDirectory(this.experiencesFolderPath);
       await fsUtil.makeDirectory(path.resolve(sanitizePath(this.experiencesFolderPath), 'versions'));
       const experiences: Array<ExperienceStruct> = (await this.getExperiences()) || [];
       if (!experiences || experiences?.length < 1) {
-        v2Logger.info('No Experiences found with the given project!', this.exportConfig.context);
+        log.info('No Experiences found with the given project!', this.exportConfig.context);
         return;
       }
       fsUtil.writeFile(path.resolve(sanitizePath(this.experiencesFolderPath), 'experiences.json'), experiences);
@@ -62,7 +62,7 @@ export default class ExportExperiences extends PersonalizationAdapter<ExportConf
               experienceVersions,
             );
           } else {
-            v2Logger.info(
+            log.info(
               `No versions found for experience '${experience.name}'`,
               this.exportConfig.context,
             );
@@ -99,7 +99,7 @@ export default class ExportExperiences extends PersonalizationAdapter<ExportConf
         path.resolve(sanitizePath(this.experiencesFolderPath), 'experiences-content-types.json'),
         experienceToContentTypesMap,
       );
-      v2Logger.success('Experiences exported successfully!', this.exportConfig.context);
+      log.success('Experiences exported successfully!', this.exportConfig.context);
     } catch (error) {
       handleAndLogError(error, {...this.exportConfig.context});
     }

--- a/packages/contentstack-variants/src/export/projects.ts
+++ b/packages/contentstack-variants/src/export/projects.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import { sanitizePath, v2Logger } from '@contentstack/cli-utilities';
+import { sanitizePath, log } from '@contentstack/cli-utilities';
 import { ExportConfig, PersonalizeConfig } from '../types';
 import { PersonalizationAdapter, fsUtil, } from '../utils';
 
@@ -25,22 +25,22 @@ export default class ExportProjects extends PersonalizationAdapter<ExportConfig>
 
   async start() {
     try {
-      v2Logger.info(`Starting projects export`, this.exportConfig.context);
+      log.info(`Starting projects export`, this.exportConfig.context);
       await this.init();
       await fsUtil.makeDirectory(this.projectFolderPath);
       const project = await this.projects({ connectedStackApiKey: this.exportConfig.apiKey });
       if (!project || project?.length < 1) {
-        v2Logger.info(`No Personalize Project connected with the given stack`, this.exportConfig.context);
+        log.info(`No Personalize Project connected with the given stack`, this.exportConfig.context);
         this.exportConfig.personalizationEnabled = false;
         return;
       }
       this.exportConfig.personalizationEnabled = true;
       this.exportConfig.project_id = project[0]?.uid;
       fsUtil.writeFile(path.resolve(sanitizePath(this.projectFolderPath), 'projects.json'), project);
-      v2Logger.success(`Projects exported successfully!`, this.exportConfig.context);
+      log.success(`Projects exported successfully!`, this.exportConfig.context);
     } catch (error) {
       if (error !== 'Forbidden') {
-        v2Logger.error('Failed to export projects!', this.exportConfig.context);
+        log.error('Failed to export projects!', this.exportConfig.context);
       }
       throw error;
     }

--- a/packages/contentstack-variants/src/export/projects.ts
+++ b/packages/contentstack-variants/src/export/projects.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
-import { sanitizePath, v2Logger, handleAndLogError } from '@contentstack/cli-utilities';
+import { sanitizePath, v2Logger } from '@contentstack/cli-utilities';
 import { ExportConfig, PersonalizeConfig } from '../types';
-import { PersonalizationAdapter, log, fsUtil, formatError } from '../utils';
+import { PersonalizationAdapter, fsUtil, } from '../utils';
 
 export default class ExportProjects extends PersonalizationAdapter<ExportConfig> {
   private projectFolderPath: string;

--- a/packages/contentstack-variants/src/export/projects.ts
+++ b/packages/contentstack-variants/src/export/projects.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import { sanitizePath } from '@contentstack/cli-utilities';
+import { sanitizePath, v2Logger, handleAndLogError } from '@contentstack/cli-utilities';
 import { ExportConfig, PersonalizeConfig } from '../types';
 import { PersonalizationAdapter, log, fsUtil, formatError } from '../utils';
 
@@ -25,22 +25,22 @@ export default class ExportProjects extends PersonalizationAdapter<ExportConfig>
 
   async start() {
     try {
-      log(this.exportConfig, 'Starting projects export', 'info');
+      v2Logger.info(`Starting projects export`, this.exportConfig.context);
       await this.init();
       await fsUtil.makeDirectory(this.projectFolderPath);
       const project = await this.projects({ connectedStackApiKey: this.exportConfig.apiKey });
       if (!project || project?.length < 1) {
-        log(this.exportConfig, 'No Personalize Project connected with the given stack', 'info');
+        v2Logger.info(`No Personalize Project connected with the given stack`, this.exportConfig.context);
         this.exportConfig.personalizationEnabled = false;
         return;
       }
       this.exportConfig.personalizationEnabled = true;
       this.exportConfig.project_id = project[0]?.uid;
       fsUtil.writeFile(path.resolve(sanitizePath(this.projectFolderPath), 'projects.json'), project);
-      log(this.exportConfig, 'Project exported successfully!', 'success');
+      v2Logger.success(`Projects exported successfully!`, this.exportConfig.context);
     } catch (error) {
       if (error !== 'Forbidden') {
-        log(this.exportConfig, `Failed to export projects!`, 'error');
+        v2Logger.error('Failed to export projects!', this.exportConfig.context);
       }
       throw error;
     }

--- a/packages/contentstack-variants/src/export/variant-entries.ts
+++ b/packages/contentstack-variants/src/export/variant-entries.ts
@@ -1,6 +1,6 @@
 import { existsSync, mkdirSync } from 'fs';
 import { join, resolve } from 'path';
-import { FsUtility, sanitizePath, v2Logger, handleAndLogError } from '@contentstack/cli-utilities';
+import { FsUtility, sanitizePath, log, handleAndLogError } from '@contentstack/cli-utilities';
 
 import { APIConfig, AdapterType, ExportConfig } from '../types';
 import VariantAdapter, { VariantHttpClient } from '../utils/variant-api-adapter';
@@ -77,7 +77,7 @@ export default class VariantEntries extends VariantAdapter<VariantHttpClient<Exp
         });
         if (existsSync(variantEntryBasePath)) {
           variantEntriesFs.completeFile(true);
-          v2Logger.info(
+          log.info(
             `Exported variant entries of type '${entry.title} (${entry.uid})' locale '${locale}'`,
             this.config.context,
           );

--- a/packages/contentstack-variants/src/export/variant-entries.ts
+++ b/packages/contentstack-variants/src/export/variant-entries.ts
@@ -2,9 +2,8 @@ import { existsSync, mkdirSync } from 'fs';
 import { join, resolve } from 'path';
 import { FsUtility, sanitizePath, v2Logger, handleAndLogError } from '@contentstack/cli-utilities';
 
-import { APIConfig, AdapterType, ExportConfig, LogType } from '../types';
+import { APIConfig, AdapterType, ExportConfig } from '../types';
 import VariantAdapter, { VariantHttpClient } from '../utils/variant-api-adapter';
-import { fsUtil, log } from '../utils';
 
 export default class VariantEntries extends VariantAdapter<VariantHttpClient<ExportConfig>> {
   public entriesDirPath: string;

--- a/packages/contentstack-variants/src/types/export-config.ts
+++ b/packages/contentstack-variants/src/types/export-config.ts
@@ -3,7 +3,7 @@
  * because it will create a circular dependency and cause the prepack/build command to fail.
  * Therefore, we are duplicating the following types from the export.
  */
-import { AnyProperty } from './utils';
+import { AnyProperty, Context } from './utils';
 
 export type Modules =
   | 'stack'
@@ -32,6 +32,7 @@ export type masterLocale = {
 };
 
 export interface DefaultConfig {
+  context: Context;
   contentVersion: number;
   versioning: boolean;
   host: string;

--- a/packages/contentstack-variants/src/types/utils.ts
+++ b/packages/contentstack-variants/src/types/utils.ts
@@ -6,3 +6,14 @@ export interface LogType {
   (message: any): void;
   (config: any, message: any, type: 'info' | 'error' | 'success'): void;
 }
+
+export interface Context {
+  command: string;
+  module: string;
+  userId: string | undefined;
+  email: string | undefined;
+  sessionId: string | undefined;
+  clientId: string | undefined;
+  apiKey: string;
+  orgId: string;
+}

--- a/packages/contentstack/README.md
+++ b/packages/contentstack/README.md
@@ -3953,7 +3953,7 @@ EXAMPLES
   $ csdx plugins
 ```
 
-_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v5.4.38/src/commands/plugins/index.ts)_
+_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v5.4.39/src/commands/plugins/index.ts)_
 
 ## `csdx plugins:add PLUGIN`
 
@@ -4027,7 +4027,7 @@ EXAMPLES
   $ csdx plugins:inspect myplugin
 ```
 
-_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v5.4.38/src/commands/plugins/inspect.ts)_
+_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v5.4.39/src/commands/plugins/inspect.ts)_
 
 ## `csdx plugins:install PLUGIN`
 
@@ -4076,7 +4076,7 @@ EXAMPLES
     $ csdx plugins:install someuser/someplugin
 ```
 
-_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v5.4.38/src/commands/plugins/install.ts)_
+_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v5.4.39/src/commands/plugins/install.ts)_
 
 ## `csdx plugins:link PATH`
 
@@ -4107,7 +4107,7 @@ EXAMPLES
   $ csdx plugins:link myplugin
 ```
 
-_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v5.4.38/src/commands/plugins/link.ts)_
+_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v5.4.39/src/commands/plugins/link.ts)_
 
 ## `csdx plugins:remove [PLUGIN]`
 
@@ -4148,7 +4148,7 @@ FLAGS
   --reinstall  Reinstall all plugins after uninstalling.
 ```
 
-_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v5.4.38/src/commands/plugins/reset.ts)_
+_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v5.4.39/src/commands/plugins/reset.ts)_
 
 ## `csdx plugins:uninstall [PLUGIN]`
 
@@ -4176,7 +4176,7 @@ EXAMPLES
   $ csdx plugins:uninstall myplugin
 ```
 
-_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v5.4.38/src/commands/plugins/uninstall.ts)_
+_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v5.4.39/src/commands/plugins/uninstall.ts)_
 
 ## `csdx plugins:unlink [PLUGIN]`
 
@@ -4220,7 +4220,7 @@ DESCRIPTION
   Update installed plugins.
 ```
 
-_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v5.4.38/src/commands/plugins/update.ts)_
+_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v5.4.39/src/commands/plugins/update.ts)_
 
 ## `csdx tokens`
 


### PR DESCRIPTION
Integrates v2Logger, messageHandler, and handleAndLogError from @contentstack/cli-utilities to replace the old logging and error handling mechanisms in the export plugin. 
Key changes include replacing log calls with v2Logger calls across modules, setting the exportConfig.context.module appropriately in each module, and streamlining error reporting using a unified error handler.

**NOTE:-** Will do version bump before releasing this feature to avoid unnecessary version conflict.