### PR TITLE
fix: Skip stack settings import when using management token

### DIFF
--- a/packages/contentstack-import/src/import/module-importer.ts
+++ b/packages/contentstack-import/src/import/module-importer.ts
@@ -65,7 +65,7 @@ class ModuleImporter {
       this.importConfig.masterLocale = { code: masterLocalResponse.code };
     }
 
-    await sanitizeStack(this.stackAPIClient);
+    await sanitizeStack(this.importConfig);
 
     return this.import();
   }

--- a/packages/contentstack-import/src/import/modules/stack.ts
+++ b/packages/contentstack-import/src/import/modules/stack.ts
@@ -24,6 +24,12 @@ export default class ImportStack extends BaseClass { // classname
       throw new Error('Please run the environments migration first.');
     }
 
+    if (this.importConfig.management_token) {
+      log(this.importConfig, 'Skipping stack settings import: Operation is not supported when using a management token.', 'info');
+      log(this.importConfig, 'Successfully imported stack', 'success');
+      return;
+    }
+
     if (fileHelper.fileExistsSync(this.stackSettingsPath)) {
       this.stackSettings = fsUtil.readFile(this.stackSettingsPath, true) as Record<string, any>;
     } else {

--- a/packages/contentstack-import/src/utils/common-helper.ts
+++ b/packages/contentstack-import/src/utils/common-helper.ts
@@ -56,6 +56,12 @@ export const sanitizeStack = (importConfig: ImportConfig) => {
   if (typeof importConfig.preserveStackVersion !== 'boolean' || !importConfig.preserveStackVersion) {
     return Promise.resolve();
   }
+  
+  if (importConfig.management_token) {
+    log(importConfig, 'Skipping stack version sanitization: Operation is not supported when using a management token.', 'info');
+    return Promise.resolve();
+  }
+  
   log(importConfig, 'Running script to maintain stack version.', 'success');
   try {
     const httpClient = HttpClient.create();


### PR DESCRIPTION
## Issue Description
The import command fails with "Session timed out, please login to proceed" error when using management token alias (`-a` flag) due to unsupported stack settings operations.


## Root Cause
PR #1979 added stack settings import functionality but didn't include management token handling, causing timeout errors similar to what was fixed for export in PR #1983.

## Solution
Applied the same management token protection pattern from export fix (PR #1983) to the import functionality.

### Changes Made:
1. **Import Stack Module** (`stack.ts`): Skip `addSettings` operation when using management token
2. **Module Importer** (`module-importer.ts`): Fixed `sanitizeStack` function call parameter  
3. **Common Helper** (`common-helper.ts`): Added management token protection to `sanitizeStack`

### Existing Auth Methods (--stack-api-key, OAuth):
- **No changes** - all existing authentication flows work exactly as before
- Stack settings import continues to work normally

## Backward Compatibility
- **Zero breaking changes** for existing authentication methods
- **Conditional logic** only affects management token flows
- **Battle-tested pattern** - same approach as successful export fix in PR #1983

## 📋 Checklist
- [x] Applied same pattern as export fix (PR #1983)
- [x] Maintains backward compatibility with all auth methods
- [x] Added informative logging for skipped operations
- [x] Fixed related function call parameter issue
- [x] Tested with management token - no more timeouts
- [x] Verified existing auth flows remain unchanged

## Related
- Fixes timeout issue introduced by PR #1979 (import stack settings)
- Follows same approach as PR #1983 (export stack settings fix)
- Ensures parity between import and export command behavior
