### PR TITLE
refactor: CLI error handling and updates how authentication metadata is captured in import/export commands

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -159,7 +159,7 @@ fileignoreconfig:
   - filename: packages/contentstack-import/src/utils/extension-helper.ts
     checksum: 147ffe7069333c30a20e63f3dcfde3c4f359748f82a8b9a071adc0361a968814
   - filename: packages/contentstack-import/src/commands/cm/stacks/import.ts
-    checksum: 5290d129c6fff85450e862a4df9669492f805503cef1825c1f3bcbf9c9818d5e
+    checksum: 4544b53e063a64b2c49fbee2dd34a62e1653f03b9d6d55f724ef442f236d0741
   - filename: packages/contentstack-export/src/commands/cm/stacks/export.ts
-    checksum: 23277452f504a246c27b58e1b69fc1d8855ec301c60b4cae60c1e8f865794926
+    checksum: d2222fd14a30cc4c9680e65433d603caf389646a1b4714e0d363bfedff11f423
 version: "1.0"

--- a/.talismanrc
+++ b/.talismanrc
@@ -158,4 +158,8 @@ fileignoreconfig:
     checksum: 9ee0a01dbdffa71a972cc8e64c24a219731e27d3c98b4607e2114337a3ebbf94
   - filename: packages/contentstack-import/src/utils/extension-helper.ts
     checksum: 147ffe7069333c30a20e63f3dcfde3c4f359748f82a8b9a071adc0361a968814
+  - filename: packages/contentstack-import/src/commands/cm/stacks/import.ts
+    checksum: 5290d129c6fff85450e862a4df9669492f805503cef1825c1f3bcbf9c9818d5e
+  - filename: packages/contentstack-export/src/commands/cm/stacks/export.ts
+    checksum: 23277452f504a246c27b58e1b69fc1d8855ec301c60b4cae60c1e8f865794926
 version: "1.0"

--- a/packages/contentstack-auth/src/base-command.ts
+++ b/packages/contentstack-auth/src/base-command.ts
@@ -53,11 +53,11 @@ export abstract class BaseCommand<T extends typeof Command> extends Command {
     return {
       command: this.context.info.command,
       module: '',
-      userId: configHandler.get('userId'),
+      userId: configHandler.get('userUid'),
       email: configHandler.get('email'),
       sessionId: this.context.sessionId,
       apiKey: apiKey || '',
-      orgId: configHandler.get('organization_uid') || '',
+      orgId: configHandler.get('oauthOrgUid') || '',
     };
   }
 }

--- a/packages/contentstack-export/src/commands/cm/stacks/export.ts
+++ b/packages/contentstack-export/src/commands/cm/stacks/export.ts
@@ -112,7 +112,8 @@ export default class ExportCommand extends Command {
       const { flags } = await this.parse(ExportCommand);
       const exportConfig = await setupExportConfig(flags);
       // Prepare the context object
-      const context = this.createExportContext(exportConfig.apiKey, exportConfig.authenticationMethod);
+      const stackKey = exportConfig.apiKey || exportConfig.source_stack;
+      const context = this.createExportContext(stackKey, exportConfig.authenticationMethod);
       exportConfig.context = { ...context };
       log.info(`Using Cli Version: ${this.context?.plugin?.version}`, exportConfig.context);
 
@@ -139,14 +140,14 @@ export default class ExportCommand extends Command {
   }
 
   // Create export context object
-  private createExportContext(apiKey: string, authenticationMethod?: string): Context {
+  private createExportContext(stackKey: string, authenticationMethod?: string): Context {
     return {
       command: this.context.info.command,
       module: '',
       userId: configHandler.get('userUid'),
       email: configHandler.get('email'),
       sessionId: this.context.sessionId,
-      apiKey: apiKey || '',
+      apiKey: stackKey || '',
       orgId: configHandler.get('oauthOrgUid') || '',
       authenticationMethod: authenticationMethod || 'Basic Auth',
     };

--- a/packages/contentstack-export/src/commands/cm/stacks/export.ts
+++ b/packages/contentstack-export/src/commands/cm/stacks/export.ts
@@ -112,7 +112,7 @@ export default class ExportCommand extends Command {
       const { flags } = await this.parse(ExportCommand);
       const exportConfig = await setupExportConfig(flags);
       // Prepare the context object
-      const context = this.createExportContext(exportConfig.apiKey);
+      const context = this.createExportContext(exportConfig.apiKey, exportConfig.authMethod);
       exportConfig.context = { ...context };
       log.info(`Using Cli Version: ${this.context?.plugin?.version}`, exportConfig.context);
 
@@ -139,16 +139,16 @@ export default class ExportCommand extends Command {
   }
 
   // Create export context object
-  private createExportContext(apiKey: string): Context {
+  private createExportContext(apiKey: string, authMethod: string): Context {
     return {
       command: this.context.info.command,
       module: '',
-      userId: configHandler.get('userId'),
+      userId: configHandler.get('userUid'),
       email: configHandler.get('email'),
       sessionId: this.context.sessionId,
       apiKey: apiKey || '',
-      orgId: configHandler.get('organization_uid') || '',
-      authMethod: this.context.authMethod || 'Basic Auth',
+      orgId: configHandler.get('oauthOrgUid') || '',
+      authMethod: authMethod || 'Basic Auth',
     };
   }
 

--- a/packages/contentstack-export/src/commands/cm/stacks/export.ts
+++ b/packages/contentstack-export/src/commands/cm/stacks/export.ts
@@ -112,7 +112,7 @@ export default class ExportCommand extends Command {
       const { flags } = await this.parse(ExportCommand);
       const exportConfig = await setupExportConfig(flags);
       // Prepare the context object
-      const context = this.createExportContext(exportConfig.apiKey, exportConfig.authMethod);
+      const context = this.createExportContext(exportConfig.apiKey, exportConfig.authenticationMethod);
       exportConfig.context = { ...context };
       log.info(`Using Cli Version: ${this.context?.plugin?.version}`, exportConfig.context);
 
@@ -139,7 +139,7 @@ export default class ExportCommand extends Command {
   }
 
   // Create export context object
-  private createExportContext(apiKey: string, authMethod: string): Context {
+  private createExportContext(apiKey: string, authenticationMethod?: string): Context {
     return {
       command: this.context.info.command,
       module: '',
@@ -148,7 +148,7 @@ export default class ExportCommand extends Command {
       sessionId: this.context.sessionId,
       apiKey: apiKey || '',
       orgId: configHandler.get('oauthOrgUid') || '',
-      authMethod: authMethod || 'Basic Auth',
+      authenticationMethod: authenticationMethod || 'Basic Auth',
     };
   }
 

--- a/packages/contentstack-export/src/commands/cm/stacks/export.ts
+++ b/packages/contentstack-export/src/commands/cm/stacks/export.ts
@@ -112,8 +112,7 @@ export default class ExportCommand extends Command {
       const { flags } = await this.parse(ExportCommand);
       const exportConfig = await setupExportConfig(flags);
       // Prepare the context object
-      const stackKey = exportConfig.apiKey || exportConfig.source_stack;
-      const context = this.createExportContext(stackKey, exportConfig.authenticationMethod);
+      const context = this.createExportContext(exportConfig.apiKey, exportConfig.authenticationMethod);
       exportConfig.context = { ...context };
       log.info(`Using Cli Version: ${this.context?.plugin?.version}`, exportConfig.context);
 
@@ -140,14 +139,14 @@ export default class ExportCommand extends Command {
   }
 
   // Create export context object
-  private createExportContext(stackKey: string, authenticationMethod?: string): Context {
+  private createExportContext(apiKey: string, authenticationMethod?: string): Context {
     return {
       command: this.context.info.command,
       module: '',
       userId: configHandler.get('userUid'),
       email: configHandler.get('email'),
       sessionId: this.context.sessionId,
-      apiKey: stackKey || '',
+      apiKey: apiKey || '',
       orgId: configHandler.get('oauthOrgUid') || '',
       authenticationMethod: authenticationMethod || 'Basic Auth',
     };

--- a/packages/contentstack-export/src/types/export-config.ts
+++ b/packages/contentstack-export/src/types/export-config.ts
@@ -31,6 +31,7 @@ export default interface ExportConfig extends DefaultConfig {
   source_stack?: string;
   sourceStackName?: string;
   region: Region;
+  authMethod?: string;
 }
 
 type branch = {

--- a/packages/contentstack-export/src/types/export-config.ts
+++ b/packages/contentstack-export/src/types/export-config.ts
@@ -31,7 +31,7 @@ export default interface ExportConfig extends DefaultConfig {
   source_stack?: string;
   sourceStackName?: string;
   region: Region;
-  authMethod?: string;
+  authenticationMethod?: string;
 }
 
 type branch = {

--- a/packages/contentstack-export/src/types/index.ts
+++ b/packages/contentstack-export/src/types/index.ts
@@ -138,7 +138,7 @@ export interface Context {
   clientId?: string | undefined;
   apiKey: string;
   orgId: string;
-  authMethod?: string;
+  authenticationMethod?: string;
 }
 
 export { default as DefaultConfig } from './default-config';

--- a/packages/contentstack-export/src/utils/export-config-handler.ts
+++ b/packages/contentstack-export/src/utils/export-config-handler.ts
@@ -12,7 +12,7 @@ const setupConfig = async (exportCmdFlags: any): Promise<ExportConfig> => {
   let config = merge({}, defaultConfig);
 
   // Track authentication method
-  let authMethod = 'unknown';
+  let authenticationMethod = 'unknown';
 
   log.debug('Setting up export configuration');
 
@@ -46,7 +46,7 @@ const setupConfig = async (exportCmdFlags: any): Promise<ExportConfig> => {
     const { token, apiKey } = configHandler.get(`tokens.${managementTokenAlias}`) || {};
     config.management_token = token;
     config.apiKey = apiKey;
-    authMethod = 'Management Token';
+    authenticationMethod = 'Management Token';
     if (!config.management_token) {
       log.debug('Management token not found for alias', { alias: managementTokenAlias });
       throw new Error(`No management token found on given alias ${managementTokenAlias}`);
@@ -61,7 +61,7 @@ const setupConfig = async (exportCmdFlags: any): Promise<ExportConfig> => {
       if (config.username && config.password) {
         log.debug('Using basic authentication with username/password');
         await login(config);
-        authMethod = 'Basic Auth';
+        authenticationMethod = 'Basic Auth';
         log.debug('Basic authentication successful');
       } else {
         log.debug('No authentication method available');
@@ -72,10 +72,10 @@ const setupConfig = async (exportCmdFlags: any): Promise<ExportConfig> => {
       const isOAuthUser = configHandler.get('authorisationType') === 'OAUTH' || false;
 
       if (isOAuthUser) {
-        authMethod = 'OAuth';
+        authenticationMethod = 'OAuth';
         log.debug('User authenticated via OAuth');
       } else {
-        authMethod = 'Basic Auth';
+        authenticationMethod = 'Basic Auth';
         log.debug('User authenticated via auth token');
       }
 
@@ -114,7 +114,7 @@ const setupConfig = async (exportCmdFlags: any): Promise<ExportConfig> => {
   }
 
   // Add authentication details to config for context tracking
-  config.authMethod = authMethod;
+  config.authenticationMethod = authenticationMethod;
   log.debug('Export configuration setup completed', { ...config });
 
   return config;

--- a/packages/contentstack-export/src/utils/export-config-handler.ts
+++ b/packages/contentstack-export/src/utils/export-config-handler.ts
@@ -46,7 +46,7 @@ const setupConfig = async (exportCmdFlags: any): Promise<ExportConfig> => {
     const { token, apiKey } = configHandler.get(`tokens.${managementTokenAlias}`) || {};
     config.management_token = token;
     config.apiKey = apiKey;
-    authMethod = 'management_token';
+    authMethod = 'Management Token';
     if (!config.management_token) {
       log.debug('Management token not found for alias', { alias: managementTokenAlias });
       throw new Error(`No management token found on given alias ${managementTokenAlias}`);
@@ -72,7 +72,7 @@ const setupConfig = async (exportCmdFlags: any): Promise<ExportConfig> => {
       const isOAuthUser = configHandler.get('authorisationType') === 'OAUTH' || false;
 
       if (isOAuthUser) {
-        authMethod = 'Oauth';
+        authMethod = 'OAuth';
         log.debug('User authenticated via OAuth');
       } else {
         authMethod = 'Basic Auth';

--- a/packages/contentstack-import/src/commands/cm/stacks/import.ts
+++ b/packages/contentstack-import/src/commands/cm/stacks/import.ts
@@ -148,7 +148,7 @@ export default class ImportCommand extends Command {
       const { flags } = await this.parse(ImportCommand);
       let importConfig: ImportConfig = await setupImportConfig(flags);
       // Prepare the context object
-      const context = this.createImportContext(importConfig.apiKey);
+      const context = this.createImportContext(importConfig.apiKey, importConfig.authMethod);
       importConfig.context = {...context};
       log.info(`Using Cli Version: ${this.context?.plugin?.version}`, importConfig.context);
       
@@ -194,16 +194,16 @@ export default class ImportCommand extends Command {
   }
 
   // Create export context object
-  private createImportContext(apiKey: string): Context {
+  private createImportContext(apiKey: string, authMethod: string): Context {
     return {
       command: this.context.info.command,
       module: '',
-      userId: configHandler.get('userId'),
+      userId: configHandler.get('userUid'),
       email: configHandler.get('email'),
       sessionId: this.context.sessionId,
       apiKey: apiKey || '',
-      orgId: configHandler.get('organization_uid') || '',
-      authMethod: this.context.authMethod || 'Basic Auth',
+      orgId: configHandler.get('oauthOrgUid') || '',
+      authMethod: authMethod || 'Basic Auth',
     };
   }
 }

--- a/packages/contentstack-import/src/commands/cm/stacks/import.ts
+++ b/packages/contentstack-import/src/commands/cm/stacks/import.ts
@@ -148,7 +148,8 @@ export default class ImportCommand extends Command {
       const { flags } = await this.parse(ImportCommand);
       let importConfig: ImportConfig = await setupImportConfig(flags);
       // Prepare the context object
-      const context = this.createImportContext(importConfig.apiKey, importConfig.authenticationMethod);
+      const stackKey = importConfig.apiKey
+      const context = this.createImportContext(stackKey, importConfig.authenticationMethod);
       importConfig.context = {...context};
       log.info(`Using Cli Version: ${this.context?.plugin?.version}`, importConfig.context);
       
@@ -194,14 +195,14 @@ export default class ImportCommand extends Command {
   }
 
   // Create export context object
-  private createImportContext(apiKey: string, authenticationMethod?: string): Context {
+  private createImportContext(stackKey: string, authenticationMethod?: string): Context {
     return {
       command: this.context.info.command,
       module: '',
       userId: configHandler.get('userUid'),
       email: configHandler.get('email'),
       sessionId: this.context.sessionId,
-      apiKey: apiKey || '',
+      apiKey: stackKey || '',
       orgId: configHandler.get('oauthOrgUid') || '',
       authenticationMethod: authenticationMethod || 'Basic Auth',
     };

--- a/packages/contentstack-import/src/commands/cm/stacks/import.ts
+++ b/packages/contentstack-import/src/commands/cm/stacks/import.ts
@@ -148,8 +148,7 @@ export default class ImportCommand extends Command {
       const { flags } = await this.parse(ImportCommand);
       let importConfig: ImportConfig = await setupImportConfig(flags);
       // Prepare the context object
-      const stackKey = importConfig.apiKey
-      const context = this.createImportContext(stackKey, importConfig.authenticationMethod);
+      const context = this.createImportContext(importConfig.apiKey, importConfig.authenticationMethod);
       importConfig.context = {...context};
       log.info(`Using Cli Version: ${this.context?.plugin?.version}`, importConfig.context);
       
@@ -195,14 +194,14 @@ export default class ImportCommand extends Command {
   }
 
   // Create export context object
-  private createImportContext(stackKey: string, authenticationMethod?: string): Context {
+  private createImportContext(apiKey: string, authenticationMethod?: string): Context {
     return {
       command: this.context.info.command,
       module: '',
       userId: configHandler.get('userUid'),
       email: configHandler.get('email'),
       sessionId: this.context.sessionId,
-      apiKey: stackKey || '',
+      apiKey: apiKey || '',
       orgId: configHandler.get('oauthOrgUid') || '',
       authenticationMethod: authenticationMethod || 'Basic Auth',
     };

--- a/packages/contentstack-import/src/commands/cm/stacks/import.ts
+++ b/packages/contentstack-import/src/commands/cm/stacks/import.ts
@@ -148,7 +148,7 @@ export default class ImportCommand extends Command {
       const { flags } = await this.parse(ImportCommand);
       let importConfig: ImportConfig = await setupImportConfig(flags);
       // Prepare the context object
-      const context = this.createImportContext(importConfig.apiKey, importConfig.authMethod);
+      const context = this.createImportContext(importConfig.apiKey, importConfig.authenticationMethod);
       importConfig.context = {...context};
       log.info(`Using Cli Version: ${this.context?.plugin?.version}`, importConfig.context);
       
@@ -194,7 +194,7 @@ export default class ImportCommand extends Command {
   }
 
   // Create export context object
-  private createImportContext(apiKey: string, authMethod: string): Context {
+  private createImportContext(apiKey: string, authenticationMethod?: string): Context {
     return {
       command: this.context.info.command,
       module: '',
@@ -203,7 +203,7 @@ export default class ImportCommand extends Command {
       sessionId: this.context.sessionId,
       apiKey: apiKey || '',
       orgId: configHandler.get('oauthOrgUid') || '',
-      authMethod: authMethod || 'Basic Auth',
+      authenticationMethod: authenticationMethod || 'Basic Auth',
     };
   }
 }

--- a/packages/contentstack-import/src/types/import-config.ts
+++ b/packages/contentstack-import/src/types/import-config.ts
@@ -11,7 +11,7 @@ export interface ExternalConfig {
 }
 
 export default interface ImportConfig extends DefaultConfig, ExternalConfig {
-  authMethod?: string;
+  authenticationMethod?: string;
   skipAssetsPublish?: boolean;
   skipEntriesPublish?: boolean;
   cliLogsPath: string;

--- a/packages/contentstack-import/src/types/import-config.ts
+++ b/packages/contentstack-import/src/types/import-config.ts
@@ -11,7 +11,7 @@ export interface ExternalConfig {
 }
 
 export default interface ImportConfig extends DefaultConfig, ExternalConfig {
-  authMethod: string;
+  authMethod?: string;
   skipAssetsPublish?: boolean;
   skipEntriesPublish?: boolean;
   cliLogsPath: string;

--- a/packages/contentstack-import/src/types/index.ts
+++ b/packages/contentstack-import/src/types/index.ts
@@ -114,7 +114,7 @@ export interface Context {
   clientId?: string | undefined;
   apiKey: string;
   orgId: string;
-  authMethod?: string;
+  authenticationMethod?: string;
 }
 
 export { default as DefaultConfig } from './default-config';
@@ -138,5 +138,5 @@ export interface Context {
   clientId?: string | undefined;
   apiKey: string;
   orgId: string;
-  authMethod?: string;
+  authenticationMethod?: string;
 }

--- a/packages/contentstack-import/src/utils/import-config-handler.ts
+++ b/packages/contentstack-import/src/utils/import-config-handler.ts
@@ -11,7 +11,7 @@ import { ImportConfig } from '../types';
 const setupConfig = async (importCmdFlags: any): Promise<ImportConfig> => {
   let config: ImportConfig = merge({}, defaultConfig);
   // Track authentication method
-  let authMethod = 'unknown';
+  let authenticationMethod = 'unknown';
 
   // setup the config
   if (importCmdFlags['config']) {
@@ -50,7 +50,7 @@ const setupConfig = async (importCmdFlags: any): Promise<ImportConfig> => {
     const { token, apiKey } = configHandler.get(`tokens.${managementTokenAlias}`) ?? {};
     config.management_token = token;
     config.apiKey = apiKey;
-    authMethod = 'Management Token';
+    authenticationMethod = 'Management Token';
     if (!config.management_token) {
       throw new Error(`No management token found on given alias ${managementTokenAlias}`);
     }
@@ -62,7 +62,7 @@ const setupConfig = async (importCmdFlags: any): Promise<ImportConfig> => {
       if (config.email && config.password) {
         log.debug('Using basic authentication with username/password');
         await login(config);
-        authMethod = 'Basic Auth';
+        authenticationMethod = 'Basic Auth';
         log.debug('Basic authentication successful');
       } else {
         log.debug('No authentication method available');
@@ -73,10 +73,10 @@ const setupConfig = async (importCmdFlags: any): Promise<ImportConfig> => {
       const isOAuthUser = configHandler.get('authorisationType') === 'OAUTH' || false;
 
       if (isOAuthUser) {
-        authMethod = 'OAuth';
+        authenticationMethod = 'OAuth';
         log.debug('User authenticated via OAuth');
       } else {
-        authMethod = 'Basic Auth';
+        authenticationMethod = 'Basic Auth';
         log.debug('User authenticated via auth token');
       }
       config.apiKey =
@@ -132,7 +132,7 @@ const setupConfig = async (importCmdFlags: any): Promise<ImportConfig> => {
   }
 
   // Add authentication details to config for context tracking
-  config.authMethod = authMethod;
+  config.authenticationMethod = authenticationMethod;
   log.debug('Import configuration setup completed', { ...config });
 
   return config;

--- a/packages/contentstack-import/src/utils/import-config-handler.ts
+++ b/packages/contentstack-import/src/utils/import-config-handler.ts
@@ -50,7 +50,7 @@ const setupConfig = async (importCmdFlags: any): Promise<ImportConfig> => {
     const { token, apiKey } = configHandler.get(`tokens.${managementTokenAlias}`) ?? {};
     config.management_token = token;
     config.apiKey = apiKey;
-    authMethod = 'management_token';
+    authMethod = 'Management Token';
     if (!config.management_token) {
       throw new Error(`No management token found on given alias ${managementTokenAlias}`);
     }
@@ -62,7 +62,7 @@ const setupConfig = async (importCmdFlags: any): Promise<ImportConfig> => {
       if (config.email && config.password) {
         log.debug('Using basic authentication with username/password');
         await login(config);
-        authMethod = 'basic_auth';
+        authMethod = 'Basic Auth';
         log.debug('Basic authentication successful');
       } else {
         log.debug('No authentication method available');
@@ -73,7 +73,7 @@ const setupConfig = async (importCmdFlags: any): Promise<ImportConfig> => {
       const isOAuthUser = configHandler.get('authorisationType') === 'OAUTH' || false;
 
       if (isOAuthUser) {
-        authMethod = 'Oauth';
+        authMethod = 'OAuth';
         log.debug('User authenticated via OAuth');
       } else {
         authMethod = 'Basic Auth';


### PR DESCRIPTION
**This PR refactors the CLI error handling and updates how authentication metadata is captured in import/export commands.**

Introduces new helper methods (extractClearMessage, streamlined normalization/classification, enhanced metadata extraction) in CLIErrorHandler.
Standardizes authMethod values, makes it optional in config types, and updates context creation in import/export commands.
Renames context identifiers (userId → userUid, organization_uid → oauthOrgUid) and adjusts BaseCommand.