### PR TITLE
Fix: Handle undefined backup directory in import plugin when module throws an error

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -80,7 +80,7 @@ fileignoreconfig:
   - filename: packages/contentstack-export/src/commands/cm/stacks/export.ts
     checksum: ece7891cb6fd7edff4a3cd54adb03ba8f7d8d5758f52d98a5c0ff0bd1b071f74
   - filename: packages/contentstack-import/src/commands/cm/stacks/import.ts
-    checksum: c979bcc18cb0d3e5c58f1b27a106b3d89bb6524d47c0cc2b2fd199031ea33279
+    checksum: 97463e90433387396c1effeef8eed736179b85e3674398fc7ad22c936f7d8393
   - filename: packages/contentstack-export/src/export/modules/custom-roles.ts
     checksum: 4fc0f5cab039c84d1a12cdae90dcdcaf15ba461b23007635dc997aada75bbb23
   - filename: packages/contentstack-import/src/utils/extension-helper.ts

--- a/packages/contentstack-config/README.md
+++ b/packages/contentstack-config/README.md
@@ -18,7 +18,7 @@ $ npm install -g @contentstack/cli-config
 $ csdx COMMAND
 running command...
 $ csdx (--version)
-@contentstack/cli-config/1.14.0 darwin-arm64 node-v22.14.0
+@contentstack/cli-config/1.15.0 darwin-arm64 node-v22.14.0
 $ csdx --help [COMMAND]
 USAGE
   $ csdx COMMAND

--- a/packages/contentstack-import/README.md
+++ b/packages/contentstack-import/README.md
@@ -47,7 +47,7 @@ $ npm install -g @contentstack/cli-cm-import
 $ csdx COMMAND
 running command...
 $ csdx (--version)
-@contentstack/cli-cm-import/1.26.0 darwin-arm64 node-v22.14.0
+@contentstack/cli-cm-import/1.26.1 darwin-arm64 node-v22.14.0
 $ csdx --help [COMMAND]
 USAGE
   $ csdx COMMAND

--- a/packages/contentstack/README.md
+++ b/packages/contentstack/README.md
@@ -18,7 +18,7 @@ $ npm install -g @contentstack/cli
 $ csdx COMMAND
 running command...
 $ csdx (--version|-v)
-@contentstack/cli/1.44.0 darwin-arm64 node-v22.14.0
+@contentstack/cli/1.44.1 darwin-arm64 node-v22.14.0
 $ csdx --help [COMMAND]
 USAGE
   $ csdx COMMAND


### PR DESCRIPTION
**Root Cause**
The backupDir variable was only being set after moduleImporter.start() completed successfully. When an error occurred during the import process, this assignment never happened, leaving backupDir as undefined.