### PR TITLE
fix: pass pagination_token from entriesResponse to the recursive call in bulk unpublish getSyncEntries

### DIFF
--- a/packages/contentstack-bulk-publish/src/producer/unpublish.js
+++ b/packages/contentstack-bulk-publish/src/producer/unpublish.js
@@ -228,10 +228,11 @@ async function getSyncEntries(
         await bulkAction(stack, entriesResponse.items, bulkUnpublish, environment, locale, apiVersion, bulkPublishLimit, false);
       }
       
-      if (entriesResponse.items.length === 0) {
+      if (!entriesResponse.pagination_token) {
         if (!changedFlag) console.log('No Entries/Assets Found published on specified environment');
         return resolve();
       }
+
       setTimeout(async () => {
         await getSyncEntries(
           stack,
@@ -244,9 +245,11 @@ async function getSyncEntries(
           apiVersion,
           bulkPublishLimit,
           variantsFlag,
-          null,
+          entriesResponse.pagination_token,
         );
       }, 3000);
+
+      return resolve();
     } catch (error) {
       reject(error);
     }


### PR DESCRIPTION
This PR fixes a bug in the getSyncEntries function where the recursive call to fetch additional pages of entries would always execute — even when pagination_token was null. As a result, the function would endlessly cycle through the first page of results without making progress.