### PR TITLE
fix: Default Log Storage issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28203,7 +28203,7 @@
       "license": "MIT",
       "dependencies": {
         "@contentstack/cli-audit": "~1.14.0",
-        "@contentstack/cli-auth": "~1.5.0",
+        "@contentstack/cli-auth": "~1.5.1",
         "@contentstack/cli-cm-bootstrap": "~1.15.0",
         "@contentstack/cli-cm-branches": "~1.5.0",
         "@contentstack/cli-cm-bulk-publish": "~1.9.0",
@@ -28218,7 +28218,7 @@
         "@contentstack/cli-config": "~1.14.0",
         "@contentstack/cli-launch": "^1.9.2",
         "@contentstack/cli-migration": "~1.8.0",
-        "@contentstack/cli-utilities": "~1.13.0",
+        "@contentstack/cli-utilities": "~1.13.1",
         "@contentstack/cli-variants": "~1.3.0",
         "@contentstack/management": "~1.22.0",
         "@oclif/core": "^4.3.0",
@@ -28275,7 +28275,7 @@
       "license": "MIT",
       "dependencies": {
         "@contentstack/cli-command": "~1.6.0",
-        "@contentstack/cli-utilities": "~1.13.0",
+        "@contentstack/cli-utilities": "~1.13.1",
         "@oclif/core": "^4.3.0",
         "@oclif/plugin-help": "^6.2.28",
         "@oclif/plugin-plugins": "^5.4.38",
@@ -28352,11 +28352,11 @@
     },
     "packages/contentstack-auth": {
       "name": "@contentstack/cli-auth",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "MIT",
       "dependencies": {
         "@contentstack/cli-command": "~1.6.0",
-        "@contentstack/cli-utilities": "~1.13.0",
+        "@contentstack/cli-utilities": "~1.13.1",
         "@oclif/core": "^4.3.0",
         "@oclif/plugin-help": "^6.2.28"
       },
@@ -28514,7 +28514,7 @@
       "dependencies": {
         "@contentstack/cli-cm-seed": "~1.12.0",
         "@contentstack/cli-command": "~1.6.0",
-        "@contentstack/cli-utilities": "~1.13.0",
+        "@contentstack/cli-utilities": "~1.13.1",
         "@oclif/core": "^4.3.0",
         "@oclif/plugin-help": "^6.2.28",
         "inquirer": "8.2.6",
@@ -28602,7 +28602,7 @@
       "license": "MIT",
       "dependencies": {
         "@contentstack/cli-command": "~1.6.0",
-        "@contentstack/cli-utilities": "~1.13.0",
+        "@contentstack/cli-utilities": "~1.13.1",
         "@oclif/core": "^4.3.0",
         "@oclif/plugin-help": "^6.2.28",
         "chalk": "^4.1.2",
@@ -28635,7 +28635,7 @@
       "license": "MIT",
       "dependencies": {
         "@contentstack/cli-command": "~1.6.0",
-        "@contentstack/cli-utilities": "~1.13.0",
+        "@contentstack/cli-utilities": "~1.13.1",
         "@oclif/core": "^4.3.0",
         "@oclif/plugin-help": "^6.2.28",
         "chalk": "^4.1.2",
@@ -28666,7 +28666,7 @@
         "@contentstack/cli-cm-export": "~1.18.0",
         "@contentstack/cli-cm-import": "~1.26.0",
         "@contentstack/cli-command": "~1.6.0",
-        "@contentstack/cli-utilities": "~1.13.0",
+        "@contentstack/cli-utilities": "~1.13.1",
         "@oclif/core": "^4.3.0",
         "@oclif/plugin-help": "^6.2.28",
         "chalk": "^4.1.2",
@@ -28697,7 +28697,7 @@
       "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
-        "@contentstack/cli-utilities": "~1.13.0",
+        "@contentstack/cli-utilities": "~1.13.1",
         "@oclif/core": "^4.3.0",
         "@oclif/plugin-help": "^6.2.28",
         "contentstack": "^3.25.3"
@@ -28779,7 +28779,7 @@
       "license": "MIT",
       "dependencies": {
         "@contentstack/cli-command": "~1.6.0",
-        "@contentstack/cli-utilities": "~1.13.0",
+        "@contentstack/cli-utilities": "~1.13.1",
         "@oclif/core": "^4.3.0",
         "@oclif/plugin-help": "^6.2.28",
         "lodash": "^4.17.21"
@@ -29127,7 +29127,7 @@
       "license": "MIT",
       "dependencies": {
         "@contentstack/cli-command": "~1.6.0",
-        "@contentstack/cli-utilities": "~1.13.0",
+        "@contentstack/cli-utilities": "~1.13.1",
         "@contentstack/cli-variants": "~1.3.0",
         "@oclif/core": "^4.3.3",
         "async": "^3.2.6",
@@ -29170,7 +29170,7 @@
       "license": "MIT",
       "dependencies": {
         "@contentstack/cli-command": "~1.6.0",
-        "@contentstack/cli-utilities": "~1.13.0",
+        "@contentstack/cli-utilities": "~1.13.1",
         "@oclif/core": "^4.3.0",
         "@oclif/plugin-help": "^6.2.28",
         "fast-csv": "^4.3.6",
@@ -29639,7 +29639,7 @@
       "dependencies": {
         "@contentstack/cli-audit": "~1.14.0",
         "@contentstack/cli-command": "~1.6.0",
-        "@contentstack/cli-utilities": "~1.13.0",
+        "@contentstack/cli-utilities": "~1.13.1",
         "@contentstack/cli-variants": "~1.3.0",
         "@contentstack/management": "~1.22.0",
         "@oclif/core": "^4.3.0",
@@ -29685,7 +29685,7 @@
       "license": "MIT",
       "dependencies": {
         "@contentstack/cli-command": "~1.6.0",
-        "@contentstack/cli-utilities": "~1.13.0",
+        "@contentstack/cli-utilities": "~1.13.1",
         "@oclif/core": "^4.3.0",
         "big-json": "^3.2.0",
         "chalk": "^4.1.2",
@@ -29739,7 +29739,7 @@
       "license": "MIT",
       "dependencies": {
         "@contentstack/cli-command": "~1.6.0",
-        "@contentstack/cli-utilities": "~1.13.0",
+        "@contentstack/cli-utilities": "~1.13.1",
         "@contentstack/json-rte-serializer": "~2.1.0",
         "@oclif/core": "^4.3.0",
         "@oclif/plugin-help": "^6.2.28",
@@ -29771,7 +29771,7 @@
       "license": "MIT",
       "dependencies": {
         "@contentstack/cli-command": "~1.6.0",
-        "@contentstack/cli-utilities": "~1.13.0",
+        "@contentstack/cli-utilities": "~1.13.1",
         "@oclif/core": "^4.3.0",
         "@oclif/plugin-help": "^6.2.28",
         "async": "^3.2.6",
@@ -29803,7 +29803,7 @@
       "dependencies": {
         "@contentstack/cli-cm-import": "~1.26.0",
         "@contentstack/cli-command": "~1.6.0",
-        "@contentstack/cli-utilities": "~1.13.0",
+        "@contentstack/cli-utilities": "~1.13.1",
         "@contentstack/management": "~1.22.0",
         "inquirer": "8.2.6",
         "mkdirp": "^1.0.4",
@@ -29887,7 +29887,7 @@
     },
     "packages/contentstack-utilities": {
       "name": "@contentstack/cli-utilities",
-      "version": "1.13.0",
+      "version": "1.13.1",
       "license": "MIT",
       "dependencies": {
         "@contentstack/management": "~1.22.0",

--- a/packages/contentstack-audit/package.json
+++ b/packages/contentstack-audit/package.json
@@ -19,7 +19,7 @@
   ],
   "dependencies": {
     "@contentstack/cli-command": "~1.6.0",
-    "@contentstack/cli-utilities": "~1.13.0",
+    "@contentstack/cli-utilities": "~1.13.1",
     "@oclif/core": "^4.3.0",
     "@oclif/plugin-help": "^6.2.28",
     "@oclif/plugin-plugins": "^5.4.38",

--- a/packages/contentstack-auth/README.md
+++ b/packages/contentstack-auth/README.md
@@ -18,7 +18,7 @@ $ npm install -g @contentstack/cli-auth
 $ csdx COMMAND
 running command...
 $ csdx (--version)
-@contentstack/cli-auth/1.5.0 darwin-arm64 node-v22.14.0
+@contentstack/cli-auth/1.5.1 darwin-arm64 node-v22.14.0
 $ csdx --help [COMMAND]
 USAGE
   $ csdx COMMAND

--- a/packages/contentstack-auth/messages/index.json
+++ b/packages/contentstack-auth/messages/index.json
@@ -20,7 +20,7 @@
   "CLI_AUTH_LOGOUT_ALREADY": "You're already logged out",
   "CLI_AUTH_LOGOUT_NO_AUTHORIZATIONS": "No authorizations found",
   "CLI_AUTH_LOGOUT_NO_AUTHORIZATIONS_USER": "No authorizations found for current user",
-  "CLI_AUTH_WHOAMI_LOGGED_IN_AS": "You are currently logged in with email '%s'",
+  "CLI_AUTH_WHOAMI_LOGGED_IN_AS": "You are currently logged in with email:",
   "CLI_AUTH_WHOAMI_FAILED": "Failed to get the current user details",
   "CLI_AUTH_WHOAMI_DESCRIPTION": "Display current users email address",
   "CLI_AUTH_TOKENS_ADD_ASK_TOKEN_ALIAS": "Provide alias to store token",

--- a/packages/contentstack-auth/package.json
+++ b/packages/contentstack-auth/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contentstack/cli-auth",
   "description": "Contentstack CLI plugin for authentication activities",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "author": "Contentstack",
   "bugs": "https://github.com/contentstack/cli/issues",
   "scripts": {
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@contentstack/cli-command": "~1.6.0",
-    "@contentstack/cli-utilities": "~1.13.0",
+    "@contentstack/cli-utilities": "~1.13.1",
     "@oclif/core": "^4.3.0",
     "@oclif/plugin-help": "^6.2.28"
   },

--- a/packages/contentstack-auth/src/commands/auth/whoami.ts
+++ b/packages/contentstack-auth/src/commands/auth/whoami.ts
@@ -18,7 +18,6 @@ export default class WhoamiCommand extends BaseCommand<typeof WhoamiCommand> {
         log.debug('User email found, displaying user information', { ...this.contextDetails, email: this.email });
         cliux.print('CLI_AUTH_WHOAMI_LOGGED_IN_AS', { color: 'white' });
         cliux.print(this.email, { color: 'green' });
-        log.info(messageHandler.parse('CLI_AUTH_WHOAMI_LOGGED_IN_AS', this.email), this.contextDetails);
         log.debug('Whoami command completed successfully', this.contextDetails);
       } else {
         log.debug('No user email found in context', this.contextDetails);

--- a/packages/contentstack-bootstrap/README.md
+++ b/packages/contentstack-bootstrap/README.md
@@ -15,7 +15,7 @@ $ npm install -g @contentstack/cli-cm-bootstrap
 $ csdx COMMAND
 running command...
 $ csdx (--version)
-@contentstack/cli-cm-bootstrap/1.15.0 darwin-arm64 node-v18.20.2
+@contentstack/cli-cm-bootstrap/1.15.0 darwin-arm64 node-v22.14.0
 $ csdx --help [COMMAND]
 USAGE
   $ csdx COMMAND

--- a/packages/contentstack-bootstrap/package.json
+++ b/packages/contentstack-bootstrap/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@contentstack/cli-cm-seed": "~1.12.0",
     "@contentstack/cli-command": "~1.6.0",
-    "@contentstack/cli-utilities": "~1.13.0",
+    "@contentstack/cli-utilities": "~1.13.1",
     "@oclif/core": "^4.3.0",
     "@oclif/plugin-help": "^6.2.28",
     "inquirer": "8.2.6",

--- a/packages/contentstack-branches/package.json
+++ b/packages/contentstack-branches/package.json
@@ -8,7 +8,7 @@
     "@contentstack/cli-command": "~1.6.0",
     "@oclif/core": "^4.3.0",
     "@oclif/plugin-help": "^6.2.28",
-    "@contentstack/cli-utilities": "~1.13.0",
+    "@contentstack/cli-utilities": "~1.13.1",
     "chalk": "^4.1.2",
     "just-diff": "^6.0.2",
     "lodash": "^4.17.21"

--- a/packages/contentstack-bulk-publish/package.json
+++ b/packages/contentstack-bulk-publish/package.json
@@ -6,7 +6,7 @@
   "bugs": "https://github.com/contentstack/cli/issues",
   "dependencies": {
     "@contentstack/cli-command": "~1.6.0",
-    "@contentstack/cli-utilities": "~1.13.0",
+    "@contentstack/cli-utilities": "~1.13.1",
     "@oclif/core": "^4.3.0",
     "@oclif/plugin-help": "^6.2.28",
     "chalk": "^4.1.2",

--- a/packages/contentstack-clone/README.md
+++ b/packages/contentstack-clone/README.md
@@ -16,7 +16,7 @@ $ npm install -g @contentstack/cli-cm-clone
 $ csdx COMMAND
 running command...
 $ csdx (--version)
-@contentstack/cli-cm-clone/1.15.0 darwin-arm64 node-v18.20.2
+@contentstack/cli-cm-clone/1.15.0 darwin-arm64 node-v22.14.0
 $ csdx --help [COMMAND]
 USAGE
   $ csdx COMMAND

--- a/packages/contentstack-clone/package.json
+++ b/packages/contentstack-clone/package.json
@@ -9,7 +9,7 @@
     "@contentstack/cli-cm-export": "~1.18.0",
     "@contentstack/cli-cm-import": "~1.26.0",
     "@contentstack/cli-command": "~1.6.0",
-    "@contentstack/cli-utilities": "~1.13.0",
+    "@contentstack/cli-utilities": "~1.13.1",
     "@oclif/core": "^4.3.0",
     "@oclif/plugin-help": "^6.2.28",
     "chalk": "^4.1.2",

--- a/packages/contentstack-command/package.json
+++ b/packages/contentstack-command/package.json
@@ -17,7 +17,7 @@
     "format": "eslint src/**/*.ts --fix"
   },
   "dependencies": {
-    "@contentstack/cli-utilities": "~1.13.0",
+    "@contentstack/cli-utilities": "~1.13.1",
     "contentstack": "^3.25.3",
     "@oclif/core": "^4.3.0",
     "@oclif/plugin-help": "^6.2.28"

--- a/packages/contentstack-config/README.md
+++ b/packages/contentstack-config/README.md
@@ -18,7 +18,7 @@ $ npm install -g @contentstack/cli-config
 $ csdx COMMAND
 running command...
 $ csdx (--version)
-@contentstack/cli-config/1.14.0 darwin-arm64 node-v18.20.2
+@contentstack/cli-config/1.14.0 darwin-arm64 node-v22.14.0
 $ csdx --help [COMMAND]
 USAGE
   $ csdx COMMAND
@@ -326,12 +326,13 @@ Set logging configuration for CLI
 
 ```
 USAGE
-  $ csdx config:set:log [--level debug|info|warn|error] [--path <value>]
+  $ csdx config:set:log [--level debug|info|warn|error] [--path <value>] [--show-console-logs]
 
 FLAGS
-  --level=<option>  Set the log level for the CLI.
-                    <options: debug|info|warn|error>
-  --path=<value>    Specify the file path where logs should be saved.
+  --level=<option>          Set the log level for the CLI.
+                            <options: debug|info|warn|error>
+  --path=<value>            Specify the file path where logs should be saved.
+  --[no-]show-console-logs  Enable console logging.
 
 DESCRIPTION
   Set logging configuration for CLI
@@ -339,7 +340,9 @@ DESCRIPTION
 EXAMPLES
   $ csdx config:set:log
 
-  $ csdx config:set:log --level debug --path ./logs/app.log
+  $ csdx config:set:log --level debug --path ./logs/app.log --show-console-logs
+
+  $ csdx config:set:log --no-show-console-logs
 ```
 
 _See code: [src/commands/config/set/log.ts](https://github.com/contentstack/cli/blob/main/packages/contentstack-config/src/commands/config/set/log.ts)_

--- a/packages/contentstack-config/package.json
+++ b/packages/contentstack-config/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@contentstack/cli-command": "~1.6.0",
-    "@contentstack/cli-utilities": "~1.13.0",
+    "@contentstack/cli-utilities": "~1.13.1",
     "@oclif/core": "^4.3.0",
     "@oclif/plugin-help": "^6.2.28",
     "lodash": "^4.17.21"

--- a/packages/contentstack-export-to-csv/package.json
+++ b/packages/contentstack-export-to-csv/package.json
@@ -6,7 +6,7 @@
   "bugs": "https://github.com/contentstack/cli/issues",
   "dependencies": {
     "@contentstack/cli-command": "~1.6.0",
-    "@contentstack/cli-utilities": "~1.13.0",
+    "@contentstack/cli-utilities": "~1.13.1",
     "@oclif/core": "^4.3.0",
     "@oclif/plugin-help": "^6.2.28",
     "fast-csv": "^4.3.6",

--- a/packages/contentstack-export/README.md
+++ b/packages/contentstack-export/README.md
@@ -48,7 +48,7 @@ $ npm install -g @contentstack/cli-cm-export
 $ csdx COMMAND
 running command...
 $ csdx (--version)
-@contentstack/cli-cm-export/1.18.0 darwin-arm64 node-v22.13.1
+@contentstack/cli-cm-export/1.18.0 darwin-arm64 node-v22.14.0
 $ csdx --help [COMMAND]
 USAGE
   $ csdx COMMAND
@@ -83,7 +83,7 @@ FLAGS
   -m, --module=<value>            [optional] Specific module name. If not specified, the export command will export all
                                   the modules to the stack. The available modules are assets, content-types, entries,
                                   environments, extensions, marketplace-apps, global-fields, labels, locales, webhooks,
-                                  workflows, custom-roles, personalize projects, and taxonomies.
+                                  workflows, custom-roles, and taxonomies.
   -t, --content-types=<value>...  [optional]  The UID of the content type(s) whose content you want to export. In case
                                   of multiple content types, specify the IDs separated by spaces.
   -y, --yes                       [optional] Force override all Marketplace prompts.
@@ -132,7 +132,7 @@ FLAGS
   -m, --module=<value>            [optional] Specific module name. If not specified, the export command will export all
                                   the modules to the stack. The available modules are assets, content-types, entries,
                                   environments, extensions, marketplace-apps, global-fields, labels, locales, webhooks,
-                                  workflows, custom-roles, personalize projects, and taxonomies.
+                                  workflows, custom-roles, and taxonomies.
   -t, --content-types=<value>...  [optional]  The UID of the content type(s) whose content you want to export. In case
                                   of multiple content types, specify the IDs separated by spaces.
   -y, --yes                       [optional] Force override all Marketplace prompts.

--- a/packages/contentstack-export/package.json
+++ b/packages/contentstack-export/package.json
@@ -8,7 +8,7 @@
     "@contentstack/cli-command": "~1.6.0",
     "@contentstack/cli-variants": "~1.3.0",
     "@oclif/core": "^4.3.3",
-    "@contentstack/cli-utilities": "~1.13.0",
+    "@contentstack/cli-utilities": "~1.13.1",
     "async": "^3.2.6",
     "big-json": "^3.2.0",
     "bluebird": "^3.7.2",

--- a/packages/contentstack-import-setup/README.md
+++ b/packages/contentstack-import-setup/README.md
@@ -47,7 +47,7 @@ $ npm install -g @contentstack/cli-cm-import-setup
 $ csdx COMMAND
 running command...
 $ csdx (--version)
-@contentstack/cli-cm-import-setup/1.4.0 darwin-arm64 node-v18.20.2
+@contentstack/cli-cm-import-setup/1.4.0 darwin-arm64 node-v22.14.0
 $ csdx --help [COMMAND]
 USAGE
   $ csdx COMMAND

--- a/packages/contentstack-import-setup/package.json
+++ b/packages/contentstack-import-setup/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@contentstack/cli-command": "~1.6.0",
     "@oclif/core": "^4.3.0",
-    "@contentstack/cli-utilities": "~1.13.0",
+    "@contentstack/cli-utilities": "~1.13.1",
     "big-json": "^3.2.0",
     "chalk": "^4.1.2",
     "fs-extra": "^11.3.0",

--- a/packages/contentstack-import/README.md
+++ b/packages/contentstack-import/README.md
@@ -47,7 +47,7 @@ $ npm install -g @contentstack/cli-cm-import
 $ csdx COMMAND
 running command...
 $ csdx (--version)
-@contentstack/cli-cm-import/1.26.0 darwin-arm64 node-v18.20.2
+@contentstack/cli-cm-import/1.26.0 darwin-arm64 node-v22.14.0
 $ csdx --help [COMMAND]
 USAGE
   $ csdx COMMAND

--- a/packages/contentstack-import/package.json
+++ b/packages/contentstack-import/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@contentstack/cli-audit": "~1.14.0",
     "@contentstack/cli-command": "~1.6.0",
-    "@contentstack/cli-utilities": "~1.13.0",
+    "@contentstack/cli-utilities": "~1.13.1",
     "@contentstack/management": "~1.22.0",
     "@contentstack/cli-variants": "~1.3.0",
     "@oclif/core": "^4.3.0",

--- a/packages/contentstack-migrate-rte/README.md
+++ b/packages/contentstack-migrate-rte/README.md
@@ -16,7 +16,7 @@ $ npm install -g @contentstack/cli-cm-migrate-rte
 $ csdx COMMAND
 running command...
 $ csdx (--version)
-@contentstack/cli-cm-migrate-rte/1.6.0 darwin-arm64 node-v18.20.2
+@contentstack/cli-cm-migrate-rte/1.6.0 darwin-arm64 node-v22.14.0
 $ csdx --help [COMMAND]
 USAGE
   $ csdx COMMAND

--- a/packages/contentstack-migrate-rte/package.json
+++ b/packages/contentstack-migrate-rte/package.json
@@ -6,7 +6,7 @@
   "bugs": "https://github.com/contentstack/cli/issues",
   "dependencies": {
     "@contentstack/cli-command": "~1.6.0",
-    "@contentstack/cli-utilities": "~1.13.0",
+    "@contentstack/cli-utilities": "~1.13.1",
     "@contentstack/json-rte-serializer": "~2.1.0",
     "@oclif/core": "^4.3.0",
     "@oclif/plugin-help": "^6.2.28",

--- a/packages/contentstack-migration/README.md
+++ b/packages/contentstack-migration/README.md
@@ -21,7 +21,7 @@ $ npm install -g @contentstack/cli-migration
 $ csdx COMMAND
 running command...
 $ csdx (--version)
-@contentstack/cli-migration/1.8.0 darwin-arm64 node-v18.20.2
+@contentstack/cli-migration/1.8.0 darwin-arm64 node-v22.14.0
 $ csdx --help [COMMAND]
 USAGE
   $ csdx COMMAND

--- a/packages/contentstack-migration/package.json
+++ b/packages/contentstack-migration/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/contentstack/cli/issues",
   "dependencies": {
     "@contentstack/cli-command": "~1.6.0",
-    "@contentstack/cli-utilities": "~1.13.0",
+    "@contentstack/cli-utilities": "~1.13.1",
     "@oclif/core": "^4.3.0",
     "@oclif/plugin-help": "^6.2.28",
     "async": "^3.2.6",

--- a/packages/contentstack-seed/package.json
+++ b/packages/contentstack-seed/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@contentstack/cli-cm-import": "~1.26.0",
     "@contentstack/cli-command": "~1.6.0",
-    "@contentstack/cli-utilities": "~1.13.0",
+    "@contentstack/cli-utilities": "~1.13.1",
     "@contentstack/management": "~1.22.0",
     "inquirer": "8.2.6",
     "mkdirp": "^1.0.4",

--- a/packages/contentstack-utilities/package.json
+++ b/packages/contentstack-utilities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentstack/cli-utilities",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "description": "Utilities for contentstack projects",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/contentstack-utilities/src/logger/log.ts
+++ b/packages/contentstack-utilities/src/logger/log.ts
@@ -86,8 +86,10 @@ function getLogPath(): string {
   // 3. Use current working directory (where user ran the command)
   try {
     const cwdPath = path.join(process.cwd(), 'logs');
-    const testDir = path.dirname(cwdPath);
-    fs.accessSync(testDir, fs.constants.W_OK);
+    if (!fs.existsSync(cwdPath)) {
+      fs.mkdirSync(cwdPath, { recursive: true });
+    }
+    fs.accessSync(cwdPath, fs.constants.W_OK);
     return cwdPath;
   } catch (error) {
     // If current directory is not writable, fall back to home directory

--- a/packages/contentstack/README.md
+++ b/packages/contentstack/README.md
@@ -3556,12 +3556,13 @@ Set logging configuration for CLI
 
 ```
 USAGE
-  $ csdx config:set:log [--level debug|info|warn|error] [--path <value>]
+  $ csdx config:set:log [--level debug|info|warn|error] [--path <value>] [--show-console-logs]
 
 FLAGS
-  --level=<option>  Set the log level for the CLI.
-                    <options: debug|info|warn|error>
-  --path=<value>    Specify the file path where logs should be saved.
+  --level=<option>          Set the log level for the CLI.
+                            <options: debug|info|warn|error>
+  --path=<value>            Specify the file path where logs should be saved.
+  --[no-]show-console-logs  Enable console logging.
 
 DESCRIPTION
   Set logging configuration for CLI
@@ -3569,7 +3570,9 @@ DESCRIPTION
 EXAMPLES
   $ csdx config:set:log
 
-  $ csdx config:set:log --level debug --path ./logs/app.log
+  $ csdx config:set:log --level debug --path ./logs/app.log --show-console-logs
+
+  $ csdx config:set:log --no-show-console-logs
 ```
 
 _See code: [@contentstack/cli-config](https://github.com/contentstack/cli/blob/main/packages/contentstack-config/src/commands/config/set/log.ts)_
@@ -3817,8 +3820,8 @@ USAGE
   $ csdx launch:functions [-p <value>] [-d <value>]
 
 FLAGS
-  -d, --data-dir=<value>  [default: /Users/aman.kumar/Documents/cli-repos/logger-v2/cli/packages/contentstack] Current
-                          working directory
+  -d, --data-dir=<value>  [default: /Users/aman.kumar/Documents/cli-repos/development-lates/cli/packages/contentstack]
+                          Current working directory
   -p, --port=<value>      [default: 3000] Port number
 
 DESCRIPTION

--- a/packages/contentstack/README.md
+++ b/packages/contentstack/README.md
@@ -3820,7 +3820,7 @@ USAGE
   $ csdx launch:functions [-p <value>] [-d <value>]
 
 FLAGS
-  -d, --data-dir=<value>  [default: /Users/aman.kumar/Documents/cli-repos/development-lates/cli/packages/contentstack]
+  -d, --data-dir=<value>  [default: /cli/packages/contentstack]
                           Current working directory
   -p, --port=<value>      [default: 3000] Port number
 

--- a/packages/contentstack/package.json
+++ b/packages/contentstack/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@contentstack/cli-audit": "~1.14.0",
-    "@contentstack/cli-auth": "~1.5.0",
+    "@contentstack/cli-auth": "~1.5.1",
     "@contentstack/cli-cm-bootstrap": "~1.15.0",
     "@contentstack/cli-cm-branches": "~1.5.0",
     "@contentstack/cli-cm-bulk-publish": "~1.9.0",
@@ -38,7 +38,7 @@
     "@contentstack/cli-config": "~1.14.0",
     "@contentstack/cli-launch": "^1.9.2",
     "@contentstack/cli-migration": "~1.8.0",
-    "@contentstack/cli-utilities": "~1.13.0",
+    "@contentstack/cli-utilities": "~1.13.1",
     "@contentstack/cli-variants": "~1.3.0",
     "@contentstack/management": "~1.22.0",
     "@oclif/core": "^4.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
   packages/contentstack:
     specifiers:
       '@contentstack/cli-audit': ~1.14.0
-      '@contentstack/cli-auth': ~1.5.0
+      '@contentstack/cli-auth': ~1.5.1
       '@contentstack/cli-cm-bootstrap': ~1.15.0
       '@contentstack/cli-cm-branches': ~1.5.0
       '@contentstack/cli-cm-bulk-publish': ~1.9.0
@@ -28,7 +28,7 @@ importers:
       '@contentstack/cli-config': ~1.14.0
       '@contentstack/cli-launch': ^1.9.2
       '@contentstack/cli-migration': ~1.8.0
-      '@contentstack/cli-utilities': ~1.13.0
+      '@contentstack/cli-utilities': ~1.13.1
       '@contentstack/cli-variants': ~1.3.0
       '@contentstack/management': ~1.22.0
       '@oclif/core': ^4.3.0
@@ -132,7 +132,7 @@ importers:
   packages/contentstack-audit:
     specifiers:
       '@contentstack/cli-command': ~1.6.0
-      '@contentstack/cli-utilities': ~1.13.0
+      '@contentstack/cli-utilities': ~1.13.1
       '@oclif/core': ^4.3.0
       '@oclif/plugin-help': ^6.2.28
       '@oclif/plugin-plugins': ^5.4.38
@@ -193,7 +193,7 @@ importers:
   packages/contentstack-auth:
     specifiers:
       '@contentstack/cli-command': ~1.6.0
-      '@contentstack/cli-utilities': ~1.13.0
+      '@contentstack/cli-utilities': ~1.13.1
       '@fancy-test/nock': ^0.1.1
       '@oclif/core': ^4.3.0
       '@oclif/plugin-help': ^6.2.28
@@ -243,7 +243,7 @@ importers:
     specifiers:
       '@contentstack/cli-cm-seed': ~1.12.0
       '@contentstack/cli-command': ~1.6.0
-      '@contentstack/cli-utilities': ~1.13.0
+      '@contentstack/cli-utilities': ~1.13.1
       '@oclif/core': ^4.3.0
       '@oclif/plugin-help': ^6.2.28
       '@oclif/test': ^4.1.13
@@ -294,7 +294,7 @@ importers:
     specifiers:
       '@contentstack/cli-command': ~1.6.0
       '@contentstack/cli-dev-dependencies': ~1.3.0
-      '@contentstack/cli-utilities': ~1.13.0
+      '@contentstack/cli-utilities': ~1.13.1
       '@oclif/core': ^4.3.0
       '@oclif/plugin-help': ^6.2.28
       '@types/flat': ^5.0.5
@@ -338,7 +338,7 @@ importers:
   packages/contentstack-bulk-publish:
     specifiers:
       '@contentstack/cli-command': ~1.6.0
-      '@contentstack/cli-utilities': ~1.13.0
+      '@contentstack/cli-utilities': ~1.13.1
       '@oclif/core': ^4.3.0
       '@oclif/plugin-help': ^6.2.28
       '@oclif/test': ^4.1.13
@@ -378,7 +378,7 @@ importers:
       '@contentstack/cli-cm-export': ~1.18.0
       '@contentstack/cli-cm-import': ~1.26.0
       '@contentstack/cli-command': ~1.6.0
-      '@contentstack/cli-utilities': ~1.13.0
+      '@contentstack/cli-utilities': ~1.13.1
       '@oclif/core': ^4.3.0
       '@oclif/plugin-help': ^6.2.28
       '@oclif/test': ^4.1.13
@@ -425,7 +425,7 @@ importers:
 
   packages/contentstack-command:
     specifiers:
-      '@contentstack/cli-utilities': ~1.13.0
+      '@contentstack/cli-utilities': ~1.13.1
       '@oclif/core': ^4.3.0
       '@oclif/plugin-help': ^6.2.28
       '@oclif/test': ^4.1.13
@@ -461,7 +461,7 @@ importers:
   packages/contentstack-config:
     specifiers:
       '@contentstack/cli-command': ~1.6.0
-      '@contentstack/cli-utilities': ~1.13.0
+      '@contentstack/cli-utilities': ~1.13.1
       '@oclif/core': ^4.3.0
       '@oclif/plugin-help': ^6.2.28
       '@oclif/test': ^4.1.13
@@ -534,7 +534,7 @@ importers:
       '@contentstack/cli-command': ~1.6.0
       '@contentstack/cli-config': ~1.12.1
       '@contentstack/cli-dev-dependencies': ~1.3.1
-      '@contentstack/cli-utilities': ~1.13.0
+      '@contentstack/cli-utilities': ~1.13.1
       '@contentstack/cli-variants': ~1.3.0
       '@oclif/core': ^4.3.3
       '@oclif/plugin-help': ^6.2.28
@@ -598,7 +598,7 @@ importers:
   packages/contentstack-export-to-csv:
     specifiers:
       '@contentstack/cli-command': ~1.6.0
-      '@contentstack/cli-utilities': ~1.13.0
+      '@contentstack/cli-utilities': ~1.13.1
       '@oclif/core': ^4.3.0
       '@oclif/plugin-help': ^6.2.28
       '@oclif/test': ^4.1.13
@@ -640,7 +640,7 @@ importers:
     specifiers:
       '@contentstack/cli-audit': ~1.14.0
       '@contentstack/cli-command': ~1.6.0
-      '@contentstack/cli-utilities': ~1.13.0
+      '@contentstack/cli-utilities': ~1.13.1
       '@contentstack/cli-variants': ~1.3.0
       '@contentstack/management': ~1.22.0
       '@oclif/core': ^4.3.0
@@ -714,7 +714,7 @@ importers:
   packages/contentstack-import-setup:
     specifiers:
       '@contentstack/cli-command': ~1.6.0
-      '@contentstack/cli-utilities': ~1.13.0
+      '@contentstack/cli-utilities': ~1.13.1
       '@oclif/core': ^4.3.0
       '@types/big-json': ^3.2.5
       '@types/bluebird': ^3.5.42
@@ -775,7 +775,7 @@ importers:
   packages/contentstack-migrate-rte:
     specifiers:
       '@contentstack/cli-command': ~1.6.0
-      '@contentstack/cli-utilities': ~1.13.0
+      '@contentstack/cli-utilities': ~1.13.1
       '@contentstack/json-rte-serializer': ~2.1.0
       '@oclif/core': ^4.3.0
       '@oclif/plugin-help': ^6.2.28
@@ -820,7 +820,7 @@ importers:
   packages/contentstack-migration:
     specifiers:
       '@contentstack/cli-command': ~1.6.0
-      '@contentstack/cli-utilities': ~1.13.0
+      '@contentstack/cli-utilities': ~1.13.1
       '@oclif/core': ^4.3.0
       '@oclif/plugin-help': ^6.2.28
       '@oclif/test': ^4.1.13
@@ -864,7 +864,7 @@ importers:
     specifiers:
       '@contentstack/cli-cm-import': ~1.26.0
       '@contentstack/cli-command': ~1.6.0
-      '@contentstack/cli-utilities': ~1.13.0
+      '@contentstack/cli-utilities': ~1.13.1
       '@contentstack/management': ~1.22.0
       '@types/inquirer': ^9.0.8
       '@types/jest': ^26.0.24
@@ -2081,11 +2081,13 @@ packages:
       - jest
     dev: true
 
-  /@contentstack/cli-command/1.5.1_debug@4.4.1:
-    resolution: {integrity: sha512-GJHPXH/e4bw2sftpFUGQFao3H0Btp3wEsjyukqOtlFlY3ZjzwqVRGAJTncte2NfkQUjnqlxIxRhJKE645nWSzg==}
+  /@contentstack/cli-command/1.6.0_debug@4.4.1:
+    resolution: {integrity: sha512-PZI0MmXRC05SRr0SJMHxGqTGItyUxt9gwZSJ6O7C7O6pqbwzOzUdEY0YpxgbIAj3/ZTE1ADPIj0xsVlH7yFqKQ==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@contentstack/cli-utilities': 1.12.1_debug@4.4.1
+      '@contentstack/cli-utilities': 1.13.0_debug@4.4.1
+      '@oclif/core': 4.4.0
+      '@oclif/plugin-help': 6.2.29
       contentstack: 3.25.3
     transitivePeerDependencies:
       - '@jest/globals'
@@ -2112,8 +2114,8 @@ packages:
     hasBin: true
     dependencies:
       '@apollo/client': 3.13.8_graphql@16.11.0
-      '@contentstack/cli-command': 1.5.1_debug@4.4.1
-      '@contentstack/cli-utilities': 1.12.1_debug@4.4.1
+      '@contentstack/cli-command': 1.6.0_debug@4.4.1
+      '@contentstack/cli-utilities': 1.13.0_debug@4.4.1
       '@oclif/core': 4.4.0
       '@oclif/plugin-help': 6.2.29
       '@oclif/plugin-plugins': 5.4.43
@@ -2186,8 +2188,8 @@ packages:
       - debug
     dev: true
 
-  /@contentstack/cli-utilities/1.12.1_debug@4.4.1:
-    resolution: {integrity: sha512-+DNqQxy9ERR53OAeUYSMCazUs9DjazyB6r+ZMIotg6BB6ZdlNt6Qr6XgxEFE/jgBqzZVmPox3hu+xV0KL1DEdg==}
+  /@contentstack/cli-utilities/1.13.0_debug@4.4.1:
+    resolution: {integrity: sha512-L5Wn+pbNsd+2a99DYSo+s8PGYeuJWblllRraYi735osMxXYCCTwRXtmTOz6FAl2/XwI2wBd4FwT4ssgwVPGqfQ==}
     dependencies:
       '@contentstack/management': 1.22.0_debug@4.4.1
       '@contentstack/marketplace-sdk': 1.2.8_debug@4.4.1


### PR DESCRIPTION
This PR fixes default log storage issues by improving the logging path resolution logic and updating package dependencies. 

Enhanced log path resolution with a fallback hierarchy (environment variable → user config → current working directory → home directory)
Updated CLI utilities package version from 1.13.0 to 1.13.1 across all dependent packages