### PR TITLE
refactor: ProgressManager to use centralized constants for process names and status messages in both export and import

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -55,4 +55,6 @@ fileignoreconfig:
   checksum: 0ceef8ec8489a05d8ecf07cfa7e92575b0da7d5a6c0ed65b64f46d23aab7074d
 - filename: packages/contentstack-export/src/utils/marketplace-app-helper.ts
   checksum: fcd17c120a0359baeb61b7bd0f8d1ace2662f7f7293d355867f578312fe3a1a0
+- filename: packages/contentstack-variants/src/import/variant-entries.ts
+  checksum: 6e645a3d95903058f32306d306912353272e86e60571919a34125a9cd7b69a59
 version: "1.0"

--- a/.talismanrc
+++ b/.talismanrc
@@ -44,7 +44,15 @@ fileignoreconfig:
 - filename: packages/contentstack-variants/src/import/audiences.ts
   checksum: f24697ef86e928bb4d16f93c021b647639cc344a7f02463d79d69f9434ebed56
 - filename: packages/contentstack-variants/src/import/events.ts
-  checksum: 6cb014b5518ffe204a9f894ad801c05e2ef91a1692049168f74dd12a224363c4
+  checksum: 88256a99c8ff8d6904df2e3767b39f4761d35ce680b3cabd712c33889bd02fca
 - filename: packages/contentstack-import/src/import/modules/personalize.ts
   checksum: 1311a613177160637e21b3983b281b384c2cb15837d001a398b67afef30a393a
+- filename: packages/contentstack-export/src/export/modules/environments.ts
+  checksum: fd33318628321583dbeedd70ba7ba97f1e167d364dd26847771d745db295b16f
+- filename: packages/contentstack-import/src/import/modules/environments.ts
+  checksum: 25ec3da4b218c5bbabcfa1af59f26d62e99110bf361a77aab30bfa3ab402da05
+- filename: packages/contentstack-variants/src/utils/constants.ts
+  checksum: 0ceef8ec8489a05d8ecf07cfa7e92575b0da7d5a6c0ed65b64f46d23aab7074d
+- filename: packages/contentstack-export/src/utils/marketplace-app-helper.ts
+  checksum: fcd17c120a0359baeb61b7bd0f8d1ace2662f7f7293d355867f578312fe3a1a0
 version: "1.0"

--- a/packages/contentstack-export/src/export/modules/assets.ts
+++ b/packages/contentstack-export/src/export/modules/assets.ts
@@ -24,7 +24,7 @@ import {
 import config from '../../config';
 import { ModuleClassParams } from '../../types';
 import BaseClass, { CustomPromiseHandler, CustomPromiseHandlerInput } from './base-class';
-import { EXPORT_PROCESS_NAMES, EXPORT_MODULE_CONTEXTS, EXPORT_PROCESS_STATUS, EXPORT_MODULE_NAMES } from '../../utils';
+import { PROCESS_NAMES, MODULE_CONTEXTS, PROCESS_STATUS, MODULE_NAMES } from '../../utils';
 
 export default class ExportAssets extends BaseClass {
   private assetsRootPath: string;
@@ -34,8 +34,8 @@ export default class ExportAssets extends BaseClass {
 
   constructor({ exportConfig, stackAPIClient }: ModuleClassParams) {
     super({ exportConfig, stackAPIClient });
-    this.exportConfig.context.module = EXPORT_MODULE_CONTEXTS.ASSETS;
-    this.currentModuleName = EXPORT_MODULE_NAMES[EXPORT_MODULE_CONTEXTS.ASSETS];
+    this.exportConfig.context.module = MODULE_CONTEXTS.ASSETS;
+    this.currentModuleName = MODULE_NAMES[MODULE_CONTEXTS.ASSETS];
   }
 
   get commonQueryParam(): Record<string, unknown> {
@@ -65,44 +65,44 @@ export default class ExportAssets extends BaseClass {
 
     // Add sub-processes
     if (typeof assetsFolderCount === 'number' && assetsFolderCount > 0) {
-      progress.addProcess(EXPORT_PROCESS_NAMES.ASSET_FOLDERS, assetsFolderCount);
+      progress.addProcess(PROCESS_NAMES.ASSET_FOLDERS, assetsFolderCount);
     }
     if (typeof assetsCount === 'number' && assetsCount > 0) {
-      progress.addProcess(EXPORT_PROCESS_NAMES.ASSET_METADATA, assetsCount);
-      progress.addProcess(EXPORT_PROCESS_NAMES.ASSET_DOWNLOADS, assetsCount);
+      progress.addProcess(PROCESS_NAMES.ASSET_METADATA, assetsCount);
+      progress.addProcess(PROCESS_NAMES.ASSET_DOWNLOADS, assetsCount);
     }
 
     try {
       // Process asset folders
       if (typeof assetsFolderCount === 'number' && assetsFolderCount > 0) {
         progress
-          .startProcess(EXPORT_PROCESS_NAMES.ASSET_FOLDERS)
+          .startProcess(PROCESS_NAMES.ASSET_FOLDERS)
           .updateStatus(
-            EXPORT_PROCESS_STATUS[EXPORT_PROCESS_NAMES.ASSET_FOLDERS].FETCHING,
-            EXPORT_PROCESS_NAMES.ASSET_FOLDERS,
+            PROCESS_STATUS[PROCESS_NAMES.ASSET_FOLDERS].FETCHING,
+            PROCESS_NAMES.ASSET_FOLDERS,
           );
         await this.getAssetsFolders(assetsFolderCount);
-        progress.completeProcess(EXPORT_PROCESS_NAMES.ASSET_FOLDERS, true);
+        progress.completeProcess(PROCESS_NAMES.ASSET_FOLDERS, true);
       }
 
       // Process asset metadata
       if (typeof assetsCount === 'number' && assetsCount > 0) {
         progress
-          .startProcess(EXPORT_PROCESS_NAMES.ASSET_METADATA)
+          .startProcess(PROCESS_NAMES.ASSET_METADATA)
           .updateStatus(
-            EXPORT_PROCESS_STATUS[EXPORT_PROCESS_NAMES.ASSET_METADATA].FETCHING,
-            EXPORT_PROCESS_NAMES.ASSET_METADATA,
+            PROCESS_STATUS[PROCESS_NAMES.ASSET_METADATA].FETCHING,
+            PROCESS_NAMES.ASSET_METADATA,
           );
         await this.getAssets(assetsCount);
-        progress.completeProcess(EXPORT_PROCESS_NAMES.ASSET_METADATA, true);
+        progress.completeProcess(PROCESS_NAMES.ASSET_METADATA, true);
       }
 
       // Get versioned assets
       if (!isEmpty(this.versionedAssets) && this.assetConfig.includeVersionedAssets) {
         log.debug('Fetching versioned assets metadata...', this.exportConfig.context);
         progress.updateStatus(
-          EXPORT_PROCESS_STATUS[EXPORT_PROCESS_NAMES.ASSET_METADATA].FETCHING_VERSION,
-          EXPORT_PROCESS_NAMES.ASSET_METADATA,
+          PROCESS_STATUS[PROCESS_NAMES.ASSET_METADATA].FETCHING_VERSION,
+          PROCESS_NAMES.ASSET_METADATA,
         );
         await this.getVersionedAssets();
       }
@@ -110,14 +110,14 @@ export default class ExportAssets extends BaseClass {
       // Download all assets
       if (typeof assetsCount === 'number' && assetsCount > 0) {
         progress
-          .startProcess(EXPORT_PROCESS_NAMES.ASSET_DOWNLOADS)
+          .startProcess(PROCESS_NAMES.ASSET_DOWNLOADS)
           .updateStatus(
-            EXPORT_PROCESS_STATUS[EXPORT_PROCESS_NAMES.ASSET_DOWNLOADS].DOWNLOADING,
-            EXPORT_PROCESS_NAMES.ASSET_DOWNLOADS,
+            PROCESS_STATUS[PROCESS_NAMES.ASSET_DOWNLOADS].DOWNLOADING,
+            PROCESS_NAMES.ASSET_DOWNLOADS,
           );
         log.debug('Starting download of all assets...', this.exportConfig.context);
         await this.downloadAssets();
-        progress.completeProcess(EXPORT_PROCESS_NAMES.ASSET_DOWNLOADS, true);
+        progress.completeProcess(PROCESS_NAMES.ASSET_DOWNLOADS, true);
       }
 
       this.completeProgress(true);
@@ -151,7 +151,7 @@ export default class ExportAssets extends BaseClass {
             true,
             `folder: ${folder.name || folder.uid}`,
             null,
-            EXPORT_PROCESS_NAMES.ASSET_FOLDERS,
+            PROCESS_NAMES.ASSET_FOLDERS,
           );
         });
       }
@@ -161,8 +161,8 @@ export default class ExportAssets extends BaseClass {
       this.progressManager?.tick(
         false,
         'asset folder',
-        error?.message || EXPORT_PROCESS_STATUS[EXPORT_PROCESS_NAMES.ASSET_FOLDERS].FAILED,
-        EXPORT_PROCESS_NAMES.ASSET_FOLDERS,
+        error?.message || PROCESS_STATUS[PROCESS_NAMES.ASSET_FOLDERS].FAILED,
+        PROCESS_NAMES.ASSET_FOLDERS,
       );
       handleAndLogError(error, { ...this.exportConfig.context });
     };
@@ -229,8 +229,8 @@ export default class ExportAssets extends BaseClass {
       this.progressManager?.tick(
         false,
         'asset',
-        error?.message || EXPORT_PROCESS_STATUS[EXPORT_PROCESS_NAMES.ASSET_METADATA].FAILED,
-        EXPORT_PROCESS_NAMES.ASSET_METADATA,
+        error?.message || PROCESS_STATUS[PROCESS_NAMES.ASSET_METADATA].FAILED,
+        PROCESS_NAMES.ASSET_METADATA,
       );
       handleAndLogError(error, { ...this.exportConfig.context }, messageHandler.parse('ASSET_QUERY_FAILED'));
     };
@@ -257,7 +257,7 @@ export default class ExportAssets extends BaseClass {
             true,
             `asset: ${asset.filename || asset.uid}`,
             null,
-            EXPORT_PROCESS_NAMES.ASSET_METADATA,
+            PROCESS_NAMES.ASSET_METADATA,
           );
         });
       }
@@ -461,7 +461,7 @@ export default class ExportAssets extends BaseClass {
         true,
         `Downloaded asset: ${asset.filename || asset.uid}`,
         null,
-        EXPORT_PROCESS_NAMES.ASSET_DOWNLOADS,
+        PROCESS_NAMES.ASSET_DOWNLOADS,
       );
       log.success(messageHandler.parse('ASSET_DOWNLOAD_SUCCESS', asset.filename, asset.uid), this.exportConfig.context);
     };
@@ -472,7 +472,7 @@ export default class ExportAssets extends BaseClass {
         false,
         `Failed to download asset: ${asset.filename || asset.uid}`,
         null,
-        EXPORT_PROCESS_NAMES.ASSET_DOWNLOADS,
+        PROCESS_NAMES.ASSET_DOWNLOADS,
       );
       handleAndLogError(
         error,

--- a/packages/contentstack-export/src/export/modules/content-types.ts
+++ b/packages/contentstack-export/src/export/modules/content-types.ts
@@ -3,7 +3,7 @@ import { ContentstackClient, handleAndLogError, messageHandler, log, sanitizePat
 
 import BaseClass from './base-class';
 import { ExportConfig, ModuleClassParams } from '../../types';
-import { fsUtil, executeTask, EXPORT_MODULE_CONTEXTS, EXPORT_MODULE_NAMES } from '../../utils';
+import { fsUtil, executeTask, MODULE_CONTEXTS, MODULE_NAMES } from '../../utils';
 
 export default class ContentTypesExport extends BaseClass {
   private stackAPIClient: ReturnType<ContentstackClient['stack']>;
@@ -52,8 +52,8 @@ export default class ContentTypesExport extends BaseClass {
       sanitizePath(this.contentTypesConfig.dirName),
     );
     this.contentTypes = [];
-    this.exportConfig.context.module = EXPORT_MODULE_CONTEXTS.CONTENT_TYPES;
-    this.currentModuleName = EXPORT_MODULE_NAMES[EXPORT_MODULE_CONTEXTS.CONTENT_TYPES];
+    this.exportConfig.context.module = MODULE_CONTEXTS.CONTENT_TYPES;
+    this.currentModuleName = MODULE_NAMES[MODULE_CONTEXTS.CONTENT_TYPES];
   }
 
   async start() {

--- a/packages/contentstack-export/src/export/modules/content-types.ts
+++ b/packages/contentstack-export/src/export/modules/content-types.ts
@@ -2,8 +2,8 @@ import * as path from 'path';
 import { ContentstackClient, handleAndLogError, messageHandler, log, sanitizePath } from '@contentstack/cli-utilities';
 
 import BaseClass from './base-class';
-import { fsUtil, executeTask } from '../../utils';
 import { ExportConfig, ModuleClassParams } from '../../types';
+import { fsUtil, executeTask, EXPORT_MODULE_CONTEXTS, EXPORT_MODULE_NAMES } from '../../utils';
 
 export default class ContentTypesExport extends BaseClass {
   private stackAPIClient: ReturnType<ContentstackClient['stack']>;
@@ -52,8 +52,8 @@ export default class ContentTypesExport extends BaseClass {
       sanitizePath(this.contentTypesConfig.dirName),
     );
     this.contentTypes = [];
-    this.exportConfig.context.module = 'content-types';
-    this.currentModuleName = 'Content Types';
+    this.exportConfig.context.module = EXPORT_MODULE_CONTEXTS.CONTENT_TYPES;
+    this.currentModuleName = EXPORT_MODULE_NAMES[EXPORT_MODULE_CONTEXTS.CONTENT_TYPES];
   }
 
   async start() {

--- a/packages/contentstack-export/src/export/modules/custom-roles.ts
+++ b/packages/contentstack-export/src/export/modules/custom-roles.ts
@@ -8,10 +8,10 @@ import { handleAndLogError, messageHandler, log } from '@contentstack/cli-utilit
 import BaseClass from './base-class';
 import {
   fsUtil,
-  EXPORT_PROCESS_NAMES,
-  EXPORT_MODULE_CONTEXTS,
-  EXPORT_PROCESS_STATUS,
-  EXPORT_MODULE_NAMES,
+  PROCESS_NAMES,
+  MODULE_CONTEXTS,
+  PROCESS_STATUS,
+  MODULE_NAMES,
 } from '../../utils';
 import { CustomRoleConfig, ModuleClassParams } from '../../types';
 
@@ -31,8 +31,8 @@ export default class ExportCustomRoles extends BaseClass {
     this.existingRoles = { Admin: 1, Developer: 1, 'Content Manager': 1 };
     this.localesMap = {};
     this.sourceLocalesMap = {};
-    this.exportConfig.context.module = EXPORT_MODULE_CONTEXTS.CUSTOM_ROLES;
-    this.currentModuleName = EXPORT_MODULE_NAMES[EXPORT_MODULE_CONTEXTS.CUSTOM_ROLES];
+    this.exportConfig.context.module = MODULE_CONTEXTS.CUSTOM_ROLES;
+    this.currentModuleName = MODULE_NAMES[MODULE_CONTEXTS.CUSTOM_ROLES];
   }
 
   async start(): Promise<void> {
@@ -72,36 +72,36 @@ export default class ExportCustomRoles extends BaseClass {
 
       // Create nested progress manager
       const progress = this.createNestedProgress(this.currentModuleName)
-        .addProcess(EXPORT_PROCESS_NAMES.FETCH_ROLES, totalRoles)
-        .addProcess(EXPORT_PROCESS_NAMES.FETCH_LOCALES, totalLocales)
-        .addProcess(EXPORT_PROCESS_NAMES.PROCESS_MAPPINGS, 1);
+        .addProcess(PROCESS_NAMES.FETCH_ROLES, totalRoles)
+        .addProcess(PROCESS_NAMES.FETCH_LOCALES, totalLocales)
+        .addProcess(PROCESS_NAMES.PROCESS_MAPPINGS, 1);
 
       progress
-        .startProcess(EXPORT_PROCESS_NAMES.FETCH_ROLES)
+        .startProcess(PROCESS_NAMES.FETCH_ROLES)
         .updateStatus(
-          EXPORT_PROCESS_STATUS[EXPORT_PROCESS_NAMES.FETCH_ROLES].FETCHING,
-          EXPORT_PROCESS_NAMES.FETCH_ROLES,
+          PROCESS_STATUS[PROCESS_NAMES.FETCH_ROLES].FETCHING,
+          PROCESS_NAMES.FETCH_ROLES,
         );
       await this.getCustomRoles();
-      progress.completeProcess(EXPORT_PROCESS_NAMES.FETCH_ROLES, true);
+      progress.completeProcess(PROCESS_NAMES.FETCH_ROLES, true);
 
       progress
-        .startProcess(EXPORT_PROCESS_NAMES.FETCH_LOCALES)
+        .startProcess(PROCESS_NAMES.FETCH_LOCALES)
         .updateStatus(
-          EXPORT_PROCESS_STATUS[EXPORT_PROCESS_NAMES.FETCH_LOCALES].FETCHING,
-          EXPORT_PROCESS_NAMES.FETCH_LOCALES,
+          PROCESS_STATUS[PROCESS_NAMES.FETCH_LOCALES].FETCHING,
+          PROCESS_NAMES.FETCH_LOCALES,
         );
       await this.getLocales();
-      progress.completeProcess(EXPORT_PROCESS_NAMES.FETCH_LOCALES, true);
+      progress.completeProcess(PROCESS_NAMES.FETCH_LOCALES, true);
 
       progress
-        .startProcess(EXPORT_PROCESS_NAMES.PROCESS_MAPPINGS)
+        .startProcess(PROCESS_NAMES.PROCESS_MAPPINGS)
         .updateStatus(
-          EXPORT_PROCESS_STATUS[EXPORT_PROCESS_NAMES.PROCESS_MAPPINGS].PROCESSING,
-          EXPORT_PROCESS_NAMES.PROCESS_MAPPINGS,
+          PROCESS_STATUS[PROCESS_NAMES.PROCESS_MAPPINGS].PROCESSING,
+          PROCESS_NAMES.PROCESS_MAPPINGS,
         );
       await this.getCustomRolesLocales();
-      progress.completeProcess(EXPORT_PROCESS_NAMES.PROCESS_MAPPINGS, true);
+      progress.completeProcess(PROCESS_NAMES.PROCESS_MAPPINGS, true);
 
       log.debug(
         `Custom roles export completed. Total custom roles: ${Object.keys(this.customRoles).length}`,
@@ -145,7 +145,7 @@ export default class ExportCustomRoles extends BaseClass {
       log.info(messageHandler.parse('ROLES_EXPORTING_ROLE', role.name), this.exportConfig.context);
       this.customRoles[role.uid] = role;
 
-      this.progressManager?.tick(true, `role: ${role.name}`, null, EXPORT_PROCESS_NAMES.FETCH_ROLES);
+      this.progressManager?.tick(true, `role: ${role.name}`, null, PROCESS_NAMES.FETCH_ROLES);
     });
 
     const customRolesFilePath = pResolve(this.rolesFolderPath, this.customRolesConfig.fileName);
@@ -174,7 +174,7 @@ export default class ExportCustomRoles extends BaseClass {
       this.sourceLocalesMap[locale.uid] = locale;
 
       // Track progress for each locale
-      this.progressManager?.tick(true, `locale: ${locale.name}`, null, EXPORT_PROCESS_NAMES.FETCH_LOCALES);
+      this.progressManager?.tick(true, `locale: ${locale.name}`, null, PROCESS_NAMES.FETCH_LOCALES);
     }
 
     log.debug(`Mapped ${Object.keys(this.sourceLocalesMap).length} locales`, this.exportConfig.context);
@@ -219,6 +219,6 @@ export default class ExportCustomRoles extends BaseClass {
     }
 
     // Track progress for mapping completion
-    this.progressManager?.tick(true, 'role-locale mappings', null, EXPORT_PROCESS_NAMES.PROCESS_MAPPINGS);
+    this.progressManager?.tick(true, 'role-locale mappings', null, PROCESS_NAMES.PROCESS_MAPPINGS);
   }
 }

--- a/packages/contentstack-export/src/export/modules/custom-roles.ts
+++ b/packages/contentstack-export/src/export/modules/custom-roles.ts
@@ -6,7 +6,13 @@ import { resolve as pResolve } from 'node:path';
 import { handleAndLogError, messageHandler, log } from '@contentstack/cli-utilities';
 
 import BaseClass from './base-class';
-import { fsUtil } from '../../utils';
+import {
+  fsUtil,
+  EXPORT_PROCESS_NAMES,
+  EXPORT_MODULE_CONTEXTS,
+  EXPORT_PROCESS_STATUS,
+  EXPORT_MODULE_NAMES,
+} from '../../utils';
 import { CustomRoleConfig, ModuleClassParams } from '../../types';
 
 export default class ExportCustomRoles extends BaseClass {
@@ -25,8 +31,8 @@ export default class ExportCustomRoles extends BaseClass {
     this.existingRoles = { Admin: 1, Developer: 1, 'Content Manager': 1 };
     this.localesMap = {};
     this.sourceLocalesMap = {};
-    this.exportConfig.context.module = 'custom-roles';
-    this.currentModuleName = 'Custom Roles';
+    this.exportConfig.context.module = EXPORT_MODULE_CONTEXTS.CUSTOM_ROLES;
+    this.currentModuleName = EXPORT_MODULE_NAMES[EXPORT_MODULE_CONTEXTS.CUSTOM_ROLES];
   }
 
   async start(): Promise<void> {
@@ -66,21 +72,36 @@ export default class ExportCustomRoles extends BaseClass {
 
       // Create nested progress manager
       const progress = this.createNestedProgress(this.currentModuleName)
-        .addProcess('Fetch Roles', totalRoles)
-        .addProcess('Fetch Locales', totalLocales)
-        .addProcess('Process Mappings', 1);
+        .addProcess(EXPORT_PROCESS_NAMES.FETCH_ROLES, totalRoles)
+        .addProcess(EXPORT_PROCESS_NAMES.FETCH_LOCALES, totalLocales)
+        .addProcess(EXPORT_PROCESS_NAMES.PROCESS_MAPPINGS, 1);
 
-      progress.startProcess('Fetch Roles').updateStatus('Fetching custom roles...', 'Fetch Roles');
+      progress
+        .startProcess(EXPORT_PROCESS_NAMES.FETCH_ROLES)
+        .updateStatus(
+          EXPORT_PROCESS_STATUS[EXPORT_PROCESS_NAMES.FETCH_ROLES].FETCHING,
+          EXPORT_PROCESS_NAMES.FETCH_ROLES,
+        );
       await this.getCustomRoles();
-      progress.completeProcess('Fetch Roles', true);
+      progress.completeProcess(EXPORT_PROCESS_NAMES.FETCH_ROLES, true);
 
-      progress.startProcess('Fetch Locales').updateStatus('Fetching locales...', 'Fetch Locales');
+      progress
+        .startProcess(EXPORT_PROCESS_NAMES.FETCH_LOCALES)
+        .updateStatus(
+          EXPORT_PROCESS_STATUS[EXPORT_PROCESS_NAMES.FETCH_LOCALES].FETCHING,
+          EXPORT_PROCESS_NAMES.FETCH_LOCALES,
+        );
       await this.getLocales();
-      progress.completeProcess('Fetch Locales', true);
+      progress.completeProcess(EXPORT_PROCESS_NAMES.FETCH_LOCALES, true);
 
-      progress.startProcess('Process Mappings').updateStatus('Processing role-locale mappings...', 'Process Mappings');
+      progress
+        .startProcess(EXPORT_PROCESS_NAMES.PROCESS_MAPPINGS)
+        .updateStatus(
+          EXPORT_PROCESS_STATUS[EXPORT_PROCESS_NAMES.PROCESS_MAPPINGS].PROCESSING,
+          EXPORT_PROCESS_NAMES.PROCESS_MAPPINGS,
+        );
       await this.getCustomRolesLocales();
-      progress.completeProcess('Process Mappings', true);
+      progress.completeProcess(EXPORT_PROCESS_NAMES.PROCESS_MAPPINGS, true);
 
       log.debug(
         `Custom roles export completed. Total custom roles: ${Object.keys(this.customRoles).length}`,
@@ -124,7 +145,7 @@ export default class ExportCustomRoles extends BaseClass {
       log.info(messageHandler.parse('ROLES_EXPORTING_ROLE', role.name), this.exportConfig.context);
       this.customRoles[role.uid] = role;
 
-      this.progressManager?.tick(true, `role: ${role.name}`, null, 'Fetch Roles');
+      this.progressManager?.tick(true, `role: ${role.name}`, null, EXPORT_PROCESS_NAMES.FETCH_ROLES);
     });
 
     const customRolesFilePath = pResolve(this.rolesFolderPath, this.customRolesConfig.fileName);
@@ -153,7 +174,7 @@ export default class ExportCustomRoles extends BaseClass {
       this.sourceLocalesMap[locale.uid] = locale;
 
       // Track progress for each locale
-      this.progressManager?.tick(true, `locale: ${locale.name}`, null, 'Fetch Locales');
+      this.progressManager?.tick(true, `locale: ${locale.name}`, null, EXPORT_PROCESS_NAMES.FETCH_LOCALES);
     }
 
     log.debug(`Mapped ${Object.keys(this.sourceLocalesMap).length} locales`, this.exportConfig.context);
@@ -198,6 +219,6 @@ export default class ExportCustomRoles extends BaseClass {
     }
 
     // Track progress for mapping completion
-    this.progressManager?.tick(true, 'role-locale mappings', null, 'Process Mappings');
+    this.progressManager?.tick(true, 'role-locale mappings', null, EXPORT_PROCESS_NAMES.PROCESS_MAPPINGS);
   }
 }

--- a/packages/contentstack-export/src/export/modules/entries.ts
+++ b/packages/contentstack-export/src/export/modules/entries.ts
@@ -5,10 +5,10 @@ import { sanitizePath } from '@contentstack/cli-utilities';
 
 import {
   fsUtil,
-  EXPORT_PROCESS_NAMES,
-  EXPORT_MODULE_CONTEXTS,
-  EXPORT_PROCESS_STATUS,
-  EXPORT_MODULE_NAMES,
+  PROCESS_NAMES,
+  MODULE_CONTEXTS,
+  PROCESS_STATUS,
+  MODULE_NAMES,
 } from '../../utils';
 import BaseClass, { ApiOptions } from './base-class';
 import { ExportConfig, ModuleClassParams } from '../../types';
@@ -58,8 +58,8 @@ export default class EntriesExport extends BaseClass {
       'schema.json',
     );
     this.projectInstance = new ExportProjects(this.exportConfig);
-    this.exportConfig.context.module = EXPORT_MODULE_CONTEXTS.ENTRIES;
-    this.currentModuleName = EXPORT_MODULE_NAMES[EXPORT_MODULE_CONTEXTS.ENTRIES];
+    this.exportConfig.context.module = MODULE_CONTEXTS.ENTRIES;
+    this.currentModuleName = MODULE_NAMES[MODULE_CONTEXTS.ENTRIES];
   }
 
   async start() {
@@ -109,22 +109,22 @@ export default class EntriesExport extends BaseClass {
 
       // Add sub-processes
       if (totalEntriesCount > 0) {
-        progress.addProcess(EXPORT_PROCESS_NAMES.ENTRIES, totalEntriesCount);
+        progress.addProcess(PROCESS_NAMES.ENTRIES, totalEntriesCount);
 
         if (this.entriesConfig.exportVersions) {
-          progress.addProcess(EXPORT_PROCESS_NAMES.ENTRY_VERSIONS, totalEntriesCount);
+          progress.addProcess(PROCESS_NAMES.ENTRY_VERSIONS, totalEntriesCount);
         }
 
         if (this.exportVariantEntry) {
-          progress.addProcess(EXPORT_PROCESS_NAMES.VARIANT_ENTRIES, 0);
+          progress.addProcess(PROCESS_NAMES.VARIANT_ENTRIES, 0);
         }
       }
 
       // Process entry collections
       if (totalEntriesCount > 0) {
         progress
-          .startProcess(EXPORT_PROCESS_NAMES.ENTRIES)
-          .updateStatus(EXPORT_PROCESS_STATUS[EXPORT_PROCESS_NAMES.ENTRIES].PROCESSING, EXPORT_PROCESS_NAMES.ENTRIES);
+          .startProcess(PROCESS_NAMES.ENTRIES)
+          .updateStatus(PROCESS_STATUS[PROCESS_NAMES.ENTRIES].PROCESSING, PROCESS_NAMES.ENTRIES);
 
         for (let entryRequestOption of entryRequestOptions) {
           try {
@@ -147,20 +147,20 @@ export default class EntriesExport extends BaseClass {
             this.progressManager?.tick(
               false,
               `${entryRequestOption.contentType}:${entryRequestOption.locale}`,
-              error?.message || EXPORT_PROCESS_STATUS[EXPORT_PROCESS_NAMES.ENTRIES].FAILED,
-              EXPORT_PROCESS_NAMES.ENTRIES,
+              error?.message || PROCESS_STATUS[PROCESS_NAMES.ENTRIES].FAILED,
+              PROCESS_NAMES.ENTRIES,
             );
             throw error;
           }
         }
-        progress.completeProcess(EXPORT_PROCESS_NAMES.ENTRIES, true);
+        progress.completeProcess(PROCESS_NAMES.ENTRIES, true);
 
         if (this.entriesConfig.exportVersions) {
-          progress.completeProcess(EXPORT_PROCESS_NAMES.ENTRY_VERSIONS, true);
+          progress.completeProcess(PROCESS_NAMES.ENTRY_VERSIONS, true);
         }
 
         if (this.exportVariantEntry) {
-          progress.completeProcess(EXPORT_PROCESS_NAMES.VARIANT_ENTRIES, true);
+          progress.completeProcess(PROCESS_NAMES.VARIANT_ENTRIES, true);
         }
       }
 
@@ -334,7 +334,7 @@ export default class EntriesExport extends BaseClass {
 
       // Track progress for individual entries
       entriesSearchResponse.items.forEach((entry: any) => {
-        this.progressManager?.tick(true, `entry: ${entry.uid}`, null, EXPORT_PROCESS_NAMES.ENTRIES);
+        this.progressManager?.tick(true, `entry: ${entry.uid}`, null, PROCESS_NAMES.ENTRIES);
       });
 
       if (this.entriesConfig.exportVersions) {
@@ -407,7 +407,7 @@ export default class EntriesExport extends BaseClass {
       log.debug(`Writing versioned entry to: ${versionFilePath}`, this.exportConfig.context);
       fsUtil.writeFile(versionFilePath, response);
       // Track version progress if the process exists
-      this.progressManager?.tick(true, `version: ${entry.uid}`, null, EXPORT_PROCESS_NAMES.ENTRY_VERSIONS);
+      this.progressManager?.tick(true, `version: ${entry.uid}`, null, PROCESS_NAMES.ENTRY_VERSIONS);
       log.success(
         messageHandler.parse('ENTRIES_VERSIONED_EXPORT_SUCCESS', options.contentType, entry.uid, options.locale),
         this.exportConfig.context,
@@ -419,8 +419,8 @@ export default class EntriesExport extends BaseClass {
       this.progressManager?.tick(
         false,
         `version: ${uid}`,
-        error?.message || EXPORT_PROCESS_STATUS[EXPORT_PROCESS_NAMES.ENTRY_VERSIONS].FAILED,
-        EXPORT_PROCESS_NAMES.ENTRY_VERSIONS,
+        error?.message || PROCESS_STATUS[PROCESS_NAMES.ENTRY_VERSIONS].FAILED,
+        PROCESS_NAMES.ENTRY_VERSIONS,
       );
       handleAndLogError(
         error,

--- a/packages/contentstack-export/src/export/modules/entries.ts
+++ b/packages/contentstack-export/src/export/modules/entries.ts
@@ -3,7 +3,13 @@ import { ContentstackClient, FsUtility, handleAndLogError, messageHandler, log }
 import { Export, ExportProjects } from '@contentstack/cli-variants';
 import { sanitizePath } from '@contentstack/cli-utilities';
 
-import { fsUtil } from '../../utils';
+import {
+  fsUtil,
+  EXPORT_PROCESS_NAMES,
+  EXPORT_MODULE_CONTEXTS,
+  EXPORT_PROCESS_STATUS,
+  EXPORT_MODULE_NAMES,
+} from '../../utils';
 import BaseClass, { ApiOptions } from './base-class';
 import { ExportConfig, ModuleClassParams } from '../../types';
 
@@ -52,21 +58,20 @@ export default class EntriesExport extends BaseClass {
       'schema.json',
     );
     this.projectInstance = new ExportProjects(this.exportConfig);
-    this.exportConfig.context.module = 'entries';
-    this.currentModuleName = 'Entries';
+    this.exportConfig.context.module = EXPORT_MODULE_CONTEXTS.ENTRIES;
+    this.currentModuleName = EXPORT_MODULE_NAMES[EXPORT_MODULE_CONTEXTS.ENTRIES];
   }
 
   async start() {
     try {
       log.debug('Starting entries export process...', this.exportConfig.context);
-      
+
       // Initial analysis with loading spinner
-      const [locales, contentTypes, entryRequestOptions, totalEntriesCount, variantInfo] = await this.withLoadingSpinner(
-        'ENTRIES: Analyzing content structure and entries...',
-        async () => {
+      const [locales, contentTypes, entryRequestOptions, totalEntriesCount, variantInfo] =
+        await this.withLoadingSpinner('ENTRIES: Analyzing content structure and entries...', async () => {
           const locales = fsUtil.readFile(this.localesFilePath) as Array<Record<string, unknown>>;
           const contentTypes = fsUtil.readFile(this.schemaFilePath) as Array<Record<string, unknown>>;
-          
+
           if (!Array.isArray(locales) || locales?.length === 0) {
             log.debug(`No locales found in ${this.localesFilePath}`, this.exportConfig.context);
           } else {
@@ -77,7 +82,10 @@ export default class EntriesExport extends BaseClass {
             log.info(messageHandler.parse('CONTENT_TYPE_NO_TYPES'), this.exportConfig.context);
             return [locales, contentTypes, [], 0, null];
           }
-          log.debug(`Loaded ${contentTypes?.length} content types from ${this.schemaFilePath}`, this.exportConfig.context);
+          log.debug(
+            `Loaded ${contentTypes?.length} content types from ${this.schemaFilePath}`,
+            this.exportConfig.context,
+          );
 
           // Create entry request objects
           const entryRequestOptions = this.createRequestObjects(locales, contentTypes);
@@ -87,11 +95,10 @@ export default class EntriesExport extends BaseClass {
           );
 
           // Get total entries count for better progress tracking
-          const totalEntriesCount = await this.getTotalEntriesCount(entryRequestOptions);    
+          const totalEntriesCount = await this.getTotalEntriesCount(entryRequestOptions);
           const variantInfo = await this.setupVariantExport();
           return [locales, contentTypes, entryRequestOptions, totalEntriesCount, variantInfo];
-        }
-      );
+        });
 
       if (contentTypes?.length === 0) {
         return;
@@ -100,22 +107,24 @@ export default class EntriesExport extends BaseClass {
       // Create nested progress manager
       const progress = this.createNestedProgress(this.currentModuleName);
 
-      // Add sub-processes 
+      // Add sub-processes
       if (totalEntriesCount > 0) {
-        progress.addProcess('Entries', totalEntriesCount);
-        
+        progress.addProcess(EXPORT_PROCESS_NAMES.ENTRIES, totalEntriesCount);
+
         if (this.entriesConfig.exportVersions) {
-          progress.addProcess('Entry Versions', totalEntriesCount); 
+          progress.addProcess(EXPORT_PROCESS_NAMES.ENTRY_VERSIONS, totalEntriesCount);
         }
-        
+
         if (this.exportVariantEntry) {
-          progress.addProcess('Variant Entries', 0);
+          progress.addProcess(EXPORT_PROCESS_NAMES.VARIANT_ENTRIES, 0);
         }
       }
 
       // Process entry collections
       if (totalEntriesCount > 0) {
-        progress.startProcess('Entries').updateStatus('Processing entry collections...', 'Entries');
+        progress
+          .startProcess(EXPORT_PROCESS_NAMES.ENTRIES)
+          .updateStatus(EXPORT_PROCESS_STATUS[EXPORT_PROCESS_NAMES.ENTRIES].PROCESSING, EXPORT_PROCESS_NAMES.ENTRIES);
 
         for (let entryRequestOption of entryRequestOptions) {
           try {
@@ -127,33 +136,36 @@ export default class EntriesExport extends BaseClass {
             this.entriesFileHelper?.completeFile(true);
 
             log.success(
-              messageHandler.parse('ENTRIES_EXPORT_COMPLETE', entryRequestOption.contentType, entryRequestOption.locale),
+              messageHandler.parse(
+                'ENTRIES_EXPORT_COMPLETE',
+                entryRequestOption.contentType,
+                entryRequestOption.locale,
+              ),
               this.exportConfig.context,
             );
           } catch (error) {
             this.progressManager?.tick(
               false,
               `${entryRequestOption.contentType}:${entryRequestOption.locale}`,
-              error?.message || 'Failed to export entries',
-              'Entries',
+              error?.message || EXPORT_PROCESS_STATUS[EXPORT_PROCESS_NAMES.ENTRIES].FAILED,
+              EXPORT_PROCESS_NAMES.ENTRIES,
             );
             throw error;
           }
         }
-        progress.completeProcess('Entries', true);
+        progress.completeProcess(EXPORT_PROCESS_NAMES.ENTRIES, true);
 
         if (this.entriesConfig.exportVersions) {
-          progress.completeProcess('Entry Versions', true);
+          progress.completeProcess(EXPORT_PROCESS_NAMES.ENTRY_VERSIONS, true);
         }
-        
+
         if (this.exportVariantEntry) {
-          progress.completeProcess('Variant Entries', true);
+          progress.completeProcess(EXPORT_PROCESS_NAMES.VARIANT_ENTRIES, true);
         }
       }
 
       this.completeProgress(true);
       log.success(messageHandler.parse('ENTRIES_EXPORT_SUCCESS'), this.exportConfig.context);
-      
     } catch (error) {
       handleAndLogError(error, { ...this.exportConfig.context });
       this.completeProgress(false, error?.message || 'Entries export failed');
@@ -162,9 +174,9 @@ export default class EntriesExport extends BaseClass {
 
   async getTotalEntriesCount(entryRequestOptions: Array<Record<string, any>>): Promise<number> {
     log.debug('Calculating total entries count for progress tracking...', this.exportConfig.context);
-    
+
     let totalCount = 0;
-    
+
     try {
       for (const option of entryRequestOptions) {
         const countQuery = {
@@ -173,34 +185,27 @@ export default class EntriesExport extends BaseClass {
           include_count: true,
           query: { locale: option.locale },
         };
-        
+
         this.applyQueryFilters(countQuery, 'entries');
-        
+
         try {
-          const response = await this.stackAPIClient
-            .contentType(option.contentType)
-            .entry()
-            .query(countQuery)
-            .find();
-            
+          const response = await this.stackAPIClient.contentType(option.contentType).entry().query(countQuery).find();
+
           const count = response.count || 0;
           totalCount += count;
           log.debug(
             `Content type ${option.contentType} (${option.locale}): ${count} entries`,
-            this.exportConfig.context
+            this.exportConfig.context,
           );
         } catch (error) {
-          log.debug(
-            `Failed to get count for ${option.contentType}:${option.locale}`,
-            this.exportConfig.context
-          );
+          log.debug(`Failed to get count for ${option.contentType}:${option.locale}`, this.exportConfig.context);
         }
       }
     } catch (error) {
       log.debug('Error calculating total entries count, using collection count as fallback', this.exportConfig.context);
       return entryRequestOptions.length;
     }
-    
+
     log.debug(`Total entries count: ${totalCount}`, this.exportConfig.context);
     return totalCount;
   }
@@ -209,9 +214,9 @@ export default class EntriesExport extends BaseClass {
     if (!this.exportConfig.personalizationEnabled) {
       return null;
     }
-    
+
     log.debug('Personalization is enabled, checking for variant entries...', this.exportConfig.context);
-    
+
     try {
       const project = await this.projectInstance.projects({ connectedStackApiKey: this.exportConfig.apiKey });
 
@@ -219,7 +224,7 @@ export default class EntriesExport extends BaseClass {
         const project_id = project[0].uid;
         this.exportVariantEntry = true;
         log.debug(`Found project with ID: ${project_id}, enabling variant entry export`, this.exportConfig.context);
-        
+
         this.variantEntries = new Export.VariantEntries(Object.assign(this.exportConfig, { project_id }));
         return { project_id };
       }
@@ -227,7 +232,7 @@ export default class EntriesExport extends BaseClass {
       log.debug('Failed to setup variant export', this.exportConfig.context);
       handleAndLogError(error, { ...this.exportConfig.context });
     }
-    
+
     return null;
   }
 
@@ -329,7 +334,7 @@ export default class EntriesExport extends BaseClass {
 
       // Track progress for individual entries
       entriesSearchResponse.items.forEach((entry: any) => {
-        this.progressManager?.tick(true, `entry: ${entry.uid}`, null, 'Entries');
+        this.progressManager?.tick(true, `entry: ${entry.uid}`, null, EXPORT_PROCESS_NAMES.ENTRIES);
       });
 
       if (this.entriesConfig.exportVersions) {
@@ -357,14 +362,17 @@ export default class EntriesExport extends BaseClass {
           if (this.variantEntries && typeof this.variantEntries.setParentProgressManager === 'function') {
             this.variantEntries.setParentProgressManager(this.progressManager);
           }
-          
+
           await this.variantEntries.exportVariantEntry({
             locale: options.locale,
             contentTypeUid: options.contentType,
             entries: entriesSearchResponse.items,
           });
-          
-          log.debug(`Successfully exported variant entries for ${entriesSearchResponse.items.length} entries`, this.exportConfig.context);
+
+          log.debug(
+            `Successfully exported variant entries for ${entriesSearchResponse.items.length} entries`,
+            this.exportConfig.context,
+          );
         } catch (error) {
           log.debug('Failed to export variant entries', this.exportConfig.context);
         }
@@ -399,7 +407,7 @@ export default class EntriesExport extends BaseClass {
       log.debug(`Writing versioned entry to: ${versionFilePath}`, this.exportConfig.context);
       fsUtil.writeFile(versionFilePath, response);
       // Track version progress if the process exists
-      this.progressManager?.tick(true, `version: ${entry.uid}`, null, 'Entry Versions');
+      this.progressManager?.tick(true, `version: ${entry.uid}`, null, EXPORT_PROCESS_NAMES.ENTRY_VERSIONS);
       log.success(
         messageHandler.parse('ENTRIES_VERSIONED_EXPORT_SUCCESS', options.contentType, entry.uid, options.locale),
         this.exportConfig.context,
@@ -411,8 +419,8 @@ export default class EntriesExport extends BaseClass {
       this.progressManager?.tick(
         false,
         `version: ${uid}`,
-        error?.message || 'Failed to fetch versions',
-        'Entry Versions',
+        error?.message || EXPORT_PROCESS_STATUS[EXPORT_PROCESS_NAMES.ENTRY_VERSIONS].FAILED,
+        EXPORT_PROCESS_NAMES.ENTRY_VERSIONS,
       );
       handleAndLogError(
         error,

--- a/packages/contentstack-export/src/export/modules/environments.ts
+++ b/packages/contentstack-export/src/export/modules/environments.ts
@@ -4,8 +4,8 @@ import isEmpty from 'lodash/isEmpty';
 import { handleAndLogError, messageHandler, log } from '@contentstack/cli-utilities';
 
 import BaseClass from './base-class';
-import { fsUtil } from '../../utils';
 import { EnvironmentConfig, ModuleClassParams } from '../../types';
+import { fsUtil, EXPORT_MODULE_CONTEXTS, EXPORT_MODULE_NAMES } from '../../utils';
 
 export default class ExportEnvironments extends BaseClass {
   private environments: Record<string, unknown>;
@@ -21,8 +21,8 @@ export default class ExportEnvironments extends BaseClass {
     this.environments = {};
     this.environmentConfig = exportConfig.modules.environments;
     this.qs = { include_count: true };
-    this.exportConfig.context.module = 'environments';
-    this.currentModuleName = 'Environments';
+    this.exportConfig.context.module = EXPORT_MODULE_CONTEXTS.ENVIRONMENTS;
+    this.currentModuleName = EXPORT_MODULE_NAMES[EXPORT_MODULE_CONTEXTS.ENVIRONMENTS];
   }
 
   async start(): Promise<void> {

--- a/packages/contentstack-export/src/export/modules/environments.ts
+++ b/packages/contentstack-export/src/export/modules/environments.ts
@@ -5,7 +5,7 @@ import { handleAndLogError, messageHandler, log } from '@contentstack/cli-utilit
 
 import BaseClass from './base-class';
 import { EnvironmentConfig, ModuleClassParams } from '../../types';
-import { fsUtil, EXPORT_MODULE_CONTEXTS, EXPORT_MODULE_NAMES } from '../../utils';
+import { fsUtil, MODULE_CONTEXTS, MODULE_NAMES } from '../../utils';
 
 export default class ExportEnvironments extends BaseClass {
   private environments: Record<string, unknown>;
@@ -21,8 +21,8 @@ export default class ExportEnvironments extends BaseClass {
     this.environments = {};
     this.environmentConfig = exportConfig.modules.environments;
     this.qs = { include_count: true };
-    this.exportConfig.context.module = EXPORT_MODULE_CONTEXTS.ENVIRONMENTS;
-    this.currentModuleName = EXPORT_MODULE_NAMES[EXPORT_MODULE_CONTEXTS.ENVIRONMENTS];
+    this.exportConfig.context.module = MODULE_CONTEXTS.ENVIRONMENTS;
+    this.currentModuleName = MODULE_NAMES[MODULE_CONTEXTS.ENVIRONMENTS];
   }
 
   async start(): Promise<void> {

--- a/packages/contentstack-export/src/export/modules/extensions.ts
+++ b/packages/contentstack-export/src/export/modules/extensions.ts
@@ -4,8 +4,8 @@ import { resolve as pResolve } from 'node:path';
 import { handleAndLogError, messageHandler, log } from '@contentstack/cli-utilities';
 
 import BaseClass from './base-class';
-import { fsUtil } from '../../utils';
 import { ExtensionsConfig, ModuleClassParams } from '../../types';
+import { fsUtil, EXPORT_MODULE_CONTEXTS, EXPORT_MODULE_NAMES } from '../../utils';
 
 export default class ExportExtensions extends BaseClass {
   private extensionsFolderPath: string;
@@ -22,8 +22,8 @@ export default class ExportExtensions extends BaseClass {
     this.extensionConfig = exportConfig.modules.extensions;
     this.qs = { include_count: true };
     this.applyQueryFilters(this.qs, 'extensions');
-    this.exportConfig.context.module = 'extensions';
-    this.currentModuleName = 'Extensions';
+    this.exportConfig.context.module = EXPORT_MODULE_CONTEXTS.EXTENSIONS;
+    this.currentModuleName = EXPORT_MODULE_NAMES[EXPORT_MODULE_CONTEXTS.EXTENSIONS];
   }
 
   async start(): Promise<void> {

--- a/packages/contentstack-export/src/export/modules/extensions.ts
+++ b/packages/contentstack-export/src/export/modules/extensions.ts
@@ -5,7 +5,7 @@ import { handleAndLogError, messageHandler, log } from '@contentstack/cli-utilit
 
 import BaseClass from './base-class';
 import { ExtensionsConfig, ModuleClassParams } from '../../types';
-import { fsUtil, EXPORT_MODULE_CONTEXTS, EXPORT_MODULE_NAMES } from '../../utils';
+import { fsUtil, MODULE_CONTEXTS, MODULE_NAMES } from '../../utils';
 
 export default class ExportExtensions extends BaseClass {
   private extensionsFolderPath: string;
@@ -22,8 +22,8 @@ export default class ExportExtensions extends BaseClass {
     this.extensionConfig = exportConfig.modules.extensions;
     this.qs = { include_count: true };
     this.applyQueryFilters(this.qs, 'extensions');
-    this.exportConfig.context.module = EXPORT_MODULE_CONTEXTS.EXTENSIONS;
-    this.currentModuleName = EXPORT_MODULE_NAMES[EXPORT_MODULE_CONTEXTS.EXTENSIONS];
+    this.exportConfig.context.module = MODULE_CONTEXTS.EXTENSIONS;
+    this.currentModuleName = MODULE_NAMES[MODULE_CONTEXTS.EXTENSIONS];
   }
 
   async start(): Promise<void> {

--- a/packages/contentstack-export/src/export/modules/global-fields.ts
+++ b/packages/contentstack-export/src/export/modules/global-fields.ts
@@ -3,7 +3,7 @@ import { ContentstackClient, handleAndLogError, messageHandler, log, sanitizePat
 
 import BaseClass from './base-class';
 import { ExportConfig, ModuleClassParams } from '../../types';
-import { fsUtil, EXPORT_MODULE_CONTEXTS, EXPORT_MODULE_NAMES } from '../../utils';
+import { fsUtil, MODULE_CONTEXTS, MODULE_NAMES } from '../../utils';
 
 export default class GlobalFieldsExport extends BaseClass {
   private stackAPIClient: ReturnType<ContentstackClient['stack']>;
@@ -44,8 +44,8 @@ export default class GlobalFieldsExport extends BaseClass {
     );
     this.globalFields = [];
     this.applyQueryFilters(this.qs, 'global-fields');
-    this.exportConfig.context.module = EXPORT_MODULE_CONTEXTS.GLOBAL_FIELDS;
-    this.currentModuleName = EXPORT_MODULE_NAMES[EXPORT_MODULE_CONTEXTS.GLOBAL_FIELDS];
+    this.exportConfig.context.module = MODULE_CONTEXTS.GLOBAL_FIELDS;
+    this.currentModuleName = MODULE_NAMES[MODULE_CONTEXTS.GLOBAL_FIELDS];
   }
 
   async start() {

--- a/packages/contentstack-export/src/export/modules/global-fields.ts
+++ b/packages/contentstack-export/src/export/modules/global-fields.ts
@@ -1,15 +1,9 @@
 import * as path from 'path';
-import {
-  ContentstackClient,
-  handleAndLogError,
-  messageHandler,
-  log,
-  sanitizePath,
-} from '@contentstack/cli-utilities';
+import { ContentstackClient, handleAndLogError, messageHandler, log, sanitizePath } from '@contentstack/cli-utilities';
 
-import { fsUtil } from '../../utils';
-import { ExportConfig, ModuleClassParams } from '../../types';
 import BaseClass from './base-class';
+import { ExportConfig, ModuleClassParams } from '../../types';
+import { fsUtil, EXPORT_MODULE_CONTEXTS, EXPORT_MODULE_NAMES } from '../../utils';
 
 export default class GlobalFieldsExport extends BaseClass {
   private stackAPIClient: ReturnType<ContentstackClient['stack']>;
@@ -50,8 +44,8 @@ export default class GlobalFieldsExport extends BaseClass {
     );
     this.globalFields = [];
     this.applyQueryFilters(this.qs, 'global-fields');
-    this.exportConfig.context.module = 'global-fields';
-    this.currentModuleName = 'Global Fields';
+    this.exportConfig.context.module = EXPORT_MODULE_CONTEXTS.GLOBAL_FIELDS;
+    this.currentModuleName = EXPORT_MODULE_NAMES[EXPORT_MODULE_CONTEXTS.GLOBAL_FIELDS];
   }
 
   async start() {
@@ -59,17 +53,14 @@ export default class GlobalFieldsExport extends BaseClass {
       log.debug('Starting global fields export process...', this.exportConfig.context);
 
       // Get global fields count and setup with loading spinner
-      const [totalCount] = await this.withLoadingSpinner(
-        'GLOBAL-FIELDS: Analyzing global fields...',
-        async () => {
-          await fsUtil.makeDirectory(this.globalFieldsDirPath);
-          const countResponse = await this.stackAPIClient
-            .globalField()
-            .query({ ...this.qs, include_count: true, limit: 1 })
-            .find();
-          return [countResponse.count || 0];
-        },
-      );
+      const [totalCount] = await this.withLoadingSpinner('GLOBAL-FIELDS: Analyzing global fields...', async () => {
+        await fsUtil.makeDirectory(this.globalFieldsDirPath);
+        const countResponse = await this.stackAPIClient
+          .globalField()
+          .query({ ...this.qs, include_count: true, limit: 1 })
+          .find();
+        return [countResponse.count || 0];
+      });
 
       if (totalCount === 0) {
         log.info(messageHandler.parse('GLOBAL_FIELDS_NOT_FOUND'), this.exportConfig.context);

--- a/packages/contentstack-export/src/export/modules/labels.ts
+++ b/packages/contentstack-export/src/export/modules/labels.ts
@@ -5,7 +5,7 @@ import { handleAndLogError, messageHandler, log } from '@contentstack/cli-utilit
 
 import BaseClass from './base-class';
 import { LabelConfig, ModuleClassParams } from '../../types';
-import { fsUtil, EXPORT_MODULE_CONTEXTS, EXPORT_MODULE_NAMES } from '../../utils';
+import { fsUtil, MODULE_CONTEXTS, MODULE_NAMES } from '../../utils';
 
 export default class ExportLabels extends BaseClass {
   private labels: Record<string, Record<string, string>>;
@@ -21,8 +21,8 @@ export default class ExportLabels extends BaseClass {
     this.labels = {};
     this.labelConfig = exportConfig.modules.labels;
     this.qs = { include_count: true };
-    this.exportConfig.context.module = EXPORT_MODULE_CONTEXTS.LABELS;
-    this.currentModuleName = EXPORT_MODULE_NAMES[EXPORT_MODULE_CONTEXTS.LABELS];
+    this.exportConfig.context.module = MODULE_CONTEXTS.LABELS;
+    this.currentModuleName = MODULE_NAMES[MODULE_CONTEXTS.LABELS];
   }
 
   async start(): Promise<void> {

--- a/packages/contentstack-export/src/export/modules/labels.ts
+++ b/packages/contentstack-export/src/export/modules/labels.ts
@@ -4,8 +4,8 @@ import { resolve as pResolve } from 'node:path';
 import { handleAndLogError, messageHandler, log } from '@contentstack/cli-utilities';
 
 import BaseClass from './base-class';
-import { fsUtil } from '../../utils';
 import { LabelConfig, ModuleClassParams } from '../../types';
+import { fsUtil, EXPORT_MODULE_CONTEXTS, EXPORT_MODULE_NAMES } from '../../utils';
 
 export default class ExportLabels extends BaseClass {
   private labels: Record<string, Record<string, string>>;
@@ -21,8 +21,8 @@ export default class ExportLabels extends BaseClass {
     this.labels = {};
     this.labelConfig = exportConfig.modules.labels;
     this.qs = { include_count: true };
-    this.exportConfig.context.module = 'labels';
-    this.currentModuleName = 'Labels';
+    this.exportConfig.context.module = EXPORT_MODULE_CONTEXTS.LABELS;
+    this.currentModuleName = EXPORT_MODULE_NAMES[EXPORT_MODULE_CONTEXTS.LABELS];
   }
 
   async start(): Promise<void> {

--- a/packages/contentstack-export/src/export/modules/locales.ts
+++ b/packages/contentstack-export/src/export/modules/locales.ts
@@ -1,9 +1,9 @@
 import * as path from 'path';
 import { ContentstackClient, handleAndLogError, messageHandler, log, sanitizePath } from '@contentstack/cli-utilities';
 
-import { fsUtil } from '../../utils';
 import BaseClass from './base-class';
 import { ExportConfig, ModuleClassParams } from '../../types';
+import { fsUtil, EXPORT_MODULE_CONTEXTS, EXPORT_MODULE_NAMES } from '../../utils';
 
 export default class LocaleExport extends BaseClass {
   private stackAPIClient: ReturnType<ContentstackClient['stack']>;
@@ -48,8 +48,8 @@ export default class LocaleExport extends BaseClass {
     );
     this.locales = {};
     this.masterLocale = {};
-    this.exportConfig.context.module = 'locales';
-    this.currentModuleName = 'Locales';
+    this.exportConfig.context.module = EXPORT_MODULE_CONTEXTS.LOCALES;
+    this.currentModuleName = EXPORT_MODULE_NAMES[EXPORT_MODULE_CONTEXTS.LOCALES];
   }
 
   async start() {

--- a/packages/contentstack-export/src/export/modules/locales.ts
+++ b/packages/contentstack-export/src/export/modules/locales.ts
@@ -3,7 +3,7 @@ import { ContentstackClient, handleAndLogError, messageHandler, log, sanitizePat
 
 import BaseClass from './base-class';
 import { ExportConfig, ModuleClassParams } from '../../types';
-import { fsUtil, EXPORT_MODULE_CONTEXTS, EXPORT_MODULE_NAMES } from '../../utils';
+import { fsUtil, MODULE_CONTEXTS, MODULE_NAMES } from '../../utils';
 
 export default class LocaleExport extends BaseClass {
   private stackAPIClient: ReturnType<ContentstackClient['stack']>;
@@ -48,8 +48,8 @@ export default class LocaleExport extends BaseClass {
     );
     this.locales = {};
     this.masterLocale = {};
-    this.exportConfig.context.module = EXPORT_MODULE_CONTEXTS.LOCALES;
-    this.currentModuleName = EXPORT_MODULE_NAMES[EXPORT_MODULE_CONTEXTS.LOCALES];
+    this.exportConfig.context.module = MODULE_CONTEXTS.LOCALES;
+    this.currentModuleName = MODULE_NAMES[MODULE_CONTEXTS.LOCALES];
   }
 
   async start() {

--- a/packages/contentstack-export/src/export/modules/marketplace-apps.ts
+++ b/packages/contentstack-export/src/export/modules/marketplace-apps.ts
@@ -17,9 +17,18 @@ import {
   handleAndLogError,
 } from '@contentstack/cli-utilities';
 
-import { fsUtil, getOrgUid, createNodeCryptoInstance, getDeveloperHubUrl } from '../../utils';
-import { ModuleClassParams, MarketplaceAppsConfig, ExportConfig, Installation, Manifest } from '../../types';
 import BaseClass from './base-class';
+import {
+  fsUtil,
+  getOrgUid,
+  createNodeCryptoInstance,
+  getDeveloperHubUrl,
+  EXPORT_MODULE_CONTEXTS,
+  EXPORT_MODULE_NAMES,
+  EXPORT_PROCESS_NAMES,
+  EXPORT_PROCESS_STATUS,
+} from '../../utils';
+import { ModuleClassParams, MarketplaceAppsConfig, ExportConfig, Installation, Manifest } from '../../types';
 
 export default class ExportMarketplaceApps extends BaseClass {
   protected marketplaceAppConfig: MarketplaceAppsConfig;
@@ -36,14 +45,14 @@ export default class ExportMarketplaceApps extends BaseClass {
     super({ exportConfig, stackAPIClient });
     this.exportConfig = exportConfig;
     this.marketplaceAppConfig = exportConfig.modules.marketplace_apps;
-    this.exportConfig.context.module = 'marketplace-apps';
-    this.currentModuleName = 'Marketplace Apps';
+    this.exportConfig.context.module = EXPORT_MODULE_CONTEXTS.MARKETPLACE_APPS;
+    this.currentModuleName = EXPORT_MODULE_NAMES[EXPORT_MODULE_CONTEXTS.MARKETPLACE_APPS];
   }
 
   async start(): Promise<void> {
     try {
       log.debug('Starting marketplace apps export process...', this.exportConfig.context);
-      
+
       if (!isAuthenticated()) {
         cliux.print(
           'WARNING!!! To export Marketplace apps, you must be logged in. Please check csdx auth:login --help to log in',
@@ -53,14 +62,11 @@ export default class ExportMarketplaceApps extends BaseClass {
       }
 
       // Initial setup and analysis with loading spinner
-      const [appsCount] = await this.withLoadingSpinner(
-        'MARKETPLACE-APPS: Analyzing marketplace apps...',
-        async () => {
-          await this.setupPaths();
-          const appsCount = await this.getAppsCount();
-          return [appsCount];
-        }
-      );
+      const [appsCount] = await this.withLoadingSpinner('MARKETPLACE-APPS: Analyzing marketplace apps...', async () => {
+        await this.setupPaths();
+        const appsCount = await this.getAppsCount();
+        return [appsCount];
+      });
 
       if (appsCount === 0) {
         log.info(messageHandler.parse('MARKETPLACE_APPS_NOT_FOUND'), this.exportConfig.context);
@@ -71,24 +77,30 @@ export default class ExportMarketplaceApps extends BaseClass {
       const progress = this.createNestedProgress(this.currentModuleName);
 
       // Add processes based on what we found
-      progress.addProcess('Fetch', appsCount);
-      progress.addProcess('Fetch config & manifest', appsCount); // Manifests and configurations
+      progress.addProcess(EXPORT_PROCESS_NAMES.FETCH_APPS, appsCount);
+      progress.addProcess(EXPORT_PROCESS_NAMES.FETCH_CONFIG_MANIFEST, appsCount); // Manifests and configurations
 
       // Fetch stack specific apps
-      progress.startProcess('Fetch').updateStatus('Fetching marketplace apps...', 'Fetch');
+      progress
+        .startProcess(EXPORT_PROCESS_NAMES.FETCH_APPS)
+        .updateStatus(EXPORT_PROCESS_STATUS[EXPORT_PROCESS_NAMES.FETCH_APPS].FETCHING, EXPORT_PROCESS_NAMES.FETCH_APPS);
       await this.exportApps();
-      progress.completeProcess('Fetch', true);
+      progress.completeProcess(EXPORT_PROCESS_NAMES.FETCH_APPS, true);
 
       // Process apps (manifests and configurations)
       if (this.installedApps.length > 0) {
-        progress.startProcess('Fetch config & manifest').updateStatus('Processing app manifests and configurations...', 'Fetch config & manifest');
+        progress
+          .startProcess(EXPORT_PROCESS_NAMES.FETCH_CONFIG_MANIFEST)
+          .updateStatus(
+            EXPORT_PROCESS_STATUS[EXPORT_PROCESS_NAMES.FETCH_CONFIG_MANIFEST].PROCESSING,
+            EXPORT_PROCESS_NAMES.FETCH_CONFIG_MANIFEST,
+          );
         await this.getAppManifestAndAppConfig();
-        progress.completeProcess('Fetch config & manifest', true);
+        progress.completeProcess(EXPORT_PROCESS_NAMES.FETCH_CONFIG_MANIFEST, true);
       }
 
       this.completeProgress(true);
       log.success('Marketplace apps export completed successfully', this.exportConfig.context);
-      
     } catch (error) {
       log.debug('Error occurred during marketplace apps export', this.exportConfig.context);
       handleAndLogError(error, { ...this.exportConfig.context });
@@ -103,13 +115,13 @@ export default class ExportMarketplaceApps extends BaseClass {
       this.marketplaceAppConfig.dirName,
     );
     log.debug(`Marketplace apps folder path: ${this.marketplaceAppPath}`, this.exportConfig.context);
-    
+
     await fsUtil.makeDirectory(this.marketplaceAppPath);
     log.debug('Created marketplace apps directory', this.exportConfig.context);
-    
+
     this.developerHubBaseUrl = this.exportConfig.developerHubBaseUrl || (await getDeveloperHubUrl(this.exportConfig));
     log.debug(`Developer hub base URL: ${this.developerHubBaseUrl}`, this.exportConfig.context);
-    
+
     this.exportConfig.org_uid = await getOrgUid(this.exportConfig);
     this.query = { target_uids: this.exportConfig.source_stack };
     log.debug(`Organization UID: ${this.exportConfig.org_uid}`, this.exportConfig.context);
@@ -122,7 +134,7 @@ export default class ExportMarketplaceApps extends BaseClass {
 
   async getAppsCount(): Promise<number> {
     log.debug('Fetching marketplace apps count...', this.exportConfig.context);
-    
+
     try {
       const externalQuery = this.exportConfig.query?.modules['marketplace-apps'];
       if (externalQuery) {
@@ -154,7 +166,7 @@ export default class ExportMarketplaceApps extends BaseClass {
    */
   async exportApps(): Promise<any> {
     log.debug('Starting apps export process...', this.exportConfig.context);
-    
+
     await this.getStackSpecificApps();
     log.debug(`Retrieved ${this.installedApps.length} stack-specific apps`, this.exportConfig.context);
 
@@ -170,7 +182,7 @@ export default class ExportMarketplaceApps extends BaseClass {
       }
       return app;
     });
-    
+
     log.debug(`Processed ${this.installedApps.length} total marketplace apps`, this.exportConfig.context);
   }
 
@@ -183,7 +195,7 @@ export default class ExportMarketplaceApps extends BaseClass {
       log.info(messageHandler.parse('MARKETPLACE_APPS_NOT_FOUND'), this.exportConfig.context);
     } else {
       log.debug(`Processing ${this.installedApps.length} installed apps`, this.exportConfig.context);
-      
+
       for (const [index, app] of entries(this.installedApps)) {
         if (app.manifest.visibility === 'private') {
           log.debug(`Processing private app manifest: ${app.manifest.name}`, this.exportConfig.context);
@@ -194,9 +206,14 @@ export default class ExportMarketplaceApps extends BaseClass {
       for (const [index, app] of entries(this.installedApps)) {
         log.debug(`Processing app configurations: ${app.manifest?.name || app.uid}`, this.exportConfig.context);
         await this.getAppConfigurations(+index, app);
-        
+
         // Track progress for each app processed
-        this.progressManager?.tick(true, `app: ${app.manifest?.name || app.uid}`, null, 'Fetch config & manifest');
+        this.progressManager?.tick(
+          true,
+          `app: ${app.manifest?.name || app.uid}`,
+          null,
+          EXPORT_PROCESS_NAMES.FETCH_CONFIG_MANIFEST,
+        );
       }
 
       const marketplaceAppsFilePath = pResolve(this.marketplaceAppPath, this.marketplaceAppConfig.fileName);
@@ -220,14 +237,20 @@ export default class ExportMarketplaceApps extends BaseClass {
    * app's manifest.
    */
   async getPrivateAppsManifest(index: number, appInstallation: Installation) {
-    log.debug(`Fetching private app manifest for: ${appInstallation.manifest.name} (${appInstallation.manifest.uid})`, this.exportConfig.context);
-    
+    log.debug(
+      `Fetching private app manifest for: ${appInstallation.manifest.name} (${appInstallation.manifest.uid})`,
+      this.exportConfig.context,
+    );
+
     const manifest = await this.appSdk
       .marketplace(this.exportConfig.org_uid)
       .app(appInstallation.manifest.uid)
       .fetch({ include_oauth: true })
       .catch((error) => {
-        log.debug(`Failed to fetch private app manifest for: ${appInstallation.manifest.name}`, this.exportConfig.context);
+        log.debug(
+          `Failed to fetch private app manifest for: ${appInstallation.manifest.name}`,
+          this.exportConfig.context,
+        );
         handleAndLogError(
           error,
           {
@@ -238,7 +261,10 @@ export default class ExportMarketplaceApps extends BaseClass {
       });
 
     if (manifest) {
-      log.debug(`Successfully fetched private app manifest for: ${appInstallation.manifest.name}`, this.exportConfig.context);
+      log.debug(
+        `Successfully fetched private app manifest for: ${appInstallation.manifest.name}`,
+        this.exportConfig.context,
+      );
       this.installedApps[index].manifest = manifest as unknown as Manifest;
     }
   }
@@ -269,7 +295,7 @@ export default class ExportMarketplaceApps extends BaseClass {
 
         if (has(data, 'server_configuration') || has(data, 'configuration')) {
           log.debug(`Found configuration data for app: ${app}`, this.exportConfig.context);
-          
+
           if (!this.nodeCrypto && (has(data, 'server_configuration') || has(data, 'configuration'))) {
             log.debug(`Initializing NodeCrypto for app: ${app}`, this.exportConfig.context);
             this.nodeCrypto = await createNodeCryptoInstance(this.exportConfig);
@@ -318,7 +344,7 @@ export default class ExportMarketplaceApps extends BaseClass {
    * the API. In this code, it is initially set to 0, indicating that no items should be skipped in
    */
   async getStackSpecificApps(skip = 0) {
-    log.debug(`Fetching stack-specific apps with skip: ${skip}`, this.exportConfig.context);  
+    log.debug(`Fetching stack-specific apps with skip: ${skip}`, this.exportConfig.context);
     const collection = await this.appSdk
       .marketplace(this.exportConfig.org_uid)
       .installation()
@@ -333,7 +359,7 @@ export default class ExportMarketplaceApps extends BaseClass {
     if (collection) {
       const { items: apps, count } = collection;
       log.debug(`Fetched ${apps?.length || 0} apps out of total ${count}`, this.exportConfig.context);
-      
+
       // NOTE Remove all the chain functions
       const installation = map(apps, (app) =>
         omitBy(app, (val, _key) => {
@@ -341,14 +367,19 @@ export default class ExportMarketplaceApps extends BaseClass {
           return false;
         }),
       ) as unknown as Installation[];
-      
+
       log.debug(`Processed ${installation.length} app installations`, this.exportConfig.context);
-      
+
       // Track progress for each app fetched
       installation.forEach((app) => {
-        this.progressManager?.tick(true, `app: ${app.manifest?.name || app.uid}`, null, 'Fetch');
+        this.progressManager?.tick(
+          true,
+          `app: ${app.manifest?.name || app.uid}`,
+          null,
+          EXPORT_PROCESS_NAMES.FETCH_APPS,
+        );
       });
-      
+
       this.installedApps = this.installedApps.concat(installation);
 
       if (count - (skip + 50) > 0) {

--- a/packages/contentstack-export/src/export/modules/personalize.ts
+++ b/packages/contentstack-export/src/export/modules/personalize.ts
@@ -8,8 +8,9 @@ import {
 } from '@contentstack/cli-variants';
 import { handleAndLogError, messageHandler, log, CLIProgressManager } from '@contentstack/cli-utilities';
 
-import { ModuleClassParams, ExportConfig } from '../../types';
 import BaseClass from './base-class';
+import { ModuleClassParams, ExportConfig } from '../../types';
+import { EXPORT_MODULE_CONTEXTS, EXPORT_MODULE_NAMES, EXPORT_PROCESS_NAMES, EXPORT_PROCESS_STATUS } from '../../utils';
 
 export default class ExportPersonalize extends BaseClass {
   public exportConfig: ExportConfig;
@@ -23,18 +24,18 @@ export default class ExportPersonalize extends BaseClass {
   };
 
   private readonly moduleDisplayMapper = {
-    events: 'Events',
-    attributes: 'Attributes',
-    audiences: 'Audiences',
-    experiences: 'Experiences',
-  };
+    events: EXPORT_PROCESS_NAMES.PERSONALIZE_EVENTS,
+    attributes: EXPORT_PROCESS_NAMES.PERSONALIZE_ATTRIBUTES,
+    audiences: EXPORT_PROCESS_NAMES.PERSONALIZE_AUDIENCES,
+    experiences: EXPORT_PROCESS_NAMES.PERSONALIZE_EXPERIENCES,
+  } as const;
 
   constructor({ exportConfig, stackAPIClient }: ModuleClassParams) {
     super({ exportConfig, stackAPIClient });
     this.exportConfig = exportConfig;
     this.personalizeConfig = exportConfig.modules.personalize;
-    this.exportConfig.context.module = 'personalize';
-    this.currentModuleName = 'Personalize';
+    this.exportConfig.context.module = EXPORT_MODULE_CONTEXTS.PERSONALIZE;
+    this.currentModuleName = EXPORT_MODULE_NAMES[EXPORT_MODULE_CONTEXTS.PERSONALIZE];
   }
 
   async start(): Promise<void> {
@@ -123,8 +124,11 @@ export default class ExportPersonalize extends BaseClass {
   }
 
   private addProjectProcess(progress: CLIProgressManager) {
-    progress.addProcess('Projects', 1);
-    log.debug('Added Projects process to personalize progress', this.exportConfig.context);
+    progress.addProcess(EXPORT_PROCESS_NAMES.PERSONALIZE_PROJECTS, 1);
+    log.debug(
+      `Added ${EXPORT_PROCESS_NAMES.PERSONALIZE_PROJECTS} process to personalize progress`,
+      this.exportConfig.context,
+    );
   }
 
   private addModuleProcesses(progress: CLIProgressManager, moduleCount: number) {
@@ -147,14 +151,19 @@ export default class ExportPersonalize extends BaseClass {
   }
 
   private async exportProjects(progress: CLIProgressManager) {
-    progress.startProcess('Projects').updateStatus('Exporting personalization projects...', 'Projects');
+    progress
+      .startProcess(EXPORT_PROCESS_NAMES.PERSONALIZE_PROJECTS)
+      .updateStatus(
+        EXPORT_PROCESS_STATUS[EXPORT_PROCESS_NAMES.PERSONALIZE_PROJECTS].EXPORTING,
+        EXPORT_PROCESS_NAMES.PERSONALIZE_PROJECTS,
+      );
     log.debug('Starting projects export for personalization...', this.exportConfig.context);
 
     const projectsExporter = new ExportProjects(this.exportConfig);
     projectsExporter.setParentProgressManager(progress);
     await projectsExporter.start();
 
-    progress.completeProcess('Projects', true);
+    progress.completeProcess(EXPORT_PROCESS_NAMES.PERSONALIZE_PROJECTS, true);
   }
 
   private async exportModules(progress: CLIProgressManager) {
@@ -177,7 +186,12 @@ export default class ExportPersonalize extends BaseClass {
       const ModuleClass = this.moduleInstanceMapper[module];
 
       if (ModuleClass) {
-        progress.startProcess(processName).updateStatus(`Exporting ${module}...`, processName);
+        progress
+          .startProcess(processName)
+          .updateStatus(
+            (EXPORT_PROCESS_STATUS as any)[processName]?.EXPORTING || `Exporting ${module}...`,
+            processName,
+          );
         log.debug(`Starting export for module: ${module}`, this.exportConfig.context);
 
         if (this.exportConfig.personalizationEnabled) {

--- a/packages/contentstack-export/src/export/modules/personalize.ts
+++ b/packages/contentstack-export/src/export/modules/personalize.ts
@@ -10,7 +10,7 @@ import { handleAndLogError, messageHandler, log, CLIProgressManager } from '@con
 
 import BaseClass from './base-class';
 import { ModuleClassParams, ExportConfig } from '../../types';
-import { EXPORT_MODULE_CONTEXTS, EXPORT_MODULE_NAMES, EXPORT_PROCESS_NAMES, EXPORT_PROCESS_STATUS } from '../../utils';
+import { MODULE_CONTEXTS, MODULE_NAMES, PROCESS_NAMES, PROCESS_STATUS } from '../../utils';
 
 export default class ExportPersonalize extends BaseClass {
   public exportConfig: ExportConfig;
@@ -24,18 +24,18 @@ export default class ExportPersonalize extends BaseClass {
   };
 
   private readonly moduleDisplayMapper = {
-    events: EXPORT_PROCESS_NAMES.PERSONALIZE_EVENTS,
-    attributes: EXPORT_PROCESS_NAMES.PERSONALIZE_ATTRIBUTES,
-    audiences: EXPORT_PROCESS_NAMES.PERSONALIZE_AUDIENCES,
-    experiences: EXPORT_PROCESS_NAMES.PERSONALIZE_EXPERIENCES,
+    events: PROCESS_NAMES.PERSONALIZE_EVENTS,
+    attributes: PROCESS_NAMES.PERSONALIZE_ATTRIBUTES,
+    audiences: PROCESS_NAMES.PERSONALIZE_AUDIENCES,
+    experiences: PROCESS_NAMES.PERSONALIZE_EXPERIENCES,
   } as const;
 
   constructor({ exportConfig, stackAPIClient }: ModuleClassParams) {
     super({ exportConfig, stackAPIClient });
     this.exportConfig = exportConfig;
     this.personalizeConfig = exportConfig.modules.personalize;
-    this.exportConfig.context.module = EXPORT_MODULE_CONTEXTS.PERSONALIZE;
-    this.currentModuleName = EXPORT_MODULE_NAMES[EXPORT_MODULE_CONTEXTS.PERSONALIZE];
+    this.exportConfig.context.module = MODULE_CONTEXTS.PERSONALIZE;
+    this.currentModuleName = MODULE_NAMES[MODULE_CONTEXTS.PERSONALIZE];
   }
 
   async start(): Promise<void> {
@@ -124,9 +124,9 @@ export default class ExportPersonalize extends BaseClass {
   }
 
   private addProjectProcess(progress: CLIProgressManager) {
-    progress.addProcess(EXPORT_PROCESS_NAMES.PERSONALIZE_PROJECTS, 1);
+    progress.addProcess(PROCESS_NAMES.PERSONALIZE_PROJECTS, 1);
     log.debug(
-      `Added ${EXPORT_PROCESS_NAMES.PERSONALIZE_PROJECTS} process to personalize progress`,
+      `Added ${PROCESS_NAMES.PERSONALIZE_PROJECTS} process to personalize progress`,
       this.exportConfig.context,
     );
   }
@@ -152,10 +152,10 @@ export default class ExportPersonalize extends BaseClass {
 
   private async exportProjects(progress: CLIProgressManager) {
     progress
-      .startProcess(EXPORT_PROCESS_NAMES.PERSONALIZE_PROJECTS)
+      .startProcess(PROCESS_NAMES.PERSONALIZE_PROJECTS)
       .updateStatus(
-        EXPORT_PROCESS_STATUS[EXPORT_PROCESS_NAMES.PERSONALIZE_PROJECTS].EXPORTING,
-        EXPORT_PROCESS_NAMES.PERSONALIZE_PROJECTS,
+        PROCESS_STATUS[PROCESS_NAMES.PERSONALIZE_PROJECTS].EXPORTING,
+        PROCESS_NAMES.PERSONALIZE_PROJECTS,
       );
     log.debug('Starting projects export for personalization...', this.exportConfig.context);
 
@@ -163,7 +163,7 @@ export default class ExportPersonalize extends BaseClass {
     projectsExporter.setParentProgressManager(progress);
     await projectsExporter.start();
 
-    progress.completeProcess(EXPORT_PROCESS_NAMES.PERSONALIZE_PROJECTS, true);
+    progress.completeProcess(PROCESS_NAMES.PERSONALIZE_PROJECTS, true);
   }
 
   private async exportModules(progress: CLIProgressManager) {
@@ -189,7 +189,7 @@ export default class ExportPersonalize extends BaseClass {
         progress
           .startProcess(processName)
           .updateStatus(
-            (EXPORT_PROCESS_STATUS as any)[processName]?.EXPORTING || `Exporting ${module}...`,
+            (PROCESS_STATUS as any)[processName]?.EXPORTING || `Exporting ${module}...`,
             processName,
           );
         log.debug(`Starting export for module: ${module}`, this.exportConfig.context);

--- a/packages/contentstack-export/src/export/modules/taxonomies.ts
+++ b/packages/contentstack-export/src/export/modules/taxonomies.ts
@@ -7,10 +7,10 @@ import { handleAndLogError, messageHandler, log } from '@contentstack/cli-utilit
 import BaseClass from './base-class';
 import {
   fsUtil,
-  EXPORT_PROCESS_NAMES,
-  EXPORT_MODULE_CONTEXTS,
-  EXPORT_PROCESS_STATUS,
-  EXPORT_MODULE_NAMES,
+  PROCESS_NAMES,
+  MODULE_CONTEXTS,
+  PROCESS_STATUS,
+  MODULE_NAMES,
 } from '../../utils';
 import { ModuleClassParams, ExportConfig } from '../../types';
 
@@ -31,8 +31,8 @@ export default class ExportTaxonomies extends BaseClass {
     this.taxonomiesConfig = exportConfig.modules.taxonomies;
     this.qs = { include_count: true, limit: this.taxonomiesConfig.limit || 100, skip: 0 };
     this.applyQueryFilters(this.qs, 'taxonomies');
-    this.exportConfig.context.module = EXPORT_MODULE_CONTEXTS.TAXONOMIES;
-    this.currentModuleName = EXPORT_MODULE_NAMES[EXPORT_MODULE_CONTEXTS.TAXONOMIES];
+    this.exportConfig.context.module = MODULE_CONTEXTS.TAXONOMIES;
+    this.currentModuleName = MODULE_NAMES[MODULE_CONTEXTS.TAXONOMIES];
   }
 
   async start(): Promise<void> {
@@ -66,18 +66,18 @@ export default class ExportTaxonomies extends BaseClass {
       const progress = this.createNestedProgress(this.currentModuleName);
 
       // Add sub-processes
-      progress.addProcess(EXPORT_PROCESS_NAMES.FETCH_TAXONOMIES, totalCount);
-      progress.addProcess(EXPORT_PROCESS_NAMES.EXPORT_TAXONOMIES_TERMS, totalCount);
+      progress.addProcess(PROCESS_NAMES.FETCH_TAXONOMIES, totalCount);
+      progress.addProcess(PROCESS_NAMES.EXPORT_TAXONOMIES_TERMS, totalCount);
 
       // Fetch taxonomies
       progress
-        .startProcess(EXPORT_PROCESS_NAMES.FETCH_TAXONOMIES)
+        .startProcess(PROCESS_NAMES.FETCH_TAXONOMIES)
         .updateStatus(
-          EXPORT_PROCESS_STATUS[EXPORT_PROCESS_NAMES.FETCH_TAXONOMIES].FETCHING,
-          EXPORT_PROCESS_NAMES.FETCH_TAXONOMIES,
+          PROCESS_STATUS[PROCESS_NAMES.FETCH_TAXONOMIES].FETCHING,
+          PROCESS_NAMES.FETCH_TAXONOMIES,
         );
       await this.getAllTaxonomies();
-      progress.completeProcess(EXPORT_PROCESS_NAMES.FETCH_TAXONOMIES, true);
+      progress.completeProcess(PROCESS_NAMES.FETCH_TAXONOMIES, true);
 
       const actualTaxonomyCount = Object.keys(this.taxonomies)?.length;
       log.debug(
@@ -88,19 +88,19 @@ export default class ExportTaxonomies extends BaseClass {
       // Update progress for export step if counts differ
       if (actualTaxonomyCount !== totalCount && actualTaxonomyCount > 0) {
         // Remove the old process and add with correct count
-        progress.addProcess(EXPORT_PROCESS_NAMES.EXPORT_TAXONOMIES_TERMS, actualTaxonomyCount);
+        progress.addProcess(PROCESS_NAMES.EXPORT_TAXONOMIES_TERMS, actualTaxonomyCount);
       }
 
       // Export detailed taxonomies
       if (actualTaxonomyCount > 0) {
         progress
-          .startProcess(EXPORT_PROCESS_NAMES.EXPORT_TAXONOMIES_TERMS)
+          .startProcess(PROCESS_NAMES.EXPORT_TAXONOMIES_TERMS)
           .updateStatus(
-            EXPORT_PROCESS_STATUS[EXPORT_PROCESS_NAMES.EXPORT_TAXONOMIES_TERMS].EXPORTING,
-            EXPORT_PROCESS_NAMES.EXPORT_TAXONOMIES_TERMS,
+            PROCESS_STATUS[PROCESS_NAMES.EXPORT_TAXONOMIES_TERMS].EXPORTING,
+            PROCESS_NAMES.EXPORT_TAXONOMIES_TERMS,
           );
         await this.exportTaxonomies();
-        progress.completeProcess(EXPORT_PROCESS_NAMES.EXPORT_TAXONOMIES_TERMS, true);
+        progress.completeProcess(PROCESS_NAMES.EXPORT_TAXONOMIES_TERMS, true);
       } else {
         log.info('No taxonomies found to export detailed information', this.exportConfig.context);
       }
@@ -173,7 +173,7 @@ export default class ExportTaxonomies extends BaseClass {
         true,
         `taxonomy: ${taxonomyName || taxonomyUid}`,
         null,
-        EXPORT_PROCESS_NAMES.FETCH_TAXONOMIES,
+        PROCESS_NAMES.FETCH_TAXONOMIES,
       );
     }
 
@@ -210,7 +210,7 @@ export default class ExportTaxonomies extends BaseClass {
         true,
         `taxonomy: ${taxonomyName || uid}`,
         null,
-        EXPORT_PROCESS_NAMES.EXPORT_TAXONOMIES_TERMS,
+        PROCESS_NAMES.EXPORT_TAXONOMIES_TERMS,
       );
 
       log.success(messageHandler.parse('TAXONOMY_EXPORT_SUCCESS', taxonomyName || uid), this.exportConfig.context);
@@ -223,8 +223,8 @@ export default class ExportTaxonomies extends BaseClass {
       this.progressManager?.tick(
         false,
         `taxonomy: ${taxonomyName || uid}`,
-        error?.message || EXPORT_PROCESS_STATUS[EXPORT_PROCESS_NAMES.EXPORT_TAXONOMIES_TERMS].FAILED,
-        EXPORT_PROCESS_NAMES.EXPORT_TAXONOMIES_TERMS,
+        error?.message || PROCESS_STATUS[PROCESS_NAMES.EXPORT_TAXONOMIES_TERMS].FAILED,
+        PROCESS_NAMES.EXPORT_TAXONOMIES_TERMS,
       );
 
       handleAndLogError(

--- a/packages/contentstack-export/src/export/modules/taxonomies.ts
+++ b/packages/contentstack-export/src/export/modules/taxonomies.ts
@@ -5,7 +5,13 @@ import { resolve as pResolve } from 'node:path';
 import { handleAndLogError, messageHandler, log } from '@contentstack/cli-utilities';
 
 import BaseClass from './base-class';
-import { fsUtil } from '../../utils';
+import {
+  fsUtil,
+  EXPORT_PROCESS_NAMES,
+  EXPORT_MODULE_CONTEXTS,
+  EXPORT_PROCESS_STATUS,
+  EXPORT_MODULE_NAMES,
+} from '../../utils';
 import { ModuleClassParams, ExportConfig } from '../../types';
 
 export default class ExportTaxonomies extends BaseClass {
@@ -25,8 +31,8 @@ export default class ExportTaxonomies extends BaseClass {
     this.taxonomiesConfig = exportConfig.modules.taxonomies;
     this.qs = { include_count: true, limit: this.taxonomiesConfig.limit || 100, skip: 0 };
     this.applyQueryFilters(this.qs, 'taxonomies');
-    this.exportConfig.context.module = 'taxonomies';
-    this.currentModuleName = 'Taxonomies';
+    this.exportConfig.context.module = EXPORT_MODULE_CONTEXTS.TAXONOMIES;
+    this.currentModuleName = EXPORT_MODULE_NAMES[EXPORT_MODULE_CONTEXTS.TAXONOMIES];
   }
 
   async start(): Promise<void> {
@@ -60,30 +66,41 @@ export default class ExportTaxonomies extends BaseClass {
       const progress = this.createNestedProgress(this.currentModuleName);
 
       // Add sub-processes
-      progress.addProcess('Fetch', totalCount);
-      progress.addProcess('Taxonomies & Terms', totalCount);
+      progress.addProcess(EXPORT_PROCESS_NAMES.FETCH_TAXONOMIES, totalCount);
+      progress.addProcess(EXPORT_PROCESS_NAMES.EXPORT_TAXONOMIES_TERMS, totalCount);
 
       // Fetch taxonomies
-      progress.startProcess('Fetch').updateStatus('Fetching taxonomy metadata...', 'Fetch');
+      progress
+        .startProcess(EXPORT_PROCESS_NAMES.FETCH_TAXONOMIES)
+        .updateStatus(
+          EXPORT_PROCESS_STATUS[EXPORT_PROCESS_NAMES.FETCH_TAXONOMIES].FETCHING,
+          EXPORT_PROCESS_NAMES.FETCH_TAXONOMIES,
+        );
       await this.getAllTaxonomies();
-      progress.completeProcess('Fetch', true);
+      progress.completeProcess(EXPORT_PROCESS_NAMES.FETCH_TAXONOMIES, true);
 
       const actualTaxonomyCount = Object.keys(this.taxonomies)?.length;
-      log.debug(`Found ${actualTaxonomyCount} taxonomies to export (API reported ${totalCount})`, this.exportConfig.context);
+      log.debug(
+        `Found ${actualTaxonomyCount} taxonomies to export (API reported ${totalCount})`,
+        this.exportConfig.context,
+      );
 
       // Update progress for export step if counts differ
       if (actualTaxonomyCount !== totalCount && actualTaxonomyCount > 0) {
         // Remove the old process and add with correct count
-        progress.addProcess('Taxonomies & Terms', actualTaxonomyCount);
+        progress.addProcess(EXPORT_PROCESS_NAMES.EXPORT_TAXONOMIES_TERMS, actualTaxonomyCount);
       }
 
       // Export detailed taxonomies
       if (actualTaxonomyCount > 0) {
         progress
-          .startProcess('Taxonomies & Terms')
-          .updateStatus('Exporting taxonomy details...', 'Taxonomies & Terms');
+          .startProcess(EXPORT_PROCESS_NAMES.EXPORT_TAXONOMIES_TERMS)
+          .updateStatus(
+            EXPORT_PROCESS_STATUS[EXPORT_PROCESS_NAMES.EXPORT_TAXONOMIES_TERMS].EXPORTING,
+            EXPORT_PROCESS_NAMES.EXPORT_TAXONOMIES_TERMS,
+          );
         await this.exportTaxonomies();
-        progress.completeProcess('Taxonomies & Terms', true);
+        progress.completeProcess(EXPORT_PROCESS_NAMES.EXPORT_TAXONOMIES_TERMS, true);
       } else {
         log.info('No taxonomies found to export detailed information', this.exportConfig.context);
       }
@@ -152,7 +169,12 @@ export default class ExportTaxonomies extends BaseClass {
       }
 
       // Track progress for each taxonomy
-      this.progressManager?.tick(true, `taxonomy: ${taxonomyName || taxonomyUid}`, null, 'Fetch');
+      this.progressManager?.tick(
+        true,
+        `taxonomy: ${taxonomyName || taxonomyUid}`,
+        null,
+        EXPORT_PROCESS_NAMES.FETCH_TAXONOMIES,
+      );
     }
 
     log.debug(
@@ -184,7 +206,12 @@ export default class ExportTaxonomies extends BaseClass {
       fsUtil.writeFile(filePath, response);
 
       // Track progress for each exported taxonomy
-      this.progressManager?.tick(true, `taxonomy: ${taxonomyName || uid}`, null, 'Taxonomies & Terms');
+      this.progressManager?.tick(
+        true,
+        `taxonomy: ${taxonomyName || uid}`,
+        null,
+        EXPORT_PROCESS_NAMES.EXPORT_TAXONOMIES_TERMS,
+      );
 
       log.success(messageHandler.parse('TAXONOMY_EXPORT_SUCCESS', taxonomyName || uid), this.exportConfig.context);
     };
@@ -196,8 +223,8 @@ export default class ExportTaxonomies extends BaseClass {
       this.progressManager?.tick(
         false,
         `taxonomy: ${taxonomyName || uid}`,
-        error?.message || 'Export failed',
-        'Taxonomies & Terms',
+        error?.message || EXPORT_PROCESS_STATUS[EXPORT_PROCESS_NAMES.EXPORT_TAXONOMIES_TERMS].FAILED,
+        EXPORT_PROCESS_NAMES.EXPORT_TAXONOMIES_TERMS,
       );
 
       handleAndLogError(
@@ -209,7 +236,7 @@ export default class ExportTaxonomies extends BaseClass {
 
     const taxonomyUids = keys(this.taxonomies);
     log.debug(`Starting detailed export for ${taxonomyUids.length} taxonomies`, this.exportConfig.context);
-    
+
     // Export each taxonomy individually
     for (const uid of taxonomyUids) {
       try {
@@ -224,7 +251,7 @@ export default class ExportTaxonomies extends BaseClass {
         onReject({ error, uid });
       }
     }
-    
+
     // Write the taxonomies index file
     const taxonomiesFilePath = pResolve(this.taxonomiesFolderPath, this.taxonomiesConfig.fileName);
     log.debug(`Writing taxonomies index to: ${taxonomiesFilePath}`, this.exportConfig.context);

--- a/packages/contentstack-export/src/export/modules/webhooks.ts
+++ b/packages/contentstack-export/src/export/modules/webhooks.ts
@@ -5,7 +5,7 @@ import { handleAndLogError, messageHandler, log } from '@contentstack/cli-utilit
 
 import BaseClass from './base-class';
 import { WebhookConfig, ModuleClassParams } from '../../types';
-import { fsUtil, EXPORT_MODULE_CONTEXTS, EXPORT_MODULE_NAMES } from '../../utils';
+import { fsUtil, MODULE_CONTEXTS, MODULE_NAMES } from '../../utils';
 
 export default class ExportWebhooks extends BaseClass {
   private webhooks: Record<string, Record<string, string>>;
@@ -22,8 +22,8 @@ export default class ExportWebhooks extends BaseClass {
     this.webhooks = {};
     this.webhookConfig = exportConfig.modules.webhooks;
     this.qs = { include_count: true, asc: 'updated_at' };
-    this.exportConfig.context.module = EXPORT_MODULE_CONTEXTS.WEBHOOKS;
-    this.currentModuleName = EXPORT_MODULE_NAMES[EXPORT_MODULE_CONTEXTS.WEBHOOKS];
+    this.exportConfig.context.module = MODULE_CONTEXTS.WEBHOOKS;
+    this.currentModuleName = MODULE_NAMES[MODULE_CONTEXTS.WEBHOOKS];
   }
 
   async start(): Promise<void> {

--- a/packages/contentstack-export/src/export/modules/webhooks.ts
+++ b/packages/contentstack-export/src/export/modules/webhooks.ts
@@ -4,8 +4,8 @@ import { resolve as pResolve } from 'node:path';
 import { handleAndLogError, messageHandler, log } from '@contentstack/cli-utilities';
 
 import BaseClass from './base-class';
-import { fsUtil } from '../../utils';
 import { WebhookConfig, ModuleClassParams } from '../../types';
+import { fsUtil, EXPORT_MODULE_CONTEXTS, EXPORT_MODULE_NAMES } from '../../utils';
 
 export default class ExportWebhooks extends BaseClass {
   private webhooks: Record<string, Record<string, string>>;
@@ -22,8 +22,8 @@ export default class ExportWebhooks extends BaseClass {
     this.webhooks = {};
     this.webhookConfig = exportConfig.modules.webhooks;
     this.qs = { include_count: true, asc: 'updated_at' };
-    this.exportConfig.context.module = 'webhooks';
-    this.currentModuleName = 'Webhooks';
+    this.exportConfig.context.module = EXPORT_MODULE_CONTEXTS.WEBHOOKS;
+    this.currentModuleName = EXPORT_MODULE_NAMES[EXPORT_MODULE_CONTEXTS.WEBHOOKS];
   }
 
   async start(): Promise<void> {

--- a/packages/contentstack-export/src/export/modules/workflows.ts
+++ b/packages/contentstack-export/src/export/modules/workflows.ts
@@ -4,8 +4,8 @@ import { resolve as pResolve } from 'node:path';
 import { handleAndLogError, messageHandler, log } from '@contentstack/cli-utilities';
 
 import BaseClass from './base-class';
-import { fsUtil } from '../../utils';
 import { WorkflowConfig, ModuleClassParams } from '../../types';
+import { fsUtil, EXPORT_MODULE_CONTEXTS, EXPORT_MODULE_NAMES } from '../../utils';
 
 export default class ExportWorkFlows extends BaseClass {
   private workflows: Record<string, Record<string, string>>;
@@ -21,8 +21,8 @@ export default class ExportWorkFlows extends BaseClass {
     this.workflows = {};
     this.workflowConfig = exportConfig.modules.workflows;
     this.qs = { include_count: true };
-    this.exportConfig.context.module = 'workflows';
-    this.currentModuleName = 'Workflows';
+    this.exportConfig.context.module = EXPORT_MODULE_CONTEXTS.WORKFLOWS;
+    this.currentModuleName = EXPORT_MODULE_NAMES[EXPORT_MODULE_CONTEXTS.WORKFLOWS];
   }
 
   async start(): Promise<void> {
@@ -52,7 +52,7 @@ export default class ExportWorkFlows extends BaseClass {
       }
 
       // Create nested progress manager for complex workflow processing
-      const progress = this.createSimpleProgress(this.currentModuleName, totalCount)
+      const progress = this.createSimpleProgress(this.currentModuleName, totalCount);
 
       // Fetch workflows
       progress.updateStatus('Fetching workflow definitions...');
@@ -129,15 +129,10 @@ export default class ExportWorkFlows extends BaseClass {
         log.success(messageHandler.parse('WORKFLOW_EXPORT_SUCCESS', workflowName), this.exportConfig.context);
 
         // Track progress for each workflow
-        this.progressManager?.tick(true, `workflow: ${workflowName}`, null, 'Fetch');
+        this.progressManager?.tick(true, `workflow: ${workflowName}`);
       } catch (error) {
         log.error(`Failed to process workflow: ${workflowName}`, this.exportConfig.context);
-        this.progressManager?.tick(
-          false,
-          `workflow: ${workflowName}`,
-          error?.message || 'Processing failed',
-          'Fetch',
-        );
+        this.progressManager?.tick(false, `workflow: ${workflowName}`, error?.message || 'Processing failed', 'Fetch');
       }
     }
 
@@ -160,7 +155,6 @@ export default class ExportWorkFlows extends BaseClass {
         try {
           const roleData = await this.getRoles(roleUid);
           stage.SYS_ACL.roles.uids[i] = roleData;
-
         } catch (error) {
           log.error(`Failed to fetch role ${roleUid}`, this.exportConfig.context);
         }

--- a/packages/contentstack-export/src/export/modules/workflows.ts
+++ b/packages/contentstack-export/src/export/modules/workflows.ts
@@ -5,7 +5,7 @@ import { handleAndLogError, messageHandler, log } from '@contentstack/cli-utilit
 
 import BaseClass from './base-class';
 import { WorkflowConfig, ModuleClassParams } from '../../types';
-import { fsUtil, EXPORT_MODULE_CONTEXTS, EXPORT_MODULE_NAMES } from '../../utils';
+import { fsUtil, MODULE_CONTEXTS, MODULE_NAMES } from '../../utils';
 
 export default class ExportWorkFlows extends BaseClass {
   private workflows: Record<string, Record<string, string>>;
@@ -21,8 +21,8 @@ export default class ExportWorkFlows extends BaseClass {
     this.workflows = {};
     this.workflowConfig = exportConfig.modules.workflows;
     this.qs = { include_count: true };
-    this.exportConfig.context.module = EXPORT_MODULE_CONTEXTS.WORKFLOWS;
-    this.currentModuleName = EXPORT_MODULE_NAMES[EXPORT_MODULE_CONTEXTS.WORKFLOWS];
+    this.exportConfig.context.module = MODULE_CONTEXTS.WORKFLOWS;
+    this.currentModuleName = MODULE_NAMES[MODULE_CONTEXTS.WORKFLOWS];
   }
 
   async start(): Promise<void> {

--- a/packages/contentstack-export/src/utils/constants.ts
+++ b/packages/contentstack-export/src/utils/constants.ts
@@ -1,4 +1,4 @@
-export const EXPORT_PROCESS_NAMES = {
+export const PROCESS_NAMES = {
   // Assets module
   ASSET_FOLDERS: 'Folders',
   ASSET_METADATA: 'Metadata',
@@ -35,7 +35,7 @@ export const EXPORT_PROCESS_NAMES = {
   PERSONALIZE_EXPERIENCES: 'Experiences',
 } as const;
 
-export const EXPORT_MODULE_CONTEXTS = {
+export const MODULE_CONTEXTS = {
   ASSETS: 'assets',
   CONTENT_TYPES: 'content-types',
   CUSTOM_ROLES: 'custom-roles',
@@ -54,117 +54,117 @@ export const EXPORT_MODULE_CONTEXTS = {
 } as const;
 
 // Display names for modules to avoid scattering user-facing strings
-export const EXPORT_MODULE_NAMES = {
-  [EXPORT_MODULE_CONTEXTS.ASSETS]: 'Assets',
-  [EXPORT_MODULE_CONTEXTS.CONTENT_TYPES]: 'Content Types',
-  [EXPORT_MODULE_CONTEXTS.CUSTOM_ROLES]: 'Custom Roles',
-  [EXPORT_MODULE_CONTEXTS.ENTRIES]: 'Entries',
-  [EXPORT_MODULE_CONTEXTS.ENVIRONMENTS]: 'Environments',
-  [EXPORT_MODULE_CONTEXTS.EXTENSIONS]: 'Extensions',
-  [EXPORT_MODULE_CONTEXTS.GLOBAL_FIELDS]: 'Global Fields',
-  [EXPORT_MODULE_CONTEXTS.LABELS]: 'Labels',
-  [EXPORT_MODULE_CONTEXTS.LOCALES]: 'Locales',
-  [EXPORT_MODULE_CONTEXTS.MARKETPLACE_APPS]: 'Marketplace Apps',
-  [EXPORT_MODULE_CONTEXTS.PERSONALIZE]: 'Personalize',
-  [EXPORT_MODULE_CONTEXTS.STACK]: 'Stack',
-  [EXPORT_MODULE_CONTEXTS.TAXONOMIES]: 'Taxonomies',
-  [EXPORT_MODULE_CONTEXTS.WEBHOOKS]: 'Webhooks',
-  [EXPORT_MODULE_CONTEXTS.WORKFLOWS]: 'Workflows',
+export const MODULE_NAMES = {
+  [MODULE_CONTEXTS.ASSETS]: 'Assets',
+  [MODULE_CONTEXTS.CONTENT_TYPES]: 'Content Types',
+  [MODULE_CONTEXTS.CUSTOM_ROLES]: 'Custom Roles',
+  [MODULE_CONTEXTS.ENTRIES]: 'Entries',
+  [MODULE_CONTEXTS.ENVIRONMENTS]: 'Environments',
+  [MODULE_CONTEXTS.EXTENSIONS]: 'Extensions',
+  [MODULE_CONTEXTS.GLOBAL_FIELDS]: 'Global Fields',
+  [MODULE_CONTEXTS.LABELS]: 'Labels',
+  [MODULE_CONTEXTS.LOCALES]: 'Locales',
+  [MODULE_CONTEXTS.MARKETPLACE_APPS]: 'Marketplace Apps',
+  [MODULE_CONTEXTS.PERSONALIZE]: 'Personalize',
+  [MODULE_CONTEXTS.STACK]: 'Stack',
+  [MODULE_CONTEXTS.TAXONOMIES]: 'Taxonomies',
+  [MODULE_CONTEXTS.WEBHOOKS]: 'Webhooks',
+  [MODULE_CONTEXTS.WORKFLOWS]: 'Workflows',
 } as const;
 
-export const EXPORT_PROCESS_STATUS = {
-  [EXPORT_PROCESS_NAMES.ASSET_FOLDERS]: {
+export const PROCESS_STATUS = {
+  [PROCESS_NAMES.ASSET_FOLDERS]: {
     FETCHING: 'Fetching folder structure...',
     FAILED: 'Failed to fetch folder structure.',
   },
-  [EXPORT_PROCESS_NAMES.ASSET_METADATA]: {
+  [PROCESS_NAMES.ASSET_METADATA]: {
     FETCHING: 'Fetching asset information...',
     FAILED: 'Failed to fetch asset',
     FETCHING_VERSION: 'Processing versioned assets...',
   },
-  [EXPORT_PROCESS_NAMES.ASSET_DOWNLOADS]: {
+  [PROCESS_NAMES.ASSET_DOWNLOADS]: {
     DOWNLOADING: 'Downloading asset file...',
     FAILED: 'Failed to download asset:',
   },
   // Custom Roles
-  [EXPORT_PROCESS_NAMES.FETCH_ROLES]: {
+  [PROCESS_NAMES.FETCH_ROLES]: {
     FETCHING: 'Fetching custom roles...',
     FAILED: 'Failed to fetch custom roles.',
   },
-  [EXPORT_PROCESS_NAMES.FETCH_LOCALES]: {
+  [PROCESS_NAMES.FETCH_LOCALES]: {
     FETCHING: 'Fetching locales...',
     FAILED: 'Failed to fetch locales.',
   },
-  [EXPORT_PROCESS_NAMES.PROCESS_MAPPINGS]: {
+  [PROCESS_NAMES.PROCESS_MAPPINGS]: {
     PROCESSING: 'Processing role-locale mappings...',
     FAILED: 'Failed to process role-locale mappings.',
   },
-  [EXPORT_PROCESS_NAMES.ENTRIES]: {
+  [PROCESS_NAMES.ENTRIES]: {
     PROCESSING: 'Processing entry collections...',
     FAILED: 'Failed to export entries.',
   },
-  [EXPORT_PROCESS_NAMES.ENTRY_VERSIONS]: {
+  [PROCESS_NAMES.ENTRY_VERSIONS]: {
     PROCESSING: 'Processing entry versions...',
     FAILED: 'Failed to export entry versions.',
   },
-  [EXPORT_PROCESS_NAMES.VARIANT_ENTRIES]: {
+  [PROCESS_NAMES.VARIANT_ENTRIES]: {
     PROCESSING: 'Processing variant entries...',
     FAILED: 'Failed to export variant entries.',
   },
   // Marketplace Apps
-  [EXPORT_PROCESS_NAMES.FETCH_APPS]: {
+  [PROCESS_NAMES.FETCH_APPS]: {
     FETCHING: 'Fetching marketplace apps...',
     FAILED: 'Failed to fetch marketplace apps.',
   },
-  [EXPORT_PROCESS_NAMES.FETCH_CONFIG_MANIFEST]: {
+  [PROCESS_NAMES.FETCH_CONFIG_MANIFEST]: {
     PROCESSING: 'Processing app manifests and configurations...',
     FAILED: 'Failed to process app manifests/configurations.',
   },
   // Stack
-  [EXPORT_PROCESS_NAMES.STACK_SETTINGS]: {
+  [PROCESS_NAMES.STACK_SETTINGS]: {
     EXPORTING: 'Exporting stack settings...',
     FAILED: 'Failed to export stack settings.',
   },
-  [EXPORT_PROCESS_NAMES.STACK_LOCALE]: {
+  [PROCESS_NAMES.STACK_LOCALE]: {
     FETCHING: 'Fetching master locale...',
     FAILED: 'Failed to fetch master locale.',
   },
-  [EXPORT_PROCESS_NAMES.STACK_DETAILS]: {
+  [PROCESS_NAMES.STACK_DETAILS]: {
     EXPORTING: 'Exporting stack data...',
     FAILED: 'Failed to export stack data.',
   },
   // Taxonomies
-  [EXPORT_PROCESS_NAMES.FETCH_TAXONOMIES]: {
+  [PROCESS_NAMES.FETCH_TAXONOMIES]: {
     FETCHING: 'Fetching taxonomy metadata...',
     FAILED: 'Failed to fetch taxonomies.',
   },
-  [EXPORT_PROCESS_NAMES.EXPORT_TAXONOMIES_TERMS]: {
+  [PROCESS_NAMES.EXPORT_TAXONOMIES_TERMS]: {
     EXPORTING: 'Exporting taxonomy details...',
     FAILED: 'Failed to export taxonomy details.',
   },
   // Personalize
-  [EXPORT_PROCESS_NAMES.PERSONALIZE_PROJECTS]: {
+  [PROCESS_NAMES.PERSONALIZE_PROJECTS]: {
     EXPORTING: 'Exporting personalization projects...',
     FAILED: 'Failed to export personalization projects.',
   },
-  [EXPORT_PROCESS_NAMES.PERSONALIZE_EVENTS]: {
+  [PROCESS_NAMES.PERSONALIZE_EVENTS]: {
     EXPORTING: 'Exporting events...',
     FAILED: 'Failed to export events.',
   },
-  [EXPORT_PROCESS_NAMES.PERSONALIZE_ATTRIBUTES]: {
+  [PROCESS_NAMES.PERSONALIZE_ATTRIBUTES]: {
     EXPORTING: 'Exporting attributes...',
     FAILED: 'Failed to export attributes.',
   },
-  [EXPORT_PROCESS_NAMES.PERSONALIZE_AUDIENCES]: {
+  [PROCESS_NAMES.PERSONALIZE_AUDIENCES]: {
     EXPORTING: 'Exporting audiences...',
     FAILED: 'Failed to export audiences.',
   },
-  [EXPORT_PROCESS_NAMES.PERSONALIZE_EXPERIENCES]: {
+  [PROCESS_NAMES.PERSONALIZE_EXPERIENCES]: {
     EXPORTING: 'Exporting experiences...',
     FAILED: 'Failed to export experiences.',
   },
 };
 
-export type ExportProcessName = (typeof EXPORT_PROCESS_NAMES)[keyof typeof EXPORT_PROCESS_NAMES];
-export type ExportModuleContext = (typeof EXPORT_MODULE_CONTEXTS)[keyof typeof EXPORT_MODULE_CONTEXTS];
-export type ExportProcessStatus = (typeof EXPORT_PROCESS_STATUS)[keyof typeof EXPORT_PROCESS_STATUS];
+export type ExportProcessName = (typeof PROCESS_NAMES)[keyof typeof PROCESS_NAMES];
+export type ExportModuleContext = (typeof MODULE_CONTEXTS)[keyof typeof MODULE_CONTEXTS];
+export type ExportProcessStatus = (typeof PROCESS_STATUS)[keyof typeof PROCESS_STATUS];

--- a/packages/contentstack-export/src/utils/constants.ts
+++ b/packages/contentstack-export/src/utils/constants.ts
@@ -1,0 +1,170 @@
+export const EXPORT_PROCESS_NAMES = {
+  // Assets module
+  ASSET_FOLDERS: 'Folders',
+  ASSET_METADATA: 'Metadata',
+  ASSET_DOWNLOADS: 'Downloads',
+
+  // Custom Roles module
+  FETCH_ROLES: 'Fetch Roles',
+  FETCH_LOCALES: 'Fetch Locales',
+  PROCESS_MAPPINGS: 'Process Mappings',
+
+  // Entries module
+  ENTRIES: 'Entries',
+  ENTRY_VERSIONS: 'Entry Versions',
+  VARIANT_ENTRIES: 'Variant Entries',
+
+  // Marketplace Apps module
+  FETCH_APPS: 'Fetch Apps',
+  FETCH_CONFIG_MANIFEST: 'Fetch config & manifest',
+
+  // Stack module
+  STACK_SETTINGS: 'Settings',
+  STACK_LOCALE: 'Locale',
+  STACK_DETAILS: 'Details',
+
+  // Taxonomies module
+  FETCH_TAXONOMIES: 'Fetch Taxonomies',
+  EXPORT_TAXONOMIES_TERMS: 'Taxonomies & Terms',
+
+  // Personalize module
+  PERSONALIZE_PROJECTS: 'Projects',
+  PERSONALIZE_EVENTS: 'Events',
+  PERSONALIZE_ATTRIBUTES: 'Attributes',
+  PERSONALIZE_AUDIENCES: 'Audiences',
+  PERSONALIZE_EXPERIENCES: 'Experiences',
+} as const;
+
+export const EXPORT_MODULE_CONTEXTS = {
+  ASSETS: 'assets',
+  CONTENT_TYPES: 'content-types',
+  CUSTOM_ROLES: 'custom-roles',
+  ENTRIES: 'entries',
+  ENVIRONMENTS: 'environments',
+  EXTENSIONS: 'extensions',
+  GLOBAL_FIELDS: 'global-fields',
+  LABELS: 'labels',
+  LOCALES: 'locales',
+  MARKETPLACE_APPS: 'marketplace-apps',
+  PERSONALIZE: 'personalize',
+  STACK: 'stack',
+  TAXONOMIES: 'taxonomies',
+  WEBHOOKS: 'webhooks',
+  WORKFLOWS: 'workflows',
+} as const;
+
+// Display names for modules to avoid scattering user-facing strings
+export const EXPORT_MODULE_NAMES = {
+  [EXPORT_MODULE_CONTEXTS.ASSETS]: 'Assets',
+  [EXPORT_MODULE_CONTEXTS.CONTENT_TYPES]: 'Content Types',
+  [EXPORT_MODULE_CONTEXTS.CUSTOM_ROLES]: 'Custom Roles',
+  [EXPORT_MODULE_CONTEXTS.ENTRIES]: 'Entries',
+  [EXPORT_MODULE_CONTEXTS.ENVIRONMENTS]: 'Environments',
+  [EXPORT_MODULE_CONTEXTS.EXTENSIONS]: 'Extensions',
+  [EXPORT_MODULE_CONTEXTS.GLOBAL_FIELDS]: 'Global Fields',
+  [EXPORT_MODULE_CONTEXTS.LABELS]: 'Labels',
+  [EXPORT_MODULE_CONTEXTS.LOCALES]: 'Locales',
+  [EXPORT_MODULE_CONTEXTS.MARKETPLACE_APPS]: 'Marketplace Apps',
+  [EXPORT_MODULE_CONTEXTS.PERSONALIZE]: 'Personalize',
+  [EXPORT_MODULE_CONTEXTS.STACK]: 'Stack',
+  [EXPORT_MODULE_CONTEXTS.TAXONOMIES]: 'Taxonomies',
+  [EXPORT_MODULE_CONTEXTS.WEBHOOKS]: 'Webhooks',
+  [EXPORT_MODULE_CONTEXTS.WORKFLOWS]: 'Workflows',
+} as const;
+
+export const EXPORT_PROCESS_STATUS = {
+  [EXPORT_PROCESS_NAMES.ASSET_FOLDERS]: {
+    FETCHING: 'Fetching folder structure...',
+    FAILED: 'Failed to fetch folder structure.',
+  },
+  [EXPORT_PROCESS_NAMES.ASSET_METADATA]: {
+    FETCHING: 'Fetching asset information...',
+    FAILED: 'Failed to fetch asset',
+    FETCHING_VERSION: 'Processing versioned assets...',
+  },
+  [EXPORT_PROCESS_NAMES.ASSET_DOWNLOADS]: {
+    DOWNLOADING: 'Downloading asset file...',
+    FAILED: 'Failed to download asset:',
+  },
+  // Custom Roles
+  [EXPORT_PROCESS_NAMES.FETCH_ROLES]: {
+    FETCHING: 'Fetching custom roles...',
+    FAILED: 'Failed to fetch custom roles.',
+  },
+  [EXPORT_PROCESS_NAMES.FETCH_LOCALES]: {
+    FETCHING: 'Fetching locales...',
+    FAILED: 'Failed to fetch locales.',
+  },
+  [EXPORT_PROCESS_NAMES.PROCESS_MAPPINGS]: {
+    PROCESSING: 'Processing role-locale mappings...',
+    FAILED: 'Failed to process role-locale mappings.',
+  },
+  [EXPORT_PROCESS_NAMES.ENTRIES]: {
+    PROCESSING: 'Processing entry collections...',
+    FAILED: 'Failed to export entries.',
+  },
+  [EXPORT_PROCESS_NAMES.ENTRY_VERSIONS]: {
+    PROCESSING: 'Processing entry versions...',
+    FAILED: 'Failed to export entry versions.',
+  },
+  [EXPORT_PROCESS_NAMES.VARIANT_ENTRIES]: {
+    PROCESSING: 'Processing variant entries...',
+    FAILED: 'Failed to export variant entries.',
+  },
+  // Marketplace Apps
+  [EXPORT_PROCESS_NAMES.FETCH_APPS]: {
+    FETCHING: 'Fetching marketplace apps...',
+    FAILED: 'Failed to fetch marketplace apps.',
+  },
+  [EXPORT_PROCESS_NAMES.FETCH_CONFIG_MANIFEST]: {
+    PROCESSING: 'Processing app manifests and configurations...',
+    FAILED: 'Failed to process app manifests/configurations.',
+  },
+  // Stack
+  [EXPORT_PROCESS_NAMES.STACK_SETTINGS]: {
+    EXPORTING: 'Exporting stack settings...',
+    FAILED: 'Failed to export stack settings.',
+  },
+  [EXPORT_PROCESS_NAMES.STACK_LOCALE]: {
+    FETCHING: 'Fetching master locale...',
+    FAILED: 'Failed to fetch master locale.',
+  },
+  [EXPORT_PROCESS_NAMES.STACK_DETAILS]: {
+    EXPORTING: 'Exporting stack data...',
+    FAILED: 'Failed to export stack data.',
+  },
+  // Taxonomies
+  [EXPORT_PROCESS_NAMES.FETCH_TAXONOMIES]: {
+    FETCHING: 'Fetching taxonomy metadata...',
+    FAILED: 'Failed to fetch taxonomies.',
+  },
+  [EXPORT_PROCESS_NAMES.EXPORT_TAXONOMIES_TERMS]: {
+    EXPORTING: 'Exporting taxonomy details...',
+    FAILED: 'Failed to export taxonomy details.',
+  },
+  // Personalize
+  [EXPORT_PROCESS_NAMES.PERSONALIZE_PROJECTS]: {
+    EXPORTING: 'Exporting personalization projects...',
+    FAILED: 'Failed to export personalization projects.',
+  },
+  [EXPORT_PROCESS_NAMES.PERSONALIZE_EVENTS]: {
+    EXPORTING: 'Exporting events...',
+    FAILED: 'Failed to export events.',
+  },
+  [EXPORT_PROCESS_NAMES.PERSONALIZE_ATTRIBUTES]: {
+    EXPORTING: 'Exporting attributes...',
+    FAILED: 'Failed to export attributes.',
+  },
+  [EXPORT_PROCESS_NAMES.PERSONALIZE_AUDIENCES]: {
+    EXPORTING: 'Exporting audiences...',
+    FAILED: 'Failed to export audiences.',
+  },
+  [EXPORT_PROCESS_NAMES.PERSONALIZE_EXPERIENCES]: {
+    EXPORTING: 'Exporting experiences...',
+    FAILED: 'Failed to export experiences.',
+  },
+};
+
+export type ExportProcessName = (typeof EXPORT_PROCESS_NAMES)[keyof typeof EXPORT_PROCESS_NAMES];
+export type ExportModuleContext = (typeof EXPORT_MODULE_CONTEXTS)[keyof typeof EXPORT_MODULE_CONTEXTS];
+export type ExportProcessStatus = (typeof EXPORT_PROCESS_STATUS)[keyof typeof EXPORT_PROCESS_STATUS];

--- a/packages/contentstack-export/src/utils/index.ts
+++ b/packages/contentstack-export/src/utils/index.ts
@@ -8,3 +8,4 @@ export { log, unlinkFileLogger } from './logger';
 export { default as login } from './basic-login';
 export * from './common-helper';
 export * from './marketplace-app-helper';
+export { EXPORT_MODULE_CONTEXTS, EXPORT_MODULE_NAMES, EXPORT_PROCESS_NAMES, EXPORT_PROCESS_STATUS } from './constants';

--- a/packages/contentstack-export/src/utils/index.ts
+++ b/packages/contentstack-export/src/utils/index.ts
@@ -8,4 +8,4 @@ export { log, unlinkFileLogger } from './logger';
 export { default as login } from './basic-login';
 export * from './common-helper';
 export * from './marketplace-app-helper';
-export { EXPORT_MODULE_CONTEXTS, EXPORT_MODULE_NAMES, EXPORT_PROCESS_NAMES, EXPORT_PROCESS_STATUS } from './constants';
+export { MODULE_CONTEXTS, MODULE_NAMES, PROCESS_NAMES, PROCESS_STATUS } from './constants';

--- a/packages/contentstack-export/src/utils/marketplace-app-helper.ts
+++ b/packages/contentstack-export/src/utils/marketplace-app-helper.ts
@@ -29,23 +29,27 @@ export async function createNodeCryptoInstance(config: ExportConfig): Promise<No
 
   if (config.forceStopMarketplaceAppsPrompt) {
     cryptoArgs['encryptionKey'] = config.marketplaceAppEncryptionKey;
+  } else if (config.marketplaceAppEncryptionKey) {
+    cryptoArgs['encryptionKey'] = config.marketplaceAppEncryptionKey;
   } else {
-    // Add spacing
     cliux.print('');
-
-    cryptoArgs['encryptionKey'] = await cliux.inquire({
-      type: 'input',
-      name: 'name',
-      default: config.marketplaceAppEncryptionKey,
-      validate: (url: any) => {
-        if (!url) return "Encryption key can't be empty.";
-
-        return true;
-      },
-      message: 'Enter Marketplace app configurations encryption key',
-    });
+    cryptoArgs['encryptionKey'] = await askEncryptionKey(config);
     cliux.print('');
   }
 
   return new NodeCrypto(cryptoArgs);
+}
+
+export async function askEncryptionKey(config: ExportConfig): Promise<string> {
+  return await cliux.inquire({
+    type: 'input',
+    name: 'name',
+    default: config.marketplaceAppEncryptionKey,
+    validate: (url: any) => {
+      if (!url) return "Encryption key can't be empty.";
+
+      return true;
+    },
+    message: 'Enter Marketplace app configurations encryption key',
+  });
 }

--- a/packages/contentstack-export/src/utils/strategy-registrations.ts
+++ b/packages/contentstack-export/src/utils/strategy-registrations.ts
@@ -1,142 +1,113 @@
+import { MODULE_CONTEXTS, MODULE_NAMES, PROCESS_NAMES } from './constants';
 /**
  * Progress Strategy Registrations for Export Modules
  * This file registers progress calculation strategies for all export modules
  * to ensure correct item counts in the final summary.
  */
 
-import { 
-  ProgressStrategyRegistry, 
-  PrimaryProcessStrategy, 
+import {
+  ProgressStrategyRegistry,
+  PrimaryProcessStrategy,
   CustomProgressStrategy,
-  DefaultProgressStrategy 
+  DefaultProgressStrategy,
 } from '@contentstack/cli-utilities';
 
-// Register strategy for Content Types - simple module
+ProgressStrategyRegistry.register(MODULE_NAMES[MODULE_CONTEXTS.CONTENT_TYPES], new DefaultProgressStrategy());
+
+// Register strategy for Assets - use Asset Metadata as primary process
 ProgressStrategyRegistry.register(
-  'CONTENT TYPES',
-  new DefaultProgressStrategy() 
+  MODULE_NAMES[MODULE_CONTEXTS.ASSETS],
+  new PrimaryProcessStrategy(PROCESS_NAMES.ASSET_METADATA),
 );
 
-// Register strategy for Assets - use Asset Metadata as primary process  
-ProgressStrategyRegistry.register(
-  'ASSETS',
-  new PrimaryProcessStrategy('Metadata')
-);
+ProgressStrategyRegistry.register(MODULE_NAMES[MODULE_CONTEXTS.GLOBAL_FIELDS], new DefaultProgressStrategy());
 
-// Register strategy for Global Fields - simple module
-ProgressStrategyRegistry.register(
-  'GLOBAL FIELDS',
-  new DefaultProgressStrategy()
-);
-
-// Register strategy for Extensions - simple module
-ProgressStrategyRegistry.register(
-  'EXTENSIONS',
-  new DefaultProgressStrategy()
-);
+ProgressStrategyRegistry.register(MODULE_NAMES[MODULE_CONTEXTS.EXTENSIONS], new DefaultProgressStrategy());
 
 // Register strategy for Environments - simple module
-ProgressStrategyRegistry.register(
-  'ENVIRONMENTS',
-  new DefaultProgressStrategy()
-);
+ProgressStrategyRegistry.register(MODULE_NAMES[MODULE_CONTEXTS.ENVIRONMENTS], new DefaultProgressStrategy());
 
-// Register strategy for Locales - simple module
-ProgressStrategyRegistry.register(
-  'LOCALES',
-  new DefaultProgressStrategy()
-);
+ProgressStrategyRegistry.register(MODULE_NAMES[MODULE_CONTEXTS.LOCALES], new DefaultProgressStrategy());
 
-// Register strategy for Labels - simple module
-ProgressStrategyRegistry.register(
-  'LABELS',
-  new DefaultProgressStrategy()
-);
+ProgressStrategyRegistry.register(MODULE_NAMES[MODULE_CONTEXTS.LABELS], new DefaultProgressStrategy());
 
-// Register strategy for Webhooks - simple module
-ProgressStrategyRegistry.register(
-  'WEBHOOKS',
-  new DefaultProgressStrategy()
-);
+ProgressStrategyRegistry.register(MODULE_NAMES[MODULE_CONTEXTS.WEBHOOKS], new DefaultProgressStrategy());
 
-// Register strategy for Workflows - simple module
-ProgressStrategyRegistry.register(
-  'WORKFLOWS',
-  new DefaultProgressStrategy()
-);
+ProgressStrategyRegistry.register(MODULE_NAMES[MODULE_CONTEXTS.WORKFLOWS], new DefaultProgressStrategy());
 
-// Register strategy for Custom Roles - simple module
-ProgressStrategyRegistry.register(
-  'CUSTOM ROLES',
-  new DefaultProgressStrategy()
-);
+ProgressStrategyRegistry.register(MODULE_NAMES[MODULE_CONTEXTS.CUSTOM_ROLES], new DefaultProgressStrategy());
 
 // Register strategy for Taxonomies - use Taxonomies & Terms as primary process
 ProgressStrategyRegistry.register(
-  'TAXONOMIES',
-  new PrimaryProcessStrategy('Taxonomies & Terms')
+  MODULE_NAMES[MODULE_CONTEXTS.TAXONOMIES],
+  new PrimaryProcessStrategy(PROCESS_NAMES.EXPORT_TAXONOMIES_TERMS),
 );
 
 // Register strategy for Marketplace Apps - complex module with app installations
 ProgressStrategyRegistry.register(
-  'MARKETPLACE APPS',
+  MODULE_NAMES[MODULE_CONTEXTS.MARKETPLACE_APPS],
   new CustomProgressStrategy((processes) => {
     // For marketplace apps, count the actual apps exported
-    const appsExport = processes.get('Fetch');
+    const appsExport = processes.get(PROCESS_NAMES.FETCH_APPS);
     if (appsExport) {
       return {
         total: appsExport.total,
         success: appsExport.successCount,
-        failures: appsExport.failureCount
+        failures: appsExport.failureCount,
       };
     }
-    
-    // Fallback to setup process if no export process
-    const setup = processes.get('Setup');
+
+    const setup = processes.get(PROCESS_NAMES.FETCH_CONFIG_MANIFEST);
     if (setup) {
       return {
         total: setup.total,
         success: setup.successCount,
-        failures: setup.failureCount
+        failures: setup.failureCount,
       };
     }
-    
+
     return null;
-  })
+  }),
 );
 
 // Register strategy for Stack Settings - use Settings as primary process
 ProgressStrategyRegistry.register(
-  'STACK',
-  new PrimaryProcessStrategy('Settings')
+  MODULE_NAMES[MODULE_CONTEXTS.STACK],
+  new PrimaryProcessStrategy(PROCESS_NAMES.STACK_SETTINGS),
 );
 
 // Register strategy for Personalize - complex module with projects/experiences
 ProgressStrategyRegistry.register(
-  'PERSONALIZE',
+  MODULE_NAMES[MODULE_CONTEXTS.PERSONALIZE],
   new CustomProgressStrategy((processes) => {
     // For personalize, we want to count projects as the main metric
-    const projectExport = processes.get('Project Export');
+    const projectExport = processes.get(PROCESS_NAMES.PERSONALIZE_PROJECTS);
     if (projectExport) {
       return {
         total: projectExport.total,
         success: projectExport.successCount,
-        failures: projectExport.failureCount
+        failures: projectExport.failureCount,
       };
     }
-    
+
     // Fallback to any other main process
     const mainProcess = Array.from(processes.values())[0];
     if (mainProcess) {
       return {
         total: mainProcess.total,
         success: mainProcess.successCount,
-        failures: mainProcess.failureCount
+        failures: mainProcess.failureCount,
       };
     }
-    
+
     return null;
-  })
+  }),
 );
 
-export default ProgressStrategyRegistry; 
+// Register strategy for Entries - use Entries as primary process
+ProgressStrategyRegistry.register(
+  MODULE_NAMES[MODULE_CONTEXTS.ENTRIES],
+  new PrimaryProcessStrategy(PROCESS_NAMES.ENTRIES),
+);
+
+export default ProgressStrategyRegistry;

--- a/packages/contentstack-import/src/import/modules/assets.ts
+++ b/packages/contentstack-import/src/import/modules/assets.ts
@@ -13,13 +13,7 @@ import { FsUtility, log, handleAndLogError } from '@contentstack/cli-utilities';
 
 import config from '../../config';
 import { ModuleClassParams } from '../../types';
-import {
-  formatDate,
-  IMPORT_PROCESS_NAMES,
-  IMPORT_MODULE_CONTEXTS,
-  IMPORT_MODULE_NAMES,
-  IMPORT_PROCESS_STATUS,
-} from '../../utils';
+import { formatDate, PROCESS_NAMES, MODULE_CONTEXTS, MODULE_NAMES, PROCESS_STATUS } from '../../utils';
 import BaseClass, { ApiOptions } from './base-class';
 
 export default class ImportAssets extends BaseClass {
@@ -39,8 +33,8 @@ export default class ImportAssets extends BaseClass {
 
   constructor({ importConfig, stackAPIClient }: ModuleClassParams) {
     super({ importConfig, stackAPIClient });
-    this.importConfig.context.module = IMPORT_MODULE_CONTEXTS.ASSETS;
-    this.currentModuleName = IMPORT_MODULE_NAMES[IMPORT_MODULE_CONTEXTS.ASSETS];
+    this.importConfig.context.module = MODULE_CONTEXTS.ASSETS;
+    this.currentModuleName = MODULE_NAMES[MODULE_CONTEXTS.ASSETS];
 
     this.assetsPath = join(this.importConfig.backupDir, 'assets');
     this.mapperDirPath = join(this.importConfig.backupDir, 'mapper', 'assets');
@@ -82,8 +76,8 @@ export default class ImportAssets extends BaseClass {
       if (foldersCount > 0) {
         await this.executeStep(
           progress,
-          IMPORT_PROCESS_NAMES.ASSET_FOLDERS,
-          IMPORT_PROCESS_STATUS[IMPORT_PROCESS_NAMES.ASSET_FOLDERS].CREATING,
+          PROCESS_NAMES.ASSET_FOLDERS,
+          PROCESS_STATUS[PROCESS_NAMES.ASSET_FOLDERS].CREATING,
           () => this.importFolders(),
         );
       }
@@ -91,8 +85,8 @@ export default class ImportAssets extends BaseClass {
       if (this.assetConfig.includeVersionedAssets && versionedAssetsCount > 0) {
         await this.executeStep(
           progress,
-          IMPORT_PROCESS_NAMES.ASSET_VERSIONS,
-          IMPORT_PROCESS_STATUS[IMPORT_PROCESS_NAMES.ASSET_VERSIONS].IMPORTING,
+          PROCESS_NAMES.ASSET_VERSIONS,
+          PROCESS_STATUS[PROCESS_NAMES.ASSET_VERSIONS].IMPORTING,
           () => this.importAssets(true),
         );
       }
@@ -100,8 +94,8 @@ export default class ImportAssets extends BaseClass {
       if (assetsCount > 0) {
         await this.executeStep(
           progress,
-          IMPORT_PROCESS_NAMES.ASSET_UPLOAD,
-          IMPORT_PROCESS_STATUS[IMPORT_PROCESS_NAMES.ASSET_UPLOAD].UPLOADING,
+          PROCESS_NAMES.ASSET_UPLOAD,
+          PROCESS_STATUS[PROCESS_NAMES.ASSET_UPLOAD].UPLOADING,
           () => this.importAssets(),
         );
       }
@@ -109,8 +103,8 @@ export default class ImportAssets extends BaseClass {
       if (!this.importConfig.skipAssetsPublish && publishableAssetsCount > 0) {
         await this.executeStep(
           progress,
-          IMPORT_PROCESS_NAMES.ASSET_PUBLISH,
-          IMPORT_PROCESS_STATUS[IMPORT_PROCESS_NAMES.ASSET_PUBLISH].PUBLISHING,
+          PROCESS_NAMES.ASSET_PUBLISH,
+          PROCESS_STATUS[PROCESS_NAMES.ASSET_PUBLISH].PUBLISHING,
           () => this.publish(),
         );
       }
@@ -143,7 +137,7 @@ export default class ImportAssets extends BaseClass {
 
     const onSuccess = ({ response, apiData: { uid, name } = { uid: null, name: '' } }: any) => {
       this.assetsFolderMap[uid] = response.uid;
-      this.progressManager?.tick(true, `folder: ${name || uid}`, null, IMPORT_PROCESS_NAMES.ASSET_FOLDERS);
+      this.progressManager?.tick(true, `folder: ${name || uid}`, null, PROCESS_NAMES.ASSET_FOLDERS);
       log.debug(`Created folder: ${name} (Mapped ${uid} → ${response.uid})`, this.importConfig.context);
       log.success(`Created folder: '${name}'`, this.importConfig.context);
     };
@@ -152,8 +146,8 @@ export default class ImportAssets extends BaseClass {
       this.progressManager?.tick(
         false,
         `folder: ${name || uid}`,
-        error?.message || IMPORT_PROCESS_STATUS[IMPORT_PROCESS_NAMES.ASSET_FOLDERS].FAILED,
-        IMPORT_PROCESS_NAMES.ASSET_FOLDERS,
+        error?.message || PROCESS_STATUS[PROCESS_NAMES.ASSET_FOLDERS].FAILED,
+        PROCESS_NAMES.ASSET_FOLDERS,
       );
       log.error(`${name} folder creation failed.!`, this.importConfig.context);
       handleAndLogError(error, { ...this.importConfig.context, name });
@@ -216,7 +210,7 @@ export default class ImportAssets extends BaseClass {
     const processName = isVersion ? 'import versioned assets' : 'import assets';
     const indexFileName = isVersion ? 'versioned-assets.json' : 'assets.json';
     const basePath = isVersion ? join(this.assetsPath, 'versions') : this.assetsPath;
-    const progressProcessName = isVersion ? IMPORT_PROCESS_NAMES.ASSET_VERSIONS : IMPORT_PROCESS_NAMES.ASSET_UPLOAD;
+    const progressProcessName = isVersion ? PROCESS_NAMES.ASSET_VERSIONS : PROCESS_NAMES.ASSET_UPLOAD;
 
     log.debug(`Importing ${processName} from ${basePath}`, this.importConfig.context);
 
@@ -238,7 +232,7 @@ export default class ImportAssets extends BaseClass {
       this.progressManager?.tick(
         false,
         `asset: ${title || uid}`,
-        error?.message || IMPORT_PROCESS_STATUS[IMPORT_PROCESS_NAMES.ASSET_UPLOAD].FAILED,
+        error?.message || PROCESS_STATUS[PROCESS_NAMES.ASSET_UPLOAD].FAILED,
         progressProcessName,
       );
       log.error(`${title} asset upload failed.!`, this.importConfig.context);
@@ -372,7 +366,7 @@ export default class ImportAssets extends BaseClass {
     log.debug(`Found ${indexerCount} asset chunks to publish`, this.importConfig.context);
 
     const onSuccess = ({ apiData: { uid, title } = undefined }: any) => {
-      this.progressManager?.tick(true, `published: ${title || uid}`, null, IMPORT_PROCESS_NAMES.ASSET_PUBLISH);
+      this.progressManager?.tick(true, `published: ${title || uid}`, null, PROCESS_NAMES.ASSET_PUBLISH);
       log.success(`Asset '${uid}: ${title}' published successfully`, this.importConfig.context);
     };
 
@@ -380,8 +374,8 @@ export default class ImportAssets extends BaseClass {
       this.progressManager?.tick(
         false,
         `publish failed: ${title || uid}`,
-        error?.message || IMPORT_PROCESS_STATUS[IMPORT_PROCESS_NAMES.ASSET_PUBLISH].FAILED,
-        IMPORT_PROCESS_NAMES.ASSET_PUBLISH,
+        error?.message || PROCESS_STATUS[PROCESS_NAMES.ASSET_PUBLISH].FAILED,
+        PROCESS_NAMES.ASSET_PUBLISH,
       );
       log.error(`Asset '${uid}: ${title}' not published`, this.importConfig.context);
       handleAndLogError(error, { ...this.importConfig.context, uid, title });
@@ -537,16 +531,16 @@ export default class ImportAssets extends BaseClass {
     const { foldersCount, assetsCount, versionedAssetsCount, publishableAssetsCount } = counts;
 
     if (foldersCount > 0) {
-      progress.addProcess(IMPORT_PROCESS_NAMES.ASSET_FOLDERS, foldersCount);
+      progress.addProcess(PROCESS_NAMES.ASSET_FOLDERS, foldersCount);
     }
     if (versionedAssetsCount > 0) {
-      progress.addProcess(IMPORT_PROCESS_NAMES.ASSET_VERSIONS, versionedAssetsCount);
+      progress.addProcess(PROCESS_NAMES.ASSET_VERSIONS, versionedAssetsCount);
     }
     if (assetsCount > 0) {
-      progress.addProcess(IMPORT_PROCESS_NAMES.ASSET_UPLOAD, assetsCount);
+      progress.addProcess(PROCESS_NAMES.ASSET_UPLOAD, assetsCount);
     }
     if (publishableAssetsCount > 0) {
-      progress.addProcess(IMPORT_PROCESS_NAMES.ASSET_PUBLISH, publishableAssetsCount);
+      progress.addProcess(PROCESS_NAMES.ASSET_PUBLISH, publishableAssetsCount);
     }
   }
 

--- a/packages/contentstack-import/src/import/modules/content-types.ts
+++ b/packages/contentstack-import/src/import/modules/content-types.ts
@@ -10,10 +10,10 @@ import {
   schemaTemplate,
   lookupExtension,
   lookUpTaxonomy,
-  IMPORT_PROCESS_NAMES,
-  IMPORT_MODULE_CONTEXTS,
-  IMPORT_PROCESS_STATUS,
-  IMPORT_MODULE_NAMES,
+  PROCESS_NAMES,
+  MODULE_CONTEXTS,
+  PROCESS_STATUS,
+  MODULE_NAMES,
 } from '../../utils';
 
 export default class ContentTypesImport extends BaseClass {
@@ -56,8 +56,8 @@ export default class ContentTypesImport extends BaseClass {
 
   constructor({ importConfig, stackAPIClient }: ModuleClassParams) {
     super({ importConfig, stackAPIClient });
-    this.importConfig.context.module = IMPORT_MODULE_CONTEXTS.CONTENT_TYPES;
-    this.currentModuleName = IMPORT_MODULE_NAMES[IMPORT_MODULE_CONTEXTS.CONTENT_TYPES];
+    this.importConfig.context.module = MODULE_CONTEXTS.CONTENT_TYPES;
+    this.currentModuleName = MODULE_NAMES[MODULE_CONTEXTS.CONTENT_TYPES];
     this.cTsConfig = importConfig.modules['content-types'];
     this.gFsConfig = importConfig.modules['global-fields'];
     this.reqConcurrency = this.cTsConfig.writeConcurrency || this.importConfig.writeConcurrency;
@@ -139,7 +139,7 @@ export default class ContentTypesImport extends BaseClass {
   async seedCTs(): Promise<any> {
     const onSuccess = ({ response: globalField, apiData: { content_type: { uid = null } = {} } = {} }: any) => {
       this.createdCTs.push(uid);
-      this.progressManager?.tick(true, `content type: ${uid}`, null, 'Create');
+      this.progressManager?.tick(true, `content type: ${uid}`, null, PROCESS_NAMES.CONTENT_TYPES_CREATE);
       log.success(`Content type '${uid}' created successfully`, this.importConfig.context);
       log.debug(`Successfully seeded content type: ${uid}`, this.importConfig.context);
     };
@@ -148,7 +148,7 @@ export default class ContentTypesImport extends BaseClass {
         false,
         `content type: ${uid}`,
         error?.message || 'Failed to create content type',
-        'Create',
+        PROCESS_NAMES.CONTENT_TYPES_CREATE,
       );
       if (error.errorCode === 115 && (error.errors.uid || error.errors.title)) {
         log.info(`${uid} content type already exist`, this.importConfig.context);
@@ -190,7 +190,7 @@ export default class ContentTypesImport extends BaseClass {
 
   async updateCTs(): Promise<any> {
     const onSuccess = ({ response: contentType, apiData: { uid } }: any) => {
-      this.progressManager?.tick(true, `content type: ${uid}`, null, 'Update');
+      this.progressManager?.tick(true, `content type: ${uid}`, null, PROCESS_NAMES.CONTENT_TYPES_UPDATE);
       log.success(`'${uid}' updated with references`, this.importConfig.context);
       log.debug(`Content type update completed for: ${uid}`, this.importConfig.context);
     };
@@ -200,7 +200,7 @@ export default class ContentTypesImport extends BaseClass {
         false,
         `content type: ${uid}`,
         error?.message || 'Failed to update content type',
-        'Update',
+        PROCESS_NAMES.CONTENT_TYPES_UPDATE,
       );
       handleAndLogError(error, { ...this.importConfig.context, uid }, `Content type '${uid}' update failed`);
     };
@@ -276,7 +276,7 @@ export default class ContentTypesImport extends BaseClass {
     log.debug(`Loaded ${this.gFs?.length || 0} global fields from file`, this.importConfig.context);
 
     const onSuccess = ({ response: globalField, apiData: { uid } = undefined }: any) => {
-      this.progressManager?.tick(true, `global field: ${uid}`, null, 'GF Update');
+      this.progressManager?.tick(true, `global field: ${uid}`, null, PROCESS_NAMES.CONTENT_TYPES_GF_UPDATE);
       log.success(`Updated the global field ${uid} with content type references`, this.importConfig.context);
       log.debug(`Global field update completed for: ${uid}`, this.importConfig.context);
     };
@@ -285,7 +285,7 @@ export default class ContentTypesImport extends BaseClass {
         false,
         `global field: ${uid}`,
         error?.message || 'Failed to update global field',
-        'GF Update',
+        PROCESS_NAMES.CONTENT_TYPES_GF_UPDATE,
       );
       handleAndLogError(error, { ...this.importConfig.context, uid }, `Failed to update the global field '${uid}'`);
     };
@@ -359,7 +359,12 @@ export default class ContentTypesImport extends BaseClass {
     this.isExtensionsUpdate = true;
 
     const onSuccess = ({ response, apiData: { uid, title } = { uid: null, title: '' } }: any) => {
-      this.progressManager?.tick(true, `extension: ${response.title || title || uid}`, null, 'Ext Update');
+      this.progressManager?.tick(
+        true,
+        `extension: ${response.title || title || uid}`,
+        null,
+        PROCESS_NAMES.CONTENT_TYPES_EXT_UPDATE,
+      );
       log.success(`Successfully updated the '${response.title}' extension.`, this.importConfig.context);
       log.debug(`Extension update completed for: ${uid}`, this.importConfig.context);
     };
@@ -370,7 +375,7 @@ export default class ContentTypesImport extends BaseClass {
         false,
         `extension: ${title || uid}`,
         error?.message || 'Failed to update extension',
-        'Ext Update',
+        PROCESS_NAMES.CONTENT_TYPES_EXT_UPDATE,
       );
       if (error?.errors?.title) {
         if (!this.importConfig.skipExisting) {
@@ -434,38 +439,35 @@ export default class ContentTypesImport extends BaseClass {
   initializeProgress() {
     const progress = this.createNestedProgress(this.currentModuleName);
     if (this.cTs.length) {
-      progress.addProcess(IMPORT_PROCESS_NAMES.CONTENT_TYPES_CREATE, this.cTs.length);
-      progress.addProcess(IMPORT_PROCESS_NAMES.CONTENT_TYPES_UPDATE, this.cTs.length);
+      progress.addProcess(PROCESS_NAMES.CONTENT_TYPES_CREATE, this.cTs.length);
+      progress.addProcess(PROCESS_NAMES.CONTENT_TYPES_UPDATE, this.cTs.length);
     }
     if (this.pendingGFs.length) {
-      progress.addProcess(IMPORT_PROCESS_NAMES.CONTENT_TYPES_GF_UPDATE, this.pendingGFs.length);
+      progress.addProcess(PROCESS_NAMES.CONTENT_TYPES_GF_UPDATE, this.pendingGFs.length);
     }
     if (this.pendingExts.length) {
-      progress.addProcess(IMPORT_PROCESS_NAMES.CONTENT_TYPES_EXT_UPDATE, this.pendingExts.length);
+      progress.addProcess(PROCESS_NAMES.CONTENT_TYPES_EXT_UPDATE, this.pendingExts.length);
     }
     return progress;
   }
 
   async handlePendingGlobalFields(progress: any) {
     progress
-      .startProcess(IMPORT_PROCESS_NAMES.CONTENT_TYPES_GF_UPDATE)
+      .startProcess(PROCESS_NAMES.CONTENT_TYPES_GF_UPDATE)
       .updateStatus(
-        IMPORT_PROCESS_STATUS[IMPORT_PROCESS_NAMES.CONTENT_TYPES_GF_UPDATE].UPDATING,
-        IMPORT_PROCESS_NAMES.CONTENT_TYPES_GF_UPDATE,
+        PROCESS_STATUS[PROCESS_NAMES.CONTENT_TYPES_GF_UPDATE].UPDATING,
+        PROCESS_NAMES.CONTENT_TYPES_GF_UPDATE,
       );
 
     log.info('Starting pending global fields update process', this.importConfig.context);
     await this.updatePendingGFs();
-    progress.completeProcess(IMPORT_PROCESS_NAMES.CONTENT_TYPES_GF_UPDATE, true);
+    progress.completeProcess(PROCESS_NAMES.CONTENT_TYPES_GF_UPDATE, true);
   }
 
   async handleContentTypesCreation(progress: any) {
     progress
-      .startProcess(IMPORT_PROCESS_NAMES.CONTENT_TYPES_CREATE)
-      .updateStatus(
-        IMPORT_PROCESS_STATUS[IMPORT_PROCESS_NAMES.CONTENT_TYPES_CREATE].CREATING,
-        IMPORT_PROCESS_NAMES.CONTENT_TYPES_CREATE,
-      );
+      .startProcess(PROCESS_NAMES.CONTENT_TYPES_CREATE)
+      .updateStatus(PROCESS_STATUS[PROCESS_NAMES.CONTENT_TYPES_CREATE].CREATING, PROCESS_NAMES.CONTENT_TYPES_CREATE);
 
     log.info('Starting content types seeding process', this.importConfig.context);
     await this.seedCTs();
@@ -475,34 +477,31 @@ export default class ContentTypesImport extends BaseClass {
       log.debug(`Written ${this.createdCTs.length} successful content types to file`, this.importConfig.context);
     }
 
-    progress.completeProcess(IMPORT_PROCESS_NAMES.CONTENT_TYPES_CREATE, true);
+    progress.completeProcess(PROCESS_NAMES.CONTENT_TYPES_CREATE, true);
   }
 
   async handleContentTypesUpdate(progress: any) {
     progress
-      .startProcess(IMPORT_PROCESS_NAMES.CONTENT_TYPES_UPDATE)
-      .updateStatus(
-        IMPORT_PROCESS_STATUS[IMPORT_PROCESS_NAMES.CONTENT_TYPES_UPDATE].UPDATING,
-        IMPORT_PROCESS_NAMES.CONTENT_TYPES_UPDATE,
-      );
+      .startProcess(PROCESS_NAMES.CONTENT_TYPES_UPDATE)
+      .updateStatus(PROCESS_STATUS[PROCESS_NAMES.CONTENT_TYPES_UPDATE].UPDATING, PROCESS_NAMES.CONTENT_TYPES_UPDATE);
 
     log.info('Starting Update process', this.importConfig.context);
     await this.updateCTs();
 
-    progress.completeProcess(IMPORT_PROCESS_NAMES.CONTENT_TYPES_UPDATE, true);
+    progress.completeProcess(PROCESS_NAMES.CONTENT_TYPES_UPDATE, true);
   }
 
   async handlePendingExtensions(progress: any) {
     progress
-      .startProcess(IMPORT_PROCESS_NAMES.CONTENT_TYPES_EXT_UPDATE)
+      .startProcess(PROCESS_NAMES.CONTENT_TYPES_EXT_UPDATE)
       .updateStatus(
-        IMPORT_PROCESS_STATUS[IMPORT_PROCESS_NAMES.CONTENT_TYPES_EXT_UPDATE].UPDATING,
-        IMPORT_PROCESS_NAMES.CONTENT_TYPES_EXT_UPDATE,
+        PROCESS_STATUS[PROCESS_NAMES.CONTENT_TYPES_EXT_UPDATE].UPDATING,
+        PROCESS_NAMES.CONTENT_TYPES_EXT_UPDATE,
       );
 
     log.info('Starting pending extensions update process', this.importConfig.context);
     await this.updatePendingExtensions();
-    progress.completeProcess(IMPORT_PROCESS_NAMES.CONTENT_TYPES_EXT_UPDATE, true);
+    progress.completeProcess(PROCESS_NAMES.CONTENT_TYPES_EXT_UPDATE, true);
 
     if (this.isExtensionsUpdate) {
       log.success('Successfully updated the extensions.', this.importConfig.context);

--- a/packages/contentstack-import/src/import/modules/content-types.ts
+++ b/packages/contentstack-import/src/import/modules/content-types.ts
@@ -5,7 +5,16 @@ import { sanitizePath, log, handleAndLogError } from '@contentstack/cli-utilitie
 import { ModuleClassParams } from '../../types';
 import BaseClass, { ApiOptions } from './base-class';
 import { updateFieldRules } from '../../utils/content-type-helper';
-import { fsUtil, schemaTemplate, lookupExtension, lookUpTaxonomy } from '../../utils';
+import {
+  fsUtil,
+  schemaTemplate,
+  lookupExtension,
+  lookUpTaxonomy,
+  IMPORT_PROCESS_NAMES,
+  IMPORT_MODULE_CONTEXTS,
+  IMPORT_PROCESS_STATUS,
+  IMPORT_MODULE_NAMES,
+} from '../../utils';
 
 export default class ContentTypesImport extends BaseClass {
   private cTsMapperPath: string;
@@ -47,8 +56,8 @@ export default class ContentTypesImport extends BaseClass {
 
   constructor({ importConfig, stackAPIClient }: ModuleClassParams) {
     super({ importConfig, stackAPIClient });
-    this.importConfig.context.module = 'content-types';
-    this.currentModuleName = 'Content Types';
+    this.importConfig.context.module = IMPORT_MODULE_CONTEXTS.CONTENT_TYPES;
+    this.currentModuleName = IMPORT_MODULE_NAMES[IMPORT_MODULE_CONTEXTS.CONTENT_TYPES];
     this.cTsConfig = importConfig.modules['content-types'];
     this.gFsConfig = importConfig.modules['global-fields'];
     this.reqConcurrency = this.cTsConfig.writeConcurrency || this.importConfig.writeConcurrency;
@@ -425,30 +434,38 @@ export default class ContentTypesImport extends BaseClass {
   initializeProgress() {
     const progress = this.createNestedProgress(this.currentModuleName);
     if (this.cTs.length) {
-      progress.addProcess('Create', this.cTs.length);
-      progress.addProcess('Update', this.cTs.length);
+      progress.addProcess(IMPORT_PROCESS_NAMES.CONTENT_TYPES_CREATE, this.cTs.length);
+      progress.addProcess(IMPORT_PROCESS_NAMES.CONTENT_TYPES_UPDATE, this.cTs.length);
     }
     if (this.pendingGFs.length) {
-      progress.addProcess('GF Update', this.pendingGFs.length);
+      progress.addProcess(IMPORT_PROCESS_NAMES.CONTENT_TYPES_GF_UPDATE, this.pendingGFs.length);
     }
     if (this.pendingExts.length) {
-      progress.addProcess('Ext Update', this.pendingExts.length);
+      progress.addProcess(IMPORT_PROCESS_NAMES.CONTENT_TYPES_EXT_UPDATE, this.pendingExts.length);
     }
     return progress;
   }
 
   async handlePendingGlobalFields(progress: any) {
     progress
-      .startProcess('GF Update')
-      .updateStatus('Updating global fields with content type references...', 'GF Update');
+      .startProcess(IMPORT_PROCESS_NAMES.CONTENT_TYPES_GF_UPDATE)
+      .updateStatus(
+        IMPORT_PROCESS_STATUS[IMPORT_PROCESS_NAMES.CONTENT_TYPES_GF_UPDATE].UPDATING,
+        IMPORT_PROCESS_NAMES.CONTENT_TYPES_GF_UPDATE,
+      );
 
     log.info('Starting pending global fields update process', this.importConfig.context);
     await this.updatePendingGFs();
-    progress.completeProcess('GF Update', true);
+    progress.completeProcess(IMPORT_PROCESS_NAMES.CONTENT_TYPES_GF_UPDATE, true);
   }
 
   async handleContentTypesCreation(progress: any) {
-    progress.startProcess('Create').updateStatus('Creating content types...', 'Create');
+    progress
+      .startProcess(IMPORT_PROCESS_NAMES.CONTENT_TYPES_CREATE)
+      .updateStatus(
+        IMPORT_PROCESS_STATUS[IMPORT_PROCESS_NAMES.CONTENT_TYPES_CREATE].CREATING,
+        IMPORT_PROCESS_NAMES.CONTENT_TYPES_CREATE,
+      );
 
     log.info('Starting content types seeding process', this.importConfig.context);
     await this.seedCTs();
@@ -458,24 +475,34 @@ export default class ContentTypesImport extends BaseClass {
       log.debug(`Written ${this.createdCTs.length} successful content types to file`, this.importConfig.context);
     }
 
-    progress.completeProcess('Create', true);
+    progress.completeProcess(IMPORT_PROCESS_NAMES.CONTENT_TYPES_CREATE, true);
   }
 
   async handleContentTypesUpdate(progress: any) {
-    progress.startProcess('Update').updateStatus('Updating content types with references...', 'Update');
+    progress
+      .startProcess(IMPORT_PROCESS_NAMES.CONTENT_TYPES_UPDATE)
+      .updateStatus(
+        IMPORT_PROCESS_STATUS[IMPORT_PROCESS_NAMES.CONTENT_TYPES_UPDATE].UPDATING,
+        IMPORT_PROCESS_NAMES.CONTENT_TYPES_UPDATE,
+      );
 
     log.info('Starting Update process', this.importConfig.context);
     await this.updateCTs();
 
-    progress.completeProcess('Update', true);
+    progress.completeProcess(IMPORT_PROCESS_NAMES.CONTENT_TYPES_UPDATE, true);
   }
 
   async handlePendingExtensions(progress: any) {
-    progress.startProcess('Ext Update').updateStatus('Updating extensions...', 'Ext Update');
+    progress
+      .startProcess(IMPORT_PROCESS_NAMES.CONTENT_TYPES_EXT_UPDATE)
+      .updateStatus(
+        IMPORT_PROCESS_STATUS[IMPORT_PROCESS_NAMES.CONTENT_TYPES_EXT_UPDATE].UPDATING,
+        IMPORT_PROCESS_NAMES.CONTENT_TYPES_EXT_UPDATE,
+      );
 
     log.info('Starting pending extensions update process', this.importConfig.context);
     await this.updatePendingExtensions();
-    progress.completeProcess('Ext Update', true);
+    progress.completeProcess(IMPORT_PROCESS_NAMES.CONTENT_TYPES_EXT_UPDATE, true);
 
     if (this.isExtensionsUpdate) {
       log.success('Successfully updated the extensions.', this.importConfig.context);

--- a/packages/contentstack-import/src/import/modules/custom-roles.ts
+++ b/packages/contentstack-import/src/import/modules/custom-roles.ts
@@ -4,14 +4,7 @@ import { join } from 'node:path';
 import { forEach, map } from 'lodash';
 import { log, handleAndLogError } from '@contentstack/cli-utilities';
 
-import {
-  fsUtil,
-  fileHelper,
-  IMPORT_PROCESS_NAMES,
-  IMPORT_MODULE_CONTEXTS,
-  IMPORT_PROCESS_STATUS,
-  IMPORT_MODULE_NAMES,
-} from '../../utils';
+import { fsUtil, fileHelper, PROCESS_NAMES, MODULE_CONTEXTS, PROCESS_STATUS, MODULE_NAMES } from '../../utils';
 import BaseClass, { ApiOptions } from './base-class';
 import { ModuleClassParams, CustomRoleConfig } from '../../types';
 
@@ -37,8 +30,8 @@ export default class ImportCustomRoles extends BaseClass {
 
   constructor({ importConfig, stackAPIClient }: ModuleClassParams) {
     super({ importConfig, stackAPIClient });
-    this.importConfig.context.module = IMPORT_MODULE_CONTEXTS.CUSTOM_ROLES;
-    this.currentModuleName = IMPORT_MODULE_NAMES[IMPORT_MODULE_CONTEXTS.CUSTOM_ROLES];
+    this.importConfig.context.module = MODULE_CONTEXTS.CUSTOM_ROLES;
+    this.currentModuleName = MODULE_NAMES[MODULE_CONTEXTS.CUSTOM_ROLES];
     this.customRolesConfig = importConfig.modules.customRoles;
     this.customRolesMapperPath = join(this.importConfig.backupDir, 'mapper', 'custom-roles');
     this.customRolesFolderPath = join(this.importConfig.backupDir, this.customRolesConfig.dirName);
@@ -73,10 +66,10 @@ export default class ImportCustomRoles extends BaseClass {
       const progress = this.createSimpleProgress(this.currentModuleName, customRolesCount);
       await this.prepareForImport();
 
-      progress.updateStatus(IMPORT_PROCESS_STATUS[IMPORT_PROCESS_NAMES.CUSTOM_ROLES_BUILD_MAPPINGS].BUILDING);
+      progress.updateStatus(PROCESS_STATUS[PROCESS_NAMES.CUSTOM_ROLES_BUILD_MAPPINGS].BUILDING);
       await this.getLocalesUidMap();
 
-      progress.updateStatus(IMPORT_PROCESS_STATUS[IMPORT_PROCESS_NAMES.CUSTOM_ROLES_IMPORT].IMPORTING);
+      progress.updateStatus(PROCESS_STATUS[PROCESS_NAMES.CUSTOM_ROLES_IMPORT].IMPORTING);
       await this.importCustomRoles();
 
       this.handleImportResults();
@@ -141,7 +134,12 @@ export default class ImportCustomRoles extends BaseClass {
     const onSuccess = ({ response, apiData: { uid, name } = { uid: null, name: '' } }: any) => {
       this.createdCustomRoles.push(response);
       this.customRolesUidMapper[uid] = response.uid;
-      this.progressManager?.tick(true, `custom role: ${name || uid}`);
+      this.progressManager?.tick(
+        true,
+        `custom role: ${name}`,
+        `custom role: ${name || uid}`,
+        PROCESS_NAMES.CUSTOM_ROLES_IMPORT,
+      );
       log.success(`custom-role '${name}' imported successfully`, this.importConfig.context);
       log.debug(`Custom role import completed: ${name} (${uid})`, this.importConfig.context);
       fsUtil.writeFile(this.customRolesUidMapperPath, this.customRolesUidMapper);
@@ -153,11 +151,21 @@ export default class ImportCustomRoles extends BaseClass {
       log.debug(`Custom role '${name}' import failed`, this.importConfig.context);
 
       if (err?.errors?.name) {
-        this.progressManager?.tick(true, `custom role: ${name} (already exists)`);
+        this.progressManager?.tick(
+          true,
+          `custom role: ${name}`,
+          `custom role: ${name} (already exists)`,
+          PROCESS_NAMES.CUSTOM_ROLES_IMPORT,
+        );
         log.info(`custom-role '${name}' already exists`, this.importConfig.context);
       } else {
         this.failedCustomRoles.push(apiData);
-        this.progressManager?.tick(false, `custom role: ${name}`, error?.message || 'Failed to import custom role');
+        this.progressManager?.tick(
+          false,
+          `custom role: ${name}`,
+          error?.message || 'Failed to import custom role',
+          PROCESS_NAMES.CUSTOM_ROLES_IMPORT,
+        );
         handleAndLogError(error, { ...this.importConfig.context, name }, `custom-role '${name}' failed to be import`);
       }
     };
@@ -199,7 +207,11 @@ export default class ImportCustomRoles extends BaseClass {
       );
       log.debug(`Skipping custom role serialization for: ${customRole.uid}`, this.importConfig.context);
       // Still tick progress for skipped custom roles
-      this.progressManager?.tick(true, `custom role: ${customRole.name} (skipped - already exists)`);
+      this.progressManager?.tick(
+        true,
+        `custom role: ${customRole.name} (skipped - already exists)`,
+        PROCESS_NAMES.CUSTOM_ROLES_IMPORT,
+      );
       apiOptions.entity = undefined;
     } else {
       log.debug(`Processing custom role: ${customRole.name}`, this.importConfig.context);

--- a/packages/contentstack-import/src/import/modules/custom-roles.ts
+++ b/packages/contentstack-import/src/import/modules/custom-roles.ts
@@ -4,7 +4,14 @@ import { join } from 'node:path';
 import { forEach, map } from 'lodash';
 import { log, handleAndLogError } from '@contentstack/cli-utilities';
 
-import { fsUtil, fileHelper } from '../../utils';
+import {
+  fsUtil,
+  fileHelper,
+  IMPORT_PROCESS_NAMES,
+  IMPORT_MODULE_CONTEXTS,
+  IMPORT_PROCESS_STATUS,
+  IMPORT_MODULE_NAMES,
+} from '../../utils';
 import BaseClass, { ApiOptions } from './base-class';
 import { ModuleClassParams, CustomRoleConfig } from '../../types';
 
@@ -30,8 +37,8 @@ export default class ImportCustomRoles extends BaseClass {
 
   constructor({ importConfig, stackAPIClient }: ModuleClassParams) {
     super({ importConfig, stackAPIClient });
-    this.importConfig.context.module = 'custom-roles';
-    this.currentModuleName = 'Custom Roles';
+    this.importConfig.context.module = IMPORT_MODULE_CONTEXTS.CUSTOM_ROLES;
+    this.currentModuleName = IMPORT_MODULE_NAMES[IMPORT_MODULE_CONTEXTS.CUSTOM_ROLES];
     this.customRolesConfig = importConfig.modules.customRoles;
     this.customRolesMapperPath = join(this.importConfig.backupDir, 'mapper', 'custom-roles');
     this.customRolesFolderPath = join(this.importConfig.backupDir, this.customRolesConfig.dirName);
@@ -66,10 +73,10 @@ export default class ImportCustomRoles extends BaseClass {
       const progress = this.createSimpleProgress(this.currentModuleName, customRolesCount);
       await this.prepareForImport();
 
-      progress.updateStatus('Building locale mappings...');
+      progress.updateStatus(IMPORT_PROCESS_STATUS[IMPORT_PROCESS_NAMES.CUSTOM_ROLES_BUILD_MAPPINGS].BUILDING);
       await this.getLocalesUidMap();
 
-      progress.updateStatus('Importing custom roles...');
+      progress.updateStatus(IMPORT_PROCESS_STATUS[IMPORT_PROCESS_NAMES.CUSTOM_ROLES_IMPORT].IMPORTING);
       await this.importCustomRoles();
 
       this.handleImportResults();

--- a/packages/contentstack-import/src/import/modules/environments.ts
+++ b/packages/contentstack-import/src/import/modules/environments.ts
@@ -3,7 +3,14 @@ import values from 'lodash/values';
 import { join } from 'node:path';
 import { log, handleAndLogError } from '@contentstack/cli-utilities';
 
-import { fsUtil, fileHelper } from '../../utils';
+import {
+  fsUtil,
+  fileHelper,
+  IMPORT_PROCESS_NAMES,
+  IMPORT_MODULE_CONTEXTS,
+  IMPORT_PROCESS_STATUS,
+  IMPORT_MODULE_NAMES,
+} from '../../utils';
 import BaseClass, { ApiOptions } from './base-class';
 import { ModuleClassParams, EnvironmentConfig } from '../../types';
 
@@ -21,8 +28,8 @@ export default class ImportEnvironments extends BaseClass {
 
   constructor({ importConfig, stackAPIClient }: ModuleClassParams) {
     super({ importConfig, stackAPIClient });
-    this.importConfig.context.module = 'environments';
-    this.currentModuleName = 'Environments';
+    this.importConfig.context.module = IMPORT_MODULE_CONTEXTS.ENVIRONMENTS;
+    this.currentModuleName = IMPORT_MODULE_NAMES[IMPORT_MODULE_CONTEXTS.ENVIRONMENTS];
     this.environmentsConfig = importConfig.modules.environments;
     this.mapperDirPath = join(this.importConfig.backupDir, 'mapper', 'environments');
     this.environmentsFolderPath = join(this.importConfig.backupDir, this.environmentsConfig.dirName);
@@ -51,7 +58,7 @@ export default class ImportEnvironments extends BaseClass {
       const progress = this.createSimpleProgress(this.currentModuleName, environmentsCount);
       await this.prepareEnvironmentMapper();
 
-      progress.updateStatus('Importing environments...');
+      progress.updateStatus(IMPORT_PROCESS_STATUS[IMPORT_PROCESS_NAMES.ENVIRONMENTS_IMPORT].IMPORTING);
       await this.importEnvironments();
 
       await this.processImportResults();

--- a/packages/contentstack-import/src/import/modules/global-fields.ts
+++ b/packages/contentstack-import/src/import/modules/global-fields.ts
@@ -7,9 +7,19 @@
 
 import * as path from 'path';
 import { isEmpty, cloneDeep } from 'lodash';
-import { cliux, sanitizePath, log, handleAndLogError } from '@contentstack/cli-utilities';
-import { GlobalFieldData, GlobalField } from '@contentstack/management/types/stack/globalField';
-import { fsUtil, fileHelper, lookupExtension, removeReferenceFields } from '../../utils';
+import { GlobalField } from '@contentstack/management/types/stack/globalField';
+import { sanitizePath, log, handleAndLogError } from '@contentstack/cli-utilities';
+
+import {
+  fsUtil,
+  fileHelper,
+  lookupExtension,
+  removeReferenceFields,
+  IMPORT_PROCESS_NAMES,
+  IMPORT_MODULE_CONTEXTS,
+  IMPORT_PROCESS_STATUS,
+  IMPORT_MODULE_NAMES,
+} from '../../utils';
 import { ImportConfig, ModuleClassParams } from '../../types';
 import BaseClass, { ApiOptions } from './base-class';
 import { gfSchemaTemplate } from '../../utils/global-field-helper';
@@ -42,8 +52,8 @@ export default class ImportGlobalFields extends BaseClass {
 
   constructor({ importConfig, stackAPIClient }: ModuleClassParams) {
     super({ importConfig, stackAPIClient });
-    this.importConfig.context.module = 'global-fields';
-    this.currentModuleName = 'Global Fields';
+    this.importConfig.context.module = IMPORT_MODULE_CONTEXTS.GLOBAL_FIELDS;
+    this.currentModuleName = IMPORT_MODULE_NAMES[IMPORT_MODULE_CONTEXTS.GLOBAL_FIELDS];
     this.config = importConfig;
     this.gFsConfig = importConfig.modules['global-fields'];
     this.gFs = [];
@@ -86,34 +96,45 @@ export default class ImportGlobalFields extends BaseClass {
       }
 
       const progress = this.createNestedProgress(this.currentModuleName);
-      progress.addProcess('Create', globalFieldsCount);
-      progress.addProcess('Update', globalFieldsCount);
+      progress.addProcess(IMPORT_PROCESS_NAMES.GLOBAL_FIELDS_CREATE, globalFieldsCount);
+      progress.addProcess(IMPORT_PROCESS_NAMES.GLOBAL_FIELDS_UPDATE, globalFieldsCount);
 
       await this.prepareGlobalFieldMapper();
 
       // Step 1: Create global fields
       progress
-        .startProcess('Create')
-        .updateStatus('Creating global fields...', 'Create');
+        .startProcess(IMPORT_PROCESS_NAMES.GLOBAL_FIELDS_CREATE)
+        .updateStatus(
+          IMPORT_PROCESS_STATUS[IMPORT_PROCESS_NAMES.GLOBAL_FIELDS_CREATE].CREATING,
+          IMPORT_PROCESS_NAMES.GLOBAL_FIELDS_CREATE,
+        );
       log.info('Starting Create process', this.importConfig.context);
       await this.seedGFs();
-      progress.completeProcess('Create', true);
+      progress.completeProcess(IMPORT_PROCESS_NAMES.GLOBAL_FIELDS_CREATE, true);
 
       // Step 2: Update global fields with references
-      progress.startProcess('Update').updateStatus('Updating global fields', 'Update');
+      progress
+        .startProcess(IMPORT_PROCESS_NAMES.GLOBAL_FIELDS_UPDATE)
+        .updateStatus(
+          IMPORT_PROCESS_STATUS[IMPORT_PROCESS_NAMES.GLOBAL_FIELDS_UPDATE].UPDATING,
+          IMPORT_PROCESS_NAMES.GLOBAL_FIELDS_UPDATE,
+        );
       log.info('Starting Update process', this.importConfig.context);
       await this.updateGFs();
-      progress.completeProcess('Update', true);
+      progress.completeProcess(IMPORT_PROCESS_NAMES.GLOBAL_FIELDS_UPDATE, true);
 
       // Step 3: Replace existing global fields if needed
       if (this.importConfig.replaceExisting && this.existingGFs.length > 0) {
-        progress.addProcess('Replace Existing', this.existingGFs.length);
+        progress.addProcess(IMPORT_PROCESS_NAMES.GLOBAL_FIELDS_REPLACE_EXISTING, this.existingGFs.length);
         progress
-          .startProcess('Replace Existing')
-          .updateStatus('Replacing existing global fields...', 'Replace Existing');
+          .startProcess(IMPORT_PROCESS_NAMES.GLOBAL_FIELDS_REPLACE_EXISTING)
+          .updateStatus(
+            IMPORT_PROCESS_STATUS[IMPORT_PROCESS_NAMES.GLOBAL_FIELDS_REPLACE_EXISTING].REPLACING,
+            IMPORT_PROCESS_NAMES.GLOBAL_FIELDS_REPLACE_EXISTING,
+          );
         log.info('Starting Replace Existing process', this.importConfig.context);
         await this.replaceGFs();
-        progress.completeProcess('Replace Existing', true);
+        progress.completeProcess(IMPORT_PROCESS_NAMES.GLOBAL_FIELDS_REPLACE_EXISTING, true);
       }
 
       await this.processGlobalFieldResults();
@@ -135,7 +156,12 @@ export default class ImportGlobalFields extends BaseClass {
     const onSuccess = ({ response: globalField, apiData: { uid } = undefined }: any) => {
       this.createdGFs.push(globalField);
       this.gFsUidMapper[uid] = globalField;
-      this.progressManager?.tick(true, `global field: ${globalField.uid}`, null, 'Create');
+      this.progressManager?.tick(
+        true,
+        `global field: ${globalField.uid}`,
+        null,
+        IMPORT_PROCESS_NAMES.GLOBAL_FIELDS_CREATE,
+      );
       log.success(`Global field ${globalField.uid} created successfully`, this.importConfig.context);
       log.debug(`Global field Create completed: ${globalField.uid}`, this.importConfig.context);
     };
@@ -151,11 +177,16 @@ export default class ImportGlobalFields extends BaseClass {
             true,
             `global field: ${uid} (marked for replacement)`,
             null,
-            'Create',
+            IMPORT_PROCESS_NAMES.GLOBAL_FIELDS_CREATE,
           );
           log.debug(`Global field '${uid}' marked for replacement`, this.importConfig.context);
         } else {
-          this.progressManager?.tick(true, `global field: ${uid} (already exists)`, null, 'Create');
+          this.progressManager?.tick(
+            true,
+            `global field: ${uid} (already exists)`,
+            null,
+            IMPORT_PROCESS_NAMES.GLOBAL_FIELDS_CREATE,
+          );
         }
         if (!this.importConfig.skipExisting) {
           log.info(`Global fields '${uid}' already exist`, this.importConfig.context);
@@ -215,7 +246,7 @@ export default class ImportGlobalFields extends BaseClass {
     log.debug(`Updating ${gfsToUpdate} global fields`, this.importConfig.context);
 
     const onSuccess = ({ response: globalField, apiData: { uid } = undefined }: any) => {
-      this.progressManager?.tick(true, `global field: ${uid}`, null, 'Update');
+      this.progressManager?.tick(true, `global field: ${uid}`, null, IMPORT_PROCESS_NAMES.GLOBAL_FIELDS_UPDATE);
       log.success(`Updated the global field ${uid}`, this.importConfig.context);
       log.debug(`Global field update completed: ${uid}`, this.importConfig.context);
     };
@@ -315,7 +346,12 @@ export default class ImportGlobalFields extends BaseClass {
       const uid = apiData?.uid ?? apiData?.global_field?.uid ?? 'unknown';
       this.createdGFs.push(globalField);
       this.gFsUidMapper[uid] = globalField;
-      this.progressManager?.tick(true, `global field: ${uid} (replaced)`, null, 'Replace Existing');
+      this.progressManager?.tick(
+        true,
+        `global field: ${uid} (replaced)`,
+        null,
+        IMPORT_PROCESS_NAMES.GLOBAL_FIELDS_REPLACE_EXISTING,
+      );
       fsUtil.writeFile(this.gFsUidMapperPath, this.gFsUidMapper);
       log.success(`Global field '${uid}' replaced successfully`, this.importConfig.context);
       log.debug(`Global field replacement completed: ${uid}`, this.importConfig.context);

--- a/packages/contentstack-import/src/import/modules/marketplace-apps.ts
+++ b/packages/contentstack-import/src/import/modules/marketplace-apps.ts
@@ -35,10 +35,10 @@ import {
   getAllStackSpecificApps,
   getConfirmationToCreateApps,
   getDeveloperHubUrl,
-  IMPORT_PROCESS_NAMES,
-  IMPORT_MODULE_CONTEXTS,
-  IMPORT_PROCESS_STATUS,
-  IMPORT_MODULE_NAMES,
+  PROCESS_NAMES,
+  MODULE_CONTEXTS,
+  PROCESS_STATUS,
+  MODULE_NAMES,
 } from '../../utils';
 import BaseClass from './base-class';
 
@@ -60,8 +60,8 @@ export default class ImportMarketplaceApps extends BaseClass {
 
   constructor({ importConfig, stackAPIClient }: ModuleClassParams) {
     super({ importConfig, stackAPIClient });
-    this.importConfig.context.module = IMPORT_MODULE_CONTEXTS.MARKETPLACE_APPS;
-    this.currentModuleName = IMPORT_MODULE_NAMES[IMPORT_MODULE_CONTEXTS.MARKETPLACE_APPS];
+    this.importConfig.context.module = MODULE_CONTEXTS.MARKETPLACE_APPS;
+    this.currentModuleName = MODULE_NAMES[MODULE_CONTEXTS.MARKETPLACE_APPS];
     this.marketPlaceAppConfig = importConfig.modules.marketplace_apps;
     this.mapperDirPath = join(this.importConfig.backupDir, 'mapper', 'marketplace_apps');
     this.marketPlaceFolderPath = join(this.importConfig.backupDir, this.marketPlaceAppConfig.dirName);
@@ -97,51 +97,49 @@ export default class ImportMarketplaceApps extends BaseClass {
         return;
       }
 
+      // Handle encryption key prompt BEFORE starting progress
+      if (!this.importConfig.forceStopMarketplaceAppsPrompt) {
+        log.debug('Validating security configuration before progress start', this.importConfig.context);
+        await this.getAndValidateEncryptionKey(this.importConfig.marketplaceAppEncryptionKey);
+      }
+
       const progress = this.createNestedProgress(this.currentModuleName);
       const privateAppsCount = filter(this.marketplaceApps, { manifest: { visibility: 'private' } }).length;
 
-      progress.addProcess(IMPORT_PROCESS_NAMES.SETUP_ENVIRONMENT, 1);
+      progress.addProcess(PROCESS_NAMES.SETUP_ENVIRONMENT, 1);
       if (privateAppsCount > 0) {
-        progress.addProcess(IMPORT_PROCESS_NAMES.CREATE_APPS, privateAppsCount);
+        progress.addProcess(PROCESS_NAMES.CREATE_APPS, privateAppsCount);
       }
-      progress.addProcess(IMPORT_PROCESS_NAMES.INSTALL_APPS, marketplaceAppsCount);
+      progress.addProcess(PROCESS_NAMES.INSTALL_APPS, marketplaceAppsCount);
 
-      await this.prepareMarketplaceAppMapper();
+      this.prepareMarketplaceAppMapper();
 
       // Step 1: Setup Environment SDK and authentication
-      progress
-        .startProcess(IMPORT_PROCESS_NAMES.SETUP_ENVIRONMENT)
-        .updateStatus(
-          IMPORT_PROCESS_STATUS[IMPORT_PROCESS_NAMES.SETUP_ENVIRONMENT].SETTING_UP,
-          IMPORT_PROCESS_NAMES.SETUP_ENVIRONMENT,
-        );
       log.info('Setting up marketplace SDK and authentication', this.importConfig.context);
+      progress
+        .startProcess(PROCESS_NAMES.SETUP_ENVIRONMENT)
+        .updateStatus(PROCESS_STATUS[PROCESS_NAMES.SETUP_ENVIRONMENT].SETTING_UP, PROCESS_NAMES.SETUP_ENVIRONMENT);
       await this.setupMarketplaceEnvironment();
-      progress.completeProcess(IMPORT_PROCESS_NAMES.SETUP_ENVIRONMENT, true);
+      progress.completeProcess(PROCESS_NAMES.SETUP_ENVIRONMENT, true);
 
       // Step 2: Handle private apps creation (if any)
       if (privateAppsCount > 0) {
-        progress
-          .startProcess(IMPORT_PROCESS_NAMES.CREATE_APPS)
-          .updateStatus(
-            IMPORT_PROCESS_STATUS[IMPORT_PROCESS_NAMES.CREATE_APPS].CREATING,
-            IMPORT_PROCESS_NAMES.CREATE_APPS,
-          );
         log.info('Starting private apps creation process', this.importConfig.context);
+        progress
+          .startProcess(PROCESS_NAMES.CREATE_APPS)
+          .updateStatus(PROCESS_STATUS[PROCESS_NAMES.CREATE_APPS].CREATING, PROCESS_NAMES.CREATE_APPS);
         await this.handleAllPrivateAppsCreationProcess();
-        progress.completeProcess(IMPORT_PROCESS_NAMES.CREATE_APPS, true);
+        progress.completeProcess(PROCESS_NAMES.CREATE_APPS, true);
       }
 
-      // Step 3: Install marketplace apps
-      progress
-        .startProcess(IMPORT_PROCESS_NAMES.INSTALL_APPS)
-        .updateStatus(
-          IMPORT_PROCESS_STATUS[IMPORT_PROCESS_NAMES.INSTALL_APPS].INSTALLING,
-          IMPORT_PROCESS_NAMES.INSTALL_APPS,
-        );
+      // Step 3: Install marketplace apps - FIXED THIS PART
       log.info('Starting marketplace apps installation process', this.importConfig.context);
+      progress
+        .startProcess(PROCESS_NAMES.INSTALL_APPS)
+        .updateStatus(PROCESS_STATUS[PROCESS_NAMES.INSTALL_APPS].INSTALLING, PROCESS_NAMES.INSTALL_APPS);
+
       await this.importMarketplaceApps();
-      progress.completeProcess(IMPORT_PROCESS_NAMES.INSTALL_APPS, true);
+      progress.completeProcess(PROCESS_NAMES.INSTALL_APPS, true);
 
       this.completeProgress(true);
       log.success('Marketplace apps have been imported successfully!', this.importConfig.context);
@@ -163,11 +161,7 @@ export default class ImportMarketplaceApps extends BaseClass {
     if (this.importConfig.forceStopMarketplaceAppsPrompt) {
       log.debug('Using forced security configuration without validation', this.importConfig.context);
       this.nodeCrypto = new NodeCrypto(cryptoArgs);
-    } else {
-      log.debug('Validating security configuration', this.importConfig.context);
-      await this.getAndValidateEncryptionKey(this.importConfig.marketplaceAppEncryptionKey);
     }
-
     // NOTE getting all apps to validate if it's already installed in the stack to manage conflict
     log.debug('Getting all stack-specific apps for validation', this.importConfig.context);
     this.installedApps = await getAllStackSpecificApps(this.importConfig);
@@ -275,6 +269,7 @@ export default class ImportMarketplaceApps extends BaseClass {
     }
 
     log.debug('Found app configuration requiring security setup, asking for input', this.importConfig.context);
+    cliux.print('\n');
     const encryptionKey = await askEncryptionKey(defaultValue);
 
     try {
@@ -327,6 +322,7 @@ export default class ImportMarketplaceApps extends BaseClass {
     }
 
     log.debug('Getting confirmation to create private apps', this.importConfig.context);
+    cliux.print('\n');
     let canCreatePrivateApp = await getConfirmationToCreateApps(privateApps, this.importConfig);
     this.importConfig.canCreatePrivateApp = canCreatePrivateApp;
 
@@ -339,12 +335,7 @@ export default class ImportMarketplaceApps extends BaseClass {
         if (await this.isPrivateAppExistInDeveloperHub(app)) {
           // NOTE Found app already exist in the same org
           this.appUidMapping[app.uid] = app.uid;
-          this.progressManager?.tick(
-            true,
-            `${app.manifest.name} (already exists)`,
-            null,
-            IMPORT_PROCESS_NAMES.CREATE_APPS,
-          );
+          this.progressManager?.tick(true, `${app.manifest.name} (already exists)`, null, PROCESS_NAMES.CREATE_APPS);
           cliux.print(`App '${app.manifest.name}' already exist. skipping app recreation.!`, { color: 'yellow' });
           log.debug(`App '${app.manifest.name}' already exists, skipping recreation`, this.importConfig.context);
           continue;
@@ -376,12 +367,7 @@ export default class ImportMarketplaceApps extends BaseClass {
       log.info('Skipping private apps creation on Developer Hub...', this.importConfig.context);
       // Mark all private apps as skipped in progress
       for (let app of privateApps) {
-        this.progressManager?.tick(
-          true,
-          `${app.manifest.name} (creation skipped)`,
-          null,
-          IMPORT_PROCESS_NAMES.CREATE_APPS,
-        );
+        this.progressManager?.tick(true, `${app.manifest.name} (creation skipped)`, null, PROCESS_NAMES.CREATE_APPS);
       }
     }
 
@@ -551,7 +537,7 @@ export default class ImportMarketplaceApps extends BaseClass {
         log.debug(`Retrying app creation with updated name: ${updatedApp.name}`, this.importConfig.context);
         return this.createPrivateApp(updatedApp, appSuffix + 1, true);
       } else {
-        this.progressManager?.tick(false, `${app.name}`, message, IMPORT_PROCESS_NAMES.CREATE_APPS);
+        this.progressManager?.tick(false, `${app.name}`, message, PROCESS_NAMES.CREATE_APPS);
         trace(response, 'error', true);
         log.error(formatError(message), this.importConfig.context);
 
@@ -576,14 +562,14 @@ export default class ImportMarketplaceApps extends BaseClass {
       }
     } else if (response.uid) {
       // NOTE new app installation
-      this.progressManager?.tick(true, `${response.name}`, null, IMPORT_PROCESS_NAMES.CREATE_APPS);
+      this.progressManager?.tick(true, `${response.name}`, null, PROCESS_NAMES.CREATE_APPS);
       log.success(`${response.name} app created successfully.!`, this.importConfig.context);
       log.debug(`App UID mapping: ${app.uid} → ${response.uid}`, this.importConfig.context);
       this.appUidMapping[app.uid] = response.uid;
       this.appNameMapping[this.appOriginalName] = response.name;
       log.debug(`App name mapping: ${this.appOriginalName} → ${response.name}`, this.importConfig.context);
     } else {
-      this.progressManager?.tick(false, `${app.name}`, 'Unexpected response format', IMPORT_PROCESS_NAMES.CREATE_APPS);
+      this.progressManager?.tick(false, `${app.name}`, 'Unexpected response format', PROCESS_NAMES.CREATE_APPS);
       log.debug(`Unexpected response format for app: ${app.name}`, this.importConfig.context);
     }
   }
@@ -596,96 +582,102 @@ export default class ImportMarketplaceApps extends BaseClass {
    * @returns {Promise<void>}
    */
   async installApps(app: any): Promise<void> {
-    log.debug(`Installing app: ${app.manifest?.name || app.manifest?.uid}`, this.importConfig.context);
-    let updateParam;
-    const { configuration, server_configuration } = app;
-    const currentStackApp = find(this.installedApps, { manifest: { uid: app?.manifest?.uid } });
+    try {
+      log.debug(`Installing app: ${app.manifest?.name || app.manifest?.uid}`, this.importConfig.context);
+      let updateParam;
+      const { configuration, server_configuration } = app;
+      const currentStackApp = find(this.installedApps, { manifest: { uid: app?.manifest?.uid } });
 
-    if (!currentStackApp) {
-      log.debug(`App not found in current stack, installing new app: ${app.manifest?.name}`, this.importConfig.context);
-      // NOTE install new app
-      if (app.manifest.visibility === 'private' && !this.importConfig.canCreatePrivateApp) {
+      if (!currentStackApp) {
+        log.debug(
+          `App not found in current stack, installing new app: ${app.manifest?.name}`,
+          this.importConfig.context,
+        );
+        if (app.manifest.visibility === 'private' && !this.importConfig.canCreatePrivateApp) {
+          this.progressManager?.tick(
+            true,
+            `${app.manifest.name} (skipped - private app not allowed)`,
+            null,
+            PROCESS_NAMES.INSTALL_APPS,
+          );
+          log.info(`Skipping the installation of the private app ${app.manifest.name}...`, this.importConfig.context);
+          return Promise.resolve();
+        }
+
+        log.debug(
+          `Installing app with manifest UID: ${this.appUidMapping[app.manifest.uid] || app.manifest.uid}`,
+          this.importConfig.context,
+        );
+        const installation = await this.installApp(
+          this.importConfig,
+          // NOTE if it's private app it should get uid from mapper else will use manifest uid
+          this.appUidMapping[app.manifest.uid] || app.manifest.uid,
+        );
+
+        if (installation.installation_uid) {
+          const appName = this.appNameMapping[app.manifest.name] || app.manifest.name || app.manifest.uid;
+          this.progressManager?.tick(true, `${appName}`, null, PROCESS_NAMES.INSTALL_APPS);
+          log.success(`${appName} app installed successfully.!`, this.importConfig.context);
+          log.debug(`Installation UID: ${installation.installation_uid}`, this.importConfig.context);
+
+          log.debug(`Making redirect URL call for app: ${appName}`, this.importConfig.context);
+          await makeRedirectUrlCall(installation, appName, this.importConfig);
+
+          this.installationUidMapping[app.uid] = installation.installation_uid;
+          log.debug(
+            `Installation UID mapping: ${app.uid} → ${installation.installation_uid}`,
+            this.importConfig.context,
+          );
+          updateParam = { manifest: app.manifest, ...installation, configuration, server_configuration };
+        } else if (installation.message) {
+          this.progressManager?.tick(false, `${app.manifest?.name}`, installation.message, PROCESS_NAMES.INSTALL_APPS);
+          log.info(formatError(installation.message), this.importConfig.context);
+          log.debug(`Installation failed for app: ${app.manifest?.name}`, this.importConfig.context);
+          cliux.print('\n');
+          await confirmToCloseProcess(installation, this.importConfig);
+        }
+      } else if (!isEmpty(configuration) || !isEmpty(server_configuration)) {
+        const appName = app.manifest.name || app.manifest.uid;
         this.progressManager?.tick(
           true,
-          `${app.manifest.name} (skipped - private app not allowed)`,
+          `${appName} (already installed, updating config)`,
           null,
-          IMPORT_PROCESS_NAMES.INSTALL_APPS,
+          PROCESS_NAMES.INSTALL_APPS,
         );
-        log.info(`Skipping the installation of the private app ${app.manifest.name}...`, this.importConfig.context);
-        return Promise.resolve();
+        log.info(`${appName} is already installed`, this.importConfig.context);
+        log.debug(`Handling existing app configuration for: ${appName}`, this.importConfig.context);
+        updateParam = await ifAppAlreadyExist(app, currentStackApp, this.importConfig);
+      } else {
+        this.progressManager?.tick(true, `${app.manifest?.name} (already installed)`, null, PROCESS_NAMES.INSTALL_APPS);
+        log.debug(
+          `App ${app.manifest?.name} is already installed with no configuration to update`,
+          this.importConfig.context,
+        );
       }
 
-      log.debug(
-        `Installing app with manifest UID: ${this.appUidMapping[app.manifest.uid] || app.manifest.uid}`,
-        this.importConfig.context,
-      );
-      const installation = await this.installApp(
-        this.importConfig,
-        // NOTE if it's private app it should get uid from mapper else will use manifest uid
-        this.appUidMapping[app.manifest.uid] || app.manifest.uid,
-      );
-
-      if (installation.installation_uid) {
-        const appName = this.appNameMapping[app.manifest.name] || app.manifest.name || app.manifest.uid;
-        this.progressManager?.tick(true, `${appName}`, null, IMPORT_PROCESS_NAMES.INSTALL_APPS);
-        log.success(`${appName} app installed successfully.!`, this.importConfig.context);
-        log.debug(`Installation UID: ${installation.installation_uid}`, this.importConfig.context);
-
-        log.debug(`Making redirect URL call for app: ${appName}`, this.importConfig.context);
-        await makeRedirectUrlCall(installation, appName, this.importConfig);
-
-        this.installationUidMapping[app.uid] = installation.installation_uid;
-        log.debug(`Installation UID mapping: ${app.uid} → ${installation.installation_uid}`, this.importConfig.context);
-        updateParam = { manifest: app.manifest, ...installation, configuration, server_configuration };
-      } else if (installation.message) {
-        this.progressManager?.tick(
-          false,
-          `${app.manifest?.name}`,
-          installation.message,
-          IMPORT_PROCESS_NAMES.INSTALL_APPS,
+      if (!this.appUidMapping[app.manifest.uid]) {
+        this.appUidMapping[app.manifest.uid] = currentStackApp ? currentStackApp.manifest.uid : app.manifest.uid;
+        log.debug(
+          `App UID mapping: ${app.manifest.uid} → ${this.appUidMapping[app.manifest.uid]}`,
+          this.importConfig.context,
         );
-        log.info(formatError(installation.message), this.importConfig.context);
-        log.debug(`Installation failed for app: ${app.manifest?.name}`, this.importConfig.context);
-        await confirmToCloseProcess(installation, this.importConfig);
       }
-    } else if (!isEmpty(configuration) || !isEmpty(server_configuration)) {
-      const appName = app.manifest.name || app.manifest.uid;
-      this.progressManager?.tick(
-        true,
-        `${appName} (already installed, updating config)`,
-        null,
-        IMPORT_PROCESS_NAMES.INSTALL_APPS,
-      );
-      log.info(`${appName} is already installed`, this.importConfig.context);
-      log.debug(`Handling existing app configuration for: ${appName}`, this.importConfig.context);
-      updateParam = await ifAppAlreadyExist(app, currentStackApp, this.importConfig);
-    } else {
-      this.progressManager?.tick(
-        true,
-        `${app.manifest?.name} (already installed)`,
-        null,
-        IMPORT_PROCESS_NAMES.INSTALL_APPS,
-      );
-      log.debug(
-        `App ${app.manifest?.name} is already installed with no configuration to update`,
-        this.importConfig.context,
-      );
-    }
 
-    if (!this.appUidMapping[app.manifest.uid]) {
-      this.appUidMapping[app.manifest.uid] = currentStackApp ? currentStackApp.manifest.uid : app.manifest.uid;
-      log.debug(
-        `App UID mapping: ${app.manifest.uid} → ${this.appUidMapping[app.manifest.uid]}`,
-        this.importConfig.context,
+      // NOTE update configurations
+      if (updateParam && (!isEmpty(updateParam.configuration) || !isEmpty(updateParam.server_configuration))) {
+        log.debug(`Updating app configuration for: ${app.manifest?.name}`, this.importConfig.context);
+        await this.updateAppsConfig(updateParam);
+      } else {
+        log.debug(`No configuration update needed for: ${app.manifest?.name}`, this.importConfig.context);
+      }
+    } catch (error) {
+      this.progressManager?.tick(
+        false,
+        `${app.manifest?.name}`,
+        error?.message || 'Failed to install apps',
+        PROCESS_NAMES.INSTALL_APPS,
       );
-    }
-
-    // NOTE update configurations
-    if (updateParam && (!isEmpty(updateParam.configuration) || !isEmpty(updateParam.server_configuration))) {
-      log.debug(`Updating app configuration for: ${app.manifest?.name}`, this.importConfig.context);
-      await this.updateAppsConfig(updateParam);
-    } else {
-      log.debug(`No configuration update needed for: ${app.manifest?.name}`, this.importConfig.context);
+      throw error;
     }
   }
 
@@ -772,10 +764,10 @@ export default class ImportMarketplaceApps extends BaseClass {
     });
   }
 
-  private async prepareMarketplaceAppMapper(): Promise<void> {
+  private prepareMarketplaceAppMapper() {
     log.debug('Creating marketplace apps mapper directory', this.importConfig.context);
     fsUtil.makeDirectory(this.mapperDirPath);
-    log.debug('Created marketplace apps mapper directory', this.importConfig.context);
+    log.debug(`Created marketplace apps mapper directory, ${this.mapperDirPath}`, this.importConfig.context);
   }
 
   private async setupMarketplaceEnvironment(): Promise<void> {

--- a/packages/contentstack-import/src/import/modules/personalize.ts
+++ b/packages/contentstack-import/src/import/modules/personalize.ts
@@ -2,23 +2,24 @@ import { Import } from '@contentstack/cli-variants';
 import { log, handleAndLogError } from '@contentstack/cli-utilities';
 import BaseClass from './base-class';
 import { ImportConfig, ModuleClassParams } from '../../types';
+import { IMPORT_PROCESS_NAMES, IMPORT_MODULE_CONTEXTS, IMPORT_PROCESS_STATUS, IMPORT_MODULE_NAMES } from '../../utils';
 
 export default class ImportPersonalize extends BaseClass {
   private config: ImportConfig;
   public personalizeConfig: ImportConfig['modules']['personalize'];
 
   private readonly moduleDisplayMapper = {
-    events: 'Events',
-    attributes: 'Attributes',
-    audiences: 'Audiences',
-    experiences: 'Experiences',
+    events: 'events',
+    attributes: 'attributes',
+    audiences: 'audiences',
+    experiences: 'experiences',
   };
 
   constructor({ importConfig, stackAPIClient }: ModuleClassParams) {
     super({ importConfig, stackAPIClient });
     this.config = importConfig;
-    this.config.context.module = 'personalize';
-    this.currentModuleName = 'Personalize';
+    this.config.context.module = IMPORT_MODULE_CONTEXTS.PERSONALIZE;
+    this.currentModuleName = IMPORT_MODULE_NAMES[IMPORT_MODULE_CONTEXTS.PERSONALIZE];
     this.personalizeConfig = importConfig.modules.personalize;
   }
 
@@ -65,8 +66,11 @@ export default class ImportPersonalize extends BaseClass {
   }
 
   private addProjectProcess(progress: any) {
-    progress.addProcess('Projects', 1);
-    log.debug('Added Projects process to personalize progress', this.config.context);
+    progress.addProcess(IMPORT_PROCESS_NAMES.PERSONALIZE_PROJECTS, 1);
+    log.debug(
+      `Added ${IMPORT_PROCESS_NAMES.PERSONALIZE_PROJECTS} process to personalize progress`,
+      this.config.context,
+    );
   }
 
   private addModuleProcesses(progress: any, moduleCount: number) {
@@ -87,14 +91,14 @@ export default class ImportPersonalize extends BaseClass {
   }
 
   private async importProjects(progress: any): Promise<void> {
-    progress.startProcess('Projects').updateStatus('Importing personalization projects...', 'Projects');
+    progress.updateStatus(IMPORT_PROCESS_STATUS[IMPORT_PROCESS_NAMES.PERSONALIZE_PROJECTS].IMPORTING);
     log.debug('Starting projects import for personalization...', this.config.context);
 
     const projectInstance = new Import.Project(this.config);
     projectInstance.setParentProgressManager(progress);
     await projectInstance.import();
 
-    progress.completeProcess('Projects', true);
+    progress.completeProcess(IMPORT_PROCESS_NAMES.PERSONALIZE_PROJECTS, true);
   }
 
   private async importModules(progress: any): Promise<void> {
@@ -119,12 +123,18 @@ export default class ImportPersonalize extends BaseClass {
         log.debug(`Starting import for module: ${module}`, this.config.context);
 
         if (this.personalizeConfig.importData) {
-          const importer = new ModuleClass(this.config);
-          importer.setParentProgressManager(progress);
-          await importer.import();
+          try {
+            const importer = new ModuleClass(this.config);
+            importer.setParentProgressManager(progress);
+            await importer.import();
 
-          progress.completeProcess(processName, true);
-          log.debug(`Completed import for module: ${module}`, this.config.context);
+            progress.completeProcess(processName, true);
+            log.debug(`Completed import for module: ${module}`, this.config.context);
+          } catch (error) {
+            progress.completeProcess(processName, false);
+            log.debug(`Failed to import module: ${module} - ${(error as any)?.message}`, this.config.context);
+            handleAndLogError(error, { ...this.config.context, module });
+          }
         } else {
           log.debug(`Skipping ${module} - personalization not enabled`, this.config.context);
           this.progressManager?.tick(true, `${module} skipped (no project)`, null, processName);

--- a/packages/contentstack-import/src/import/modules/stack.ts
+++ b/packages/contentstack-import/src/import/modules/stack.ts
@@ -1,8 +1,16 @@
 import { join } from 'node:path';
-import { fileHelper, fsUtil } from '../../utils';
+import { log, handleAndLogError } from '@contentstack/cli-utilities';
+
 import BaseClass from './base-class';
+import {
+  fileHelper,
+  fsUtil,
+  IMPORT_PROCESS_NAMES,
+  IMPORT_MODULE_CONTEXTS,
+  IMPORT_PROCESS_STATUS,
+  IMPORT_MODULE_NAMES,
+} from '../../utils';
 import { ModuleClassParams } from '../../types';
-import { log, handleAndLogError, messageHandler } from '@contentstack/cli-utilities';
 
 export default class ImportStack extends BaseClass {
   private stackSettingsPath: string;
@@ -12,8 +20,8 @@ export default class ImportStack extends BaseClass {
 
   constructor({ importConfig, stackAPIClient }: ModuleClassParams) {
     super({ importConfig, stackAPIClient });
-    this.importConfig.context.module = 'stack';
-    this.currentModuleName = 'Stack';
+    this.importConfig.context.module = IMPORT_MODULE_CONTEXTS.STACK;
+    this.currentModuleName = IMPORT_MODULE_NAMES[IMPORT_MODULE_CONTEXTS.STACK];
     this.stackSettingsPath = join(this.importConfig.backupDir, 'stack', 'settings.json');
     this.envUidMapperPath = join(this.importConfig.backupDir, 'mapper', 'environments', 'uid-mapping.json');
   }
@@ -43,7 +51,7 @@ export default class ImportStack extends BaseClass {
 
       const progress = this.createSimpleProgress(this.currentModuleName, 1);
 
-      progress.updateStatus('Importing stack settings...');
+      progress.updateStatus(IMPORT_PROCESS_STATUS[IMPORT_PROCESS_NAMES.STACK_IMPORT].IMPORTING);
       log.info('Starting stack settings import process', this.importConfig.context);
       await this.importStackSettings();
 
@@ -74,7 +82,7 @@ export default class ImportStack extends BaseClass {
     log.debug('Applying stack settings to target stack', this.importConfig.context);
     await this.stack.addSettings(this.stackSettings);
 
-    this.progressManager?.tick(true, 'stack settings applied');
+    this.progressManager?.tick(true, 'stack settings applied', null, IMPORT_PROCESS_NAMES.STACK_IMPORT);
     log.debug('Stack settings applied successfully', this.importConfig.context);
   }
 

--- a/packages/contentstack-import/src/import/modules/stack.ts
+++ b/packages/contentstack-import/src/import/modules/stack.ts
@@ -2,14 +2,7 @@ import { join } from 'node:path';
 import { log, handleAndLogError } from '@contentstack/cli-utilities';
 
 import BaseClass from './base-class';
-import {
-  fileHelper,
-  fsUtil,
-  IMPORT_PROCESS_NAMES,
-  IMPORT_MODULE_CONTEXTS,
-  IMPORT_PROCESS_STATUS,
-  IMPORT_MODULE_NAMES,
-} from '../../utils';
+import { fileHelper, fsUtil, PROCESS_NAMES, MODULE_CONTEXTS, PROCESS_STATUS, MODULE_NAMES } from '../../utils';
 import { ModuleClassParams } from '../../types';
 
 export default class ImportStack extends BaseClass {
@@ -20,8 +13,8 @@ export default class ImportStack extends BaseClass {
 
   constructor({ importConfig, stackAPIClient }: ModuleClassParams) {
     super({ importConfig, stackAPIClient });
-    this.importConfig.context.module = IMPORT_MODULE_CONTEXTS.STACK;
-    this.currentModuleName = IMPORT_MODULE_NAMES[IMPORT_MODULE_CONTEXTS.STACK];
+    this.importConfig.context.module = MODULE_CONTEXTS.STACK;
+    this.currentModuleName = MODULE_NAMES[MODULE_CONTEXTS.STACK];
     this.stackSettingsPath = join(this.importConfig.backupDir, 'stack', 'settings.json');
     this.envUidMapperPath = join(this.importConfig.backupDir, 'mapper', 'environments', 'uid-mapping.json');
   }
@@ -51,7 +44,7 @@ export default class ImportStack extends BaseClass {
 
       const progress = this.createSimpleProgress(this.currentModuleName, 1);
 
-      progress.updateStatus(IMPORT_PROCESS_STATUS[IMPORT_PROCESS_NAMES.STACK_IMPORT].IMPORTING);
+      progress.updateStatus(PROCESS_STATUS[PROCESS_NAMES.STACK_IMPORT].IMPORTING);
       log.info('Starting stack settings import process', this.importConfig.context);
       await this.importStackSettings();
 
@@ -82,7 +75,7 @@ export default class ImportStack extends BaseClass {
     log.debug('Applying stack settings to target stack', this.importConfig.context);
     await this.stack.addSettings(this.stackSettings);
 
-    this.progressManager?.tick(true, 'stack settings applied', null, IMPORT_PROCESS_NAMES.STACK_IMPORT);
+    this.progressManager?.tick(true, 'stack settings applied', null, PROCESS_NAMES.STACK_IMPORT);
     log.debug('Stack settings applied successfully', this.importConfig.context);
   }
 

--- a/packages/contentstack-import/src/import/modules/taxonomies.ts
+++ b/packages/contentstack-import/src/import/modules/taxonomies.ts
@@ -4,7 +4,14 @@ import isEmpty from 'lodash/isEmpty';
 import { log, handleAndLogError } from '@contentstack/cli-utilities';
 
 import BaseClass, { ApiOptions } from './base-class';
-import { fsUtil, fileHelper } from '../../utils';
+import {
+  fsUtil,
+  fileHelper,
+  IMPORT_MODULE_CONTEXTS,
+  IMPORT_MODULE_NAMES,
+  IMPORT_PROCESS_STATUS,
+  IMPORT_PROCESS_NAMES,
+} from '../../utils';
 import { ModuleClassParams, TaxonomiesConfig } from '../../types';
 
 export default class ImportTaxonomies extends BaseClass {
@@ -24,8 +31,8 @@ export default class ImportTaxonomies extends BaseClass {
 
   constructor({ importConfig, stackAPIClient }: ModuleClassParams) {
     super({ importConfig, stackAPIClient });
-    this.importConfig.context.module = 'taxonomies';
-    this.currentModuleName = 'Taxonomies';
+    this.importConfig.context.module = IMPORT_MODULE_CONTEXTS.TAXONOMIES;
+    this.currentModuleName = IMPORT_MODULE_NAMES[IMPORT_MODULE_CONTEXTS.TAXONOMIES];
     this.taxonomiesConfig = importConfig.modules.taxonomies;
     this.taxonomiesMapperDirPath = join(importConfig.backupDir, 'mapper', 'taxonomies');
     this.termsMapperDirPath = join(this.taxonomiesMapperDirPath, 'terms');
@@ -52,7 +59,7 @@ export default class ImportTaxonomies extends BaseClass {
 
       const progress = this.createSimpleProgress(this.currentModuleName, taxonomiesCount);
       await this.prepareMapperDirectories();
-      progress.updateStatus('Importing taxonomies...');
+      progress.updateStatus(IMPORT_PROCESS_STATUS[IMPORT_PROCESS_NAMES.TAXONOMIES_IMPORT].IMPORTING);
       log.debug('Starting taxonomies import', this.importConfig.context);
       await this.importTaxonomies();
       this.createSuccessAndFailedFile();

--- a/packages/contentstack-import/src/import/modules/variant-entries.ts
+++ b/packages/contentstack-import/src/import/modules/variant-entries.ts
@@ -1,6 +1,6 @@
 import path from 'path';
-import { Import, ImportHelperMethodsConfig, ProjectStruct } from '@contentstack/cli-variants';
 import { sanitizePath, log, handleAndLogError } from '@contentstack/cli-utilities';
+import { Import, ImportHelperMethodsConfig, ProjectStruct } from '@contentstack/cli-variants';
 import { ImportConfig, ModuleClassParams } from '../../types';
 import {
   lookUpTerms,
@@ -10,6 +10,10 @@ import {
   restoreJsonRteEntryRefs,
   fsUtil,
   fileHelper,
+  IMPORT_PROCESS_NAMES,
+  IMPORT_MODULE_CONTEXTS,
+  IMPORT_PROCESS_STATUS,
+  IMPORT_MODULE_NAMES,
 } from '../../utils';
 import BaseClass from './base-class';
 
@@ -21,8 +25,8 @@ export default class ImportVariantEntries extends BaseClass {
   constructor({ importConfig, stackAPIClient }: ModuleClassParams) {
     super({ importConfig, stackAPIClient });
     this.config = importConfig;
-    this.config.context.module = 'variant-entries';
-    this.currentModuleName = 'Variant Entries';
+    this.config.context.module = IMPORT_MODULE_CONTEXTS.VARIANT_ENTRIES;
+    this.currentModuleName = IMPORT_MODULE_NAMES[IMPORT_MODULE_CONTEXTS.VARIANT_ENTRIES];
     this.personalize = importConfig.modules.personalize;
     this.projectMapperFilePath = path.resolve(
       sanitizePath(this.config.data),
@@ -50,7 +54,7 @@ export default class ImportVariantEntries extends BaseClass {
 
       const progress = this.createSimpleProgress(this.currentModuleName);
 
-      progress.updateStatus('Importing variant entries...');
+      progress.updateStatus(IMPORT_PROCESS_STATUS[IMPORT_PROCESS_NAMES.VARIANT_ENTRIES_IMPORT].IMPORTING);
       log.info('Starting variant entries import process', this.config.context);
       await this.importVariantEntries();
 
@@ -89,11 +93,21 @@ export default class ImportVariantEntries extends BaseClass {
       log.debug('Starting variant entries import', this.config.context);
       await variantEntriesImporter.import();
 
-      this.progressManager?.tick(true, 'variant entries import completed');
+      this.progressManager?.tick(
+        true,
+        'variant entries import completed',
+        null,
+        IMPORT_PROCESS_NAMES.VARIANT_ENTRIES_IMPORT,
+      );
       log.debug('Variant entries import completed successfully', this.config.context);
     } else {
       log.debug('No valid project found in mapper file', this.config.context);
-      this.progressManager?.tick(false, 'variant entries import', 'No personalize project linked');
+      this.progressManager?.tick(
+        false,
+        'variant entries import',
+        'No personalize project linked',
+        IMPORT_PROCESS_NAMES.VARIANT_ENTRIES_IMPORT,
+      );
       log.info('Skipping entry variants import because no personalize project is linked.', this.config.context);
     }
   }
@@ -105,7 +119,7 @@ export default class ImportVariantEntries extends BaseClass {
       if (!fileHelper.fileExistsSync(this.projectMapperFilePath)) {
         log.debug('Project mapper file does not exist', this.config.context);
         log.info('Skipping entry variants import because no personalize project mapper found.', this.config.context);
-        return [false] as [boolean]; 
+        return [false] as [boolean];
       }
 
       const project = fsUtil.readFile(this.projectMapperFilePath) as ProjectStruct;
@@ -117,7 +131,7 @@ export default class ImportVariantEntries extends BaseClass {
         log.debug('No valid project found in mapper file', this.config.context);
       }
 
-      return [hasValidProject] as [boolean]; 
+      return [hasValidProject] as [boolean];
     });
   }
 }

--- a/packages/contentstack-import/src/import/modules/webhooks.ts
+++ b/packages/contentstack-import/src/import/modules/webhooks.ts
@@ -3,14 +3,7 @@ import values from 'lodash/values';
 import { join } from 'node:path';
 import { log, handleAndLogError } from '@contentstack/cli-utilities';
 
-import {
-  fsUtil,
-  fileHelper,
-  IMPORT_PROCESS_NAMES,
-  IMPORT_MODULE_CONTEXTS,
-  IMPORT_PROCESS_STATUS,
-  IMPORT_MODULE_NAMES,
-} from '../../utils';
+import { fsUtil, fileHelper, PROCESS_NAMES, MODULE_CONTEXTS, PROCESS_STATUS, MODULE_NAMES } from '../../utils';
 import BaseClass, { ApiOptions } from './base-class';
 import { ModuleClassParams, WebhookConfig } from '../../types';
 
@@ -28,8 +21,8 @@ export default class ImportWebhooks extends BaseClass {
 
   constructor({ importConfig, stackAPIClient }: ModuleClassParams) {
     super({ importConfig, stackAPIClient });
-    this.importConfig.context.module = IMPORT_MODULE_CONTEXTS.WEBHOOKS;
-    this.currentModuleName = IMPORT_MODULE_NAMES[IMPORT_MODULE_CONTEXTS.WEBHOOKS];
+    this.importConfig.context.module = MODULE_CONTEXTS.WEBHOOKS;
+    this.currentModuleName = MODULE_NAMES[MODULE_CONTEXTS.WEBHOOKS];
     this.webhooksConfig = importConfig.modules.webhooks;
     this.mapperDirPath = join(this.importConfig.backupDir, 'mapper', 'webhooks');
     this.webhooksFolderPath = join(this.importConfig.backupDir, this.webhooksConfig.dirName);
@@ -60,7 +53,7 @@ export default class ImportWebhooks extends BaseClass {
       const progress = this.createSimpleProgress(this.currentModuleName, webhooksCount);
       await this.prepareWebhookMapper();
 
-      progress.updateStatus(IMPORT_PROCESS_STATUS[IMPORT_PROCESS_NAMES.WEBHOOKS_IMPORT].IMPORTING);
+      progress.updateStatus(PROCESS_STATUS[PROCESS_NAMES.WEBHOOKS_IMPORT].IMPORTING);
       await this.importWebhooks();
 
       this.processWebhookResults();
@@ -86,7 +79,7 @@ export default class ImportWebhooks extends BaseClass {
     const onSuccess = ({ response, apiData: { uid, name } = { uid: null, name: '' } }: any) => {
       this.createdWebhooks.push(response);
       this.webhookUidMapper[uid] = response.uid;
-      this.progressManager?.tick(true, `webhook: ${name || uid}`, null, IMPORT_PROCESS_NAMES.WEBHOOKS_IMPORT);
+      this.progressManager?.tick(true, `webhook: ${name || uid}`, null, PROCESS_NAMES.WEBHOOKS_IMPORT);
       log.success(`Webhook '${name}' imported successfully`, this.importConfig.context);
       log.debug(`Webhook UID mapping: ${uid} → ${response.uid}`, this.importConfig.context);
       fsUtil.writeFile(this.webhookUidMapperPath, this.webhookUidMapper);
@@ -102,7 +95,7 @@ export default class ImportWebhooks extends BaseClass {
           true,
           `webhook: ${name || uid} (already exists)`,
           null,
-          IMPORT_PROCESS_NAMES.WEBHOOKS_IMPORT,
+          PROCESS_NAMES.WEBHOOKS_IMPORT,
         );
         log.info(`Webhook '${name}' already exists`, this.importConfig.context);
       } else {
@@ -110,8 +103,8 @@ export default class ImportWebhooks extends BaseClass {
         this.progressManager?.tick(
           false,
           `webhook: ${name || uid}`,
-          error?.message || IMPORT_PROCESS_STATUS[IMPORT_PROCESS_NAMES.WEBHOOKS_IMPORT].FAILED,
-          IMPORT_PROCESS_NAMES.WEBHOOKS_IMPORT,
+          error?.message || PROCESS_STATUS[PROCESS_NAMES.WEBHOOKS_IMPORT].FAILED,
+          PROCESS_NAMES.WEBHOOKS_IMPORT,
         );
         handleAndLogError(
           error,
@@ -158,7 +151,7 @@ export default class ImportWebhooks extends BaseClass {
         true,
         `webhook: ${webhook.name} (skipped - already exists)`,
         null,
-        IMPORT_PROCESS_NAMES.WEBHOOKS_IMPORT,
+        PROCESS_NAMES.WEBHOOKS_IMPORT,
       );
       apiOptions.entity = undefined;
     } else {

--- a/packages/contentstack-import/src/import/modules/webhooks.ts
+++ b/packages/contentstack-import/src/import/modules/webhooks.ts
@@ -3,7 +3,14 @@ import values from 'lodash/values';
 import { join } from 'node:path';
 import { log, handleAndLogError } from '@contentstack/cli-utilities';
 
-import { fsUtil, fileHelper } from '../../utils';
+import {
+  fsUtil,
+  fileHelper,
+  IMPORT_PROCESS_NAMES,
+  IMPORT_MODULE_CONTEXTS,
+  IMPORT_PROCESS_STATUS,
+  IMPORT_MODULE_NAMES,
+} from '../../utils';
 import BaseClass, { ApiOptions } from './base-class';
 import { ModuleClassParams, WebhookConfig } from '../../types';
 
@@ -21,8 +28,8 @@ export default class ImportWebhooks extends BaseClass {
 
   constructor({ importConfig, stackAPIClient }: ModuleClassParams) {
     super({ importConfig, stackAPIClient });
-    this.importConfig.context.module = 'webhooks';
-    this.currentModuleName = 'Webhooks';
+    this.importConfig.context.module = IMPORT_MODULE_CONTEXTS.WEBHOOKS;
+    this.currentModuleName = IMPORT_MODULE_NAMES[IMPORT_MODULE_CONTEXTS.WEBHOOKS];
     this.webhooksConfig = importConfig.modules.webhooks;
     this.mapperDirPath = join(this.importConfig.backupDir, 'mapper', 'webhooks');
     this.webhooksFolderPath = join(this.importConfig.backupDir, this.webhooksConfig.dirName);
@@ -53,7 +60,7 @@ export default class ImportWebhooks extends BaseClass {
       const progress = this.createSimpleProgress(this.currentModuleName, webhooksCount);
       await this.prepareWebhookMapper();
 
-      progress.updateStatus('Importing webhooks...');
+      progress.updateStatus(IMPORT_PROCESS_STATUS[IMPORT_PROCESS_NAMES.WEBHOOKS_IMPORT].IMPORTING);
       await this.importWebhooks();
 
       this.processWebhookResults();
@@ -79,7 +86,7 @@ export default class ImportWebhooks extends BaseClass {
     const onSuccess = ({ response, apiData: { uid, name } = { uid: null, name: '' } }: any) => {
       this.createdWebhooks.push(response);
       this.webhookUidMapper[uid] = response.uid;
-      this.progressManager?.tick(true, `webhook: ${name || uid}`);
+      this.progressManager?.tick(true, `webhook: ${name || uid}`, null, IMPORT_PROCESS_NAMES.WEBHOOKS_IMPORT);
       log.success(`Webhook '${name}' imported successfully`, this.importConfig.context);
       log.debug(`Webhook UID mapping: ${uid} → ${response.uid}`, this.importConfig.context);
       fsUtil.writeFile(this.webhookUidMapperPath, this.webhookUidMapper);
@@ -91,11 +98,21 @@ export default class ImportWebhooks extends BaseClass {
       log.debug(`Webhook '${name}' (${uid}) failed to import`, this.importConfig.context);
 
       if (err?.errors?.name) {
-        this.progressManager?.tick(true, `webhook: ${name || uid} (already exists)`);
+        this.progressManager?.tick(
+          true,
+          `webhook: ${name || uid} (already exists)`,
+          null,
+          IMPORT_PROCESS_NAMES.WEBHOOKS_IMPORT,
+        );
         log.info(`Webhook '${name}' already exists`, this.importConfig.context);
       } else {
         this.failedWebhooks.push(apiData);
-        this.progressManager?.tick(false, `webhook: ${name || uid}`, error?.message || 'Failed to import webhook');
+        this.progressManager?.tick(
+          false,
+          `webhook: ${name || uid}`,
+          error?.message || IMPORT_PROCESS_STATUS[IMPORT_PROCESS_NAMES.WEBHOOKS_IMPORT].FAILED,
+          IMPORT_PROCESS_NAMES.WEBHOOKS_IMPORT,
+        );
         handleAndLogError(
           error,
           { ...this.importConfig.context, webhookName: name },
@@ -137,7 +154,12 @@ export default class ImportWebhooks extends BaseClass {
     if (this.webhookUidMapper.hasOwnProperty(webhook.uid)) {
       log.info(`Webhook '${webhook.name}' already exists. Skipping it to avoid duplicates!`, this.importConfig.context);
       log.debug(`Skipping webhook serialization for: ${webhook.uid}`, this.importConfig.context);
-      this.progressManager?.tick(true, `webhook: ${webhook.name} (skipped - already exists)`);
+      this.progressManager?.tick(
+        true,
+        `webhook: ${webhook.name} (skipped - already exists)`,
+        null,
+        IMPORT_PROCESS_NAMES.WEBHOOKS_IMPORT,
+      );
       apiOptions.entity = undefined;
     } else {
       log.debug(`Processing webhook status configuration`, this.importConfig.context);

--- a/packages/contentstack-import/src/utils/constants.ts
+++ b/packages/contentstack-import/src/utils/constants.ts
@@ -1,0 +1,278 @@
+export const IMPORT_PROCESS_NAMES = {
+  // Assets module
+  ASSET_FOLDERS: 'Folders',
+  ASSET_VERSIONS: 'Versions',
+  ASSET_UPLOAD: 'Upload',
+  ASSET_PUBLISH: 'Publish',
+
+  // Content Types module
+  CONTENT_TYPES_CREATE: 'Content Types Create',
+  CONTENT_TYPES_UPDATE: 'Content Types Update',
+  CONTENT_TYPES_REPLACE_EXISTING: 'Content Types Replace Existing',
+
+  // Entries module
+  CT_PREPARATION: 'CT Preparation',
+  ENTRIES_CREATE: 'Entries Create',
+  ENTRIES_REPLACE_EXISTING: 'Entries Replace Existing',
+  REFERENCE_UPDATES: 'Reference Updates',
+  CT_RESTORATION: 'CT Restoration',
+  FIELD_RULES_UPDATE: 'Field Rules Update',
+  ENTRIES_PUBLISH: 'Entries Publish',
+  CLEANUP: 'Cleanup',
+
+  // Extensions module
+  EXTENSIONS_CREATE: 'Extensions Create',
+  EXTENSIONS_REPLACE_EXISTING: 'Extensions Replace Existing',
+
+  // Global Fields module
+  GLOBAL_FIELDS_CREATE: 'Global Fields Create',
+  GLOBAL_FIELDS_UPDATE: 'Global Fields Update',
+  GLOBAL_FIELDS_REPLACE_EXISTING: 'Global Fields Replace Existing',
+
+  // Labels module
+  LABELS_CREATE: 'Labels Create',
+  LABELS_UPDATE: 'Labels Update',
+
+  // Locales module
+  MASTER_LOCALE: 'Master Locale',
+  LOCALES_CREATE: 'Locales Create',
+  LOCALES_UPDATE: 'Locales Update',
+
+  // Marketplace Apps module
+  SETUP_ENVIRONMENT: 'Setup Environment',
+  CREATE_APPS: 'Create Apps',
+  INSTALL_APPS: 'Install Apps',
+
+  // Workflows module
+  GET_ROLES: 'Get Roles',
+  WORKFLOWS_CREATE: 'Workflows Create',
+
+  // Additional processes for import modules
+  VARIANT_ENTRIES_IMPORT: 'Variant Entries Import',
+  ENVIRONMENTS_IMPORT: 'Environments Import',
+  CUSTOM_ROLES_BUILD_MAPPINGS: 'Custom Roles Build Mappings',
+  CUSTOM_ROLES_IMPORT: 'Custom Roles Import',
+  STACK_IMPORT: 'Stack Import',
+  CONTENT_TYPES_GF_UPDATE: 'Content Types GF Update',
+  CONTENT_TYPES_EXT_UPDATE: 'Content Types Ext Update',
+  WEBHOOKS_IMPORT: 'Webhooks Import',
+  TAXONOMIES_IMPORT: 'Taxonomies Import',
+  PERSONALIZE_PROJECTS: 'Personalize Projects',
+} as const;
+
+export const IMPORT_MODULE_CONTEXTS = {
+  ASSETS: 'assets',
+  CONTENT_TYPES: 'content-types',
+  CUSTOM_ROLES: 'custom-roles',
+  ENTRIES: 'entries',
+  ENVIRONMENTS: 'environments',
+  EXTENSIONS: 'extensions',
+  GLOBAL_FIELDS: 'global-fields',
+  LABELS: 'labels',
+  LOCALES: 'locales',
+  MARKETPLACE_APPS: 'marketplace-apps',
+  PERSONALIZE: 'personalize',
+  STACK: 'stack',
+  TAXONOMIES: 'taxonomies',
+  VARIANT_ENTRIES: 'variant-entries',
+  WEBHOOKS: 'webhooks',
+  WORKFLOWS: 'workflows',
+} as const;
+
+// Display names for modules to avoid scattering user-facing strings
+export const IMPORT_MODULE_NAMES = {
+  [IMPORT_MODULE_CONTEXTS.ASSETS]: 'Assets',
+  [IMPORT_MODULE_CONTEXTS.CONTENT_TYPES]: 'Content Types',
+  [IMPORT_MODULE_CONTEXTS.CUSTOM_ROLES]: 'Custom Roles',
+  [IMPORT_MODULE_CONTEXTS.ENTRIES]: 'Entries',
+  [IMPORT_MODULE_CONTEXTS.ENVIRONMENTS]: 'Environments',
+  [IMPORT_MODULE_CONTEXTS.EXTENSIONS]: 'Extensions',
+  [IMPORT_MODULE_CONTEXTS.GLOBAL_FIELDS]: 'Global Fields',
+  [IMPORT_MODULE_CONTEXTS.LABELS]: 'Labels',
+  [IMPORT_MODULE_CONTEXTS.LOCALES]: 'Locales',
+  [IMPORT_MODULE_CONTEXTS.MARKETPLACE_APPS]: 'Marketplace Apps',
+  [IMPORT_MODULE_CONTEXTS.PERSONALIZE]: 'Personalize',
+  [IMPORT_MODULE_CONTEXTS.STACK]: 'Stack',
+  [IMPORT_MODULE_CONTEXTS.TAXONOMIES]: 'Taxonomies',
+  [IMPORT_MODULE_CONTEXTS.VARIANT_ENTRIES]: 'Variant Entries',
+  [IMPORT_MODULE_CONTEXTS.WEBHOOKS]: 'Webhooks',
+  [IMPORT_MODULE_CONTEXTS.WORKFLOWS]: 'Workflows',
+} as const;
+
+export const IMPORT_PROCESS_STATUS = {
+  // Assets
+  [IMPORT_PROCESS_NAMES.ASSET_FOLDERS]: {
+    CREATING: 'Creating asset folders...',
+    FAILED: 'Failed to create asset folders.',
+  },
+  [IMPORT_PROCESS_NAMES.ASSET_VERSIONS]: {
+    IMPORTING: 'Importing asset versions...',
+    FAILED: 'Failed to process asset versions.',
+  },
+  [IMPORT_PROCESS_NAMES.ASSET_UPLOAD]: {
+    UPLOADING: 'Uploading asset files...',
+    FAILED: 'Failed to upload assets.',
+  },
+  [IMPORT_PROCESS_NAMES.ASSET_PUBLISH]: {
+    PUBLISHING: 'Publishing assets...',
+    FAILED: 'Failed to publish assets.',
+  },
+  // Content Types
+  [IMPORT_PROCESS_NAMES.CONTENT_TYPES_CREATE]: {
+    CREATING: 'Creating content types...',
+    FAILED: 'Failed to create content types.',
+  },
+  [IMPORT_PROCESS_NAMES.CONTENT_TYPES_UPDATE]: {
+    UPDATING: 'Updating content types with references...',
+    FAILED: 'Failed to update content types.',
+  },
+  [IMPORT_PROCESS_NAMES.CONTENT_TYPES_REPLACE_EXISTING]: {
+    REPLACING: 'Replacing existing content types...',
+    FAILED: 'Failed to replace existing content types.',
+  },
+  // Entries
+  [IMPORT_PROCESS_NAMES.CT_PREPARATION]: {
+    PREPARING: 'Preparing content types for entry import...',
+    FAILED: 'Failed to prepare content types.',
+  },
+  [IMPORT_PROCESS_NAMES.ENTRIES_CREATE]: {
+    CREATING: 'Creating entries...',
+    FAILED: 'Failed to create entries.',
+  },
+  [IMPORT_PROCESS_NAMES.ENTRIES_REPLACE_EXISTING]: {
+    REPLACING: 'Replacing existing entries...',
+    FAILED: 'Failed to replace existing entries.',
+  },
+  [IMPORT_PROCESS_NAMES.REFERENCE_UPDATES]: {
+    UPDATING: 'Updating entry references...',
+    FAILED: 'Failed to update entry references.',
+  },
+  [IMPORT_PROCESS_NAMES.CT_RESTORATION]: {
+    RESTORING: 'Restoring content type references...',
+    FAILED: 'Failed to restore content types.',
+  },
+  [IMPORT_PROCESS_NAMES.FIELD_RULES_UPDATE]: {
+    UPDATING: 'Updating field rules...',
+    FAILED: 'Failed to update field rules.',
+  },
+  [IMPORT_PROCESS_NAMES.ENTRIES_PUBLISH]: {
+    PUBLISHING: 'Publishing entries...',
+    FAILED: 'Failed to publish entries.',
+  },
+  [IMPORT_PROCESS_NAMES.CLEANUP]: {
+    CLEANING: 'Cleaning up auto-created entries...',
+    FAILED: 'Failed to clean up temporary data.',
+  },
+  // Extensions
+  [IMPORT_PROCESS_NAMES.EXTENSIONS_CREATE]: {
+    CREATING: 'Creating extensions...',
+    FAILED: 'Failed to create extensions.',
+  },
+  [IMPORT_PROCESS_NAMES.EXTENSIONS_REPLACE_EXISTING]: {
+    REPLACING: 'Replacing existing extensions...',
+    FAILED: 'Failed to replace existing extensions.',
+  },
+  // Global Fields
+  [IMPORT_PROCESS_NAMES.GLOBAL_FIELDS_CREATE]: {
+    CREATING: 'Creating global fields...',
+    FAILED: 'Failed to create global fields.',
+  },
+  [IMPORT_PROCESS_NAMES.GLOBAL_FIELDS_UPDATE]: {
+    UPDATING: 'Updating global fields...',
+    FAILED: 'Failed to update global fields.',
+  },
+  [IMPORT_PROCESS_NAMES.GLOBAL_FIELDS_REPLACE_EXISTING]: {
+    REPLACING: 'Replacing existing global fields...',
+    FAILED: 'Failed to replace existing global fields.',
+  },
+  // Labels
+  [IMPORT_PROCESS_NAMES.LABELS_CREATE]: {
+    CREATING: 'Creating labels...',
+    FAILED: 'Failed to create labels.',
+  },
+  [IMPORT_PROCESS_NAMES.LABELS_UPDATE]: {
+    UPDATING: 'Updating labels...',
+    FAILED: 'Failed to update labels.',
+  },
+  // Locales
+  [IMPORT_PROCESS_NAMES.MASTER_LOCALE]: {
+    PROCESSING: 'Processing master locale...',
+    FAILED: 'Failed to process master locale.',
+  },
+  [IMPORT_PROCESS_NAMES.LOCALES_CREATE]: {
+    CREATING: 'Creating locales...',
+    FAILED: 'Failed to create locales.',
+  },
+  [IMPORT_PROCESS_NAMES.LOCALES_UPDATE]: {
+    UPDATING: 'Updating locales...',
+    FAILED: 'Failed to update locales.',
+  },
+  // Marketplace Apps
+  [IMPORT_PROCESS_NAMES.SETUP_ENVIRONMENT]: {
+    SETTING_UP: 'Setting up marketplace SDK and authentication...',
+    FAILED: 'Failed to setup environment.',
+  },
+  [IMPORT_PROCESS_NAMES.CREATE_APPS]: {
+    CREATING: 'Creating private apps...',
+    FAILED: 'Failed to create marketplace apps.',
+  },
+  [IMPORT_PROCESS_NAMES.INSTALL_APPS]: {
+    INSTALLING: 'Installing marketplace apps...',
+    FAILED: 'Failed to install marketplace apps.',
+  },
+  // Workflows
+  [IMPORT_PROCESS_NAMES.GET_ROLES]: {
+    FETCHING: 'Fetching roles for workflow processing...',
+    FAILED: 'Failed to fetch workflow roles.',
+  },
+  [IMPORT_PROCESS_NAMES.WORKFLOWS_CREATE]: {
+    IMPORTING: 'Importing workflows...',
+    FAILED: 'Failed to create workflows.',
+  },
+
+  // Additional import processes
+  [IMPORT_PROCESS_NAMES.VARIANT_ENTRIES_IMPORT]: {
+    IMPORTING: 'Importing variant entries...',
+    FAILED: 'Failed to import variant entries.',
+  },
+  [IMPORT_PROCESS_NAMES.ENVIRONMENTS_IMPORT]: {
+    IMPORTING: 'Importing environments...',
+    FAILED: 'Failed to import environments.',
+  },
+  [IMPORT_PROCESS_NAMES.CUSTOM_ROLES_BUILD_MAPPINGS]: {
+    BUILDING: 'Building locale mappings...',
+    FAILED: 'Failed to build locale mappings.',
+  },
+  [IMPORT_PROCESS_NAMES.CUSTOM_ROLES_IMPORT]: {
+    IMPORTING: 'Importing custom roles...',
+    FAILED: 'Failed to import custom roles.',
+  },
+  [IMPORT_PROCESS_NAMES.STACK_IMPORT]: {
+    IMPORTING: 'Importing stack settings...',
+    FAILED: 'Failed to import stack settings.',
+  },
+  [IMPORT_PROCESS_NAMES.CONTENT_TYPES_GF_UPDATE]: {
+    UPDATING: 'Updating global fields with content type references...',
+    FAILED: 'Failed to update global fields.',
+  },
+  [IMPORT_PROCESS_NAMES.CONTENT_TYPES_EXT_UPDATE]: {
+    UPDATING: 'Updating extensions...',
+    FAILED: 'Failed to update extensions.',
+  },
+  [IMPORT_PROCESS_NAMES.WEBHOOKS_IMPORT]: {
+    IMPORTING: 'Importing webhooks...',
+    FAILED: 'Failed to import webhooks.',
+  },
+  [IMPORT_PROCESS_NAMES.TAXONOMIES_IMPORT]: {
+    IMPORTING: 'Importing taxonomies...',
+    FAILED: 'Failed to import taxonomies.',
+  },
+  [IMPORT_PROCESS_NAMES.PERSONALIZE_PROJECTS]: {
+    IMPORTING: 'Importing personalization projects...',
+    FAILED: 'Failed to import personalization projects.',
+  },
+};
+
+export type ImportProcessName = (typeof IMPORT_PROCESS_NAMES)[keyof typeof IMPORT_PROCESS_NAMES];
+export type ImportModuleContext = (typeof IMPORT_MODULE_CONTEXTS)[keyof typeof IMPORT_MODULE_CONTEXTS];
+export type ImportProcessStatus = (typeof IMPORT_PROCESS_STATUS)[keyof typeof IMPORT_PROCESS_STATUS];

--- a/packages/contentstack-import/src/utils/constants.ts
+++ b/packages/contentstack-import/src/utils/constants.ts
@@ -48,7 +48,7 @@ export const PROCESS_NAMES = {
   WORKFLOWS_CREATE: 'Workflows Create',
 
   // Additional processes for import modules
-  VARIANT_ENTRIES_IMPORT: 'Variant Entries Import',
+  VARIANT_ENTRIES_IMPORT: 'Variant Entries',
   ENVIRONMENTS_IMPORT: 'Environments Import',
   CUSTOM_ROLES_BUILD_MAPPINGS: 'Custom Roles Build Mappings',
   CUSTOM_ROLES_IMPORT: 'Custom Roles Import',

--- a/packages/contentstack-import/src/utils/constants.ts
+++ b/packages/contentstack-import/src/utils/constants.ts
@@ -1,4 +1,4 @@
-export const IMPORT_PROCESS_NAMES = {
+export const PROCESS_NAMES = {
   // Assets module
   ASSET_FOLDERS: 'Folders',
   ASSET_VERSIONS: 'Versions',
@@ -57,10 +57,10 @@ export const IMPORT_PROCESS_NAMES = {
   CONTENT_TYPES_EXT_UPDATE: 'Content Types Ext Update',
   WEBHOOKS_IMPORT: 'Webhooks Import',
   TAXONOMIES_IMPORT: 'Taxonomies Import',
-  PERSONALIZE_PROJECTS: 'Personalize Projects',
+  PERSONALIZE_PROJECTS: 'Projects',
 } as const;
 
-export const IMPORT_MODULE_CONTEXTS = {
+export const MODULE_CONTEXTS = {
   ASSETS: 'assets',
   CONTENT_TYPES: 'content-types',
   CUSTOM_ROLES: 'custom-roles',
@@ -80,199 +80,199 @@ export const IMPORT_MODULE_CONTEXTS = {
 } as const;
 
 // Display names for modules to avoid scattering user-facing strings
-export const IMPORT_MODULE_NAMES = {
-  [IMPORT_MODULE_CONTEXTS.ASSETS]: 'Assets',
-  [IMPORT_MODULE_CONTEXTS.CONTENT_TYPES]: 'Content Types',
-  [IMPORT_MODULE_CONTEXTS.CUSTOM_ROLES]: 'Custom Roles',
-  [IMPORT_MODULE_CONTEXTS.ENTRIES]: 'Entries',
-  [IMPORT_MODULE_CONTEXTS.ENVIRONMENTS]: 'Environments',
-  [IMPORT_MODULE_CONTEXTS.EXTENSIONS]: 'Extensions',
-  [IMPORT_MODULE_CONTEXTS.GLOBAL_FIELDS]: 'Global Fields',
-  [IMPORT_MODULE_CONTEXTS.LABELS]: 'Labels',
-  [IMPORT_MODULE_CONTEXTS.LOCALES]: 'Locales',
-  [IMPORT_MODULE_CONTEXTS.MARKETPLACE_APPS]: 'Marketplace Apps',
-  [IMPORT_MODULE_CONTEXTS.PERSONALIZE]: 'Personalize',
-  [IMPORT_MODULE_CONTEXTS.STACK]: 'Stack',
-  [IMPORT_MODULE_CONTEXTS.TAXONOMIES]: 'Taxonomies',
-  [IMPORT_MODULE_CONTEXTS.VARIANT_ENTRIES]: 'Variant Entries',
-  [IMPORT_MODULE_CONTEXTS.WEBHOOKS]: 'Webhooks',
-  [IMPORT_MODULE_CONTEXTS.WORKFLOWS]: 'Workflows',
+export const MODULE_NAMES = {
+  [MODULE_CONTEXTS.ASSETS]: 'Assets',
+  [MODULE_CONTEXTS.CONTENT_TYPES]: 'Content Types',
+  [MODULE_CONTEXTS.CUSTOM_ROLES]: 'Custom Roles',
+  [MODULE_CONTEXTS.ENTRIES]: 'Entries',
+  [MODULE_CONTEXTS.ENVIRONMENTS]: 'Environments',
+  [MODULE_CONTEXTS.EXTENSIONS]: 'Extensions',
+  [MODULE_CONTEXTS.GLOBAL_FIELDS]: 'Global Fields',
+  [MODULE_CONTEXTS.LABELS]: 'Labels',
+  [MODULE_CONTEXTS.LOCALES]: 'Locales',
+  [MODULE_CONTEXTS.MARKETPLACE_APPS]: 'Marketplace Apps',
+  [MODULE_CONTEXTS.PERSONALIZE]: 'Personalize',
+  [MODULE_CONTEXTS.STACK]: 'Stack',
+  [MODULE_CONTEXTS.TAXONOMIES]: 'Taxonomies',
+  [MODULE_CONTEXTS.VARIANT_ENTRIES]: 'Variant Entries',
+  [MODULE_CONTEXTS.WEBHOOKS]: 'Webhooks',
+  [MODULE_CONTEXTS.WORKFLOWS]: 'Workflows',
 } as const;
 
-export const IMPORT_PROCESS_STATUS = {
+export const PROCESS_STATUS = {
   // Assets
-  [IMPORT_PROCESS_NAMES.ASSET_FOLDERS]: {
+  [PROCESS_NAMES.ASSET_FOLDERS]: {
     CREATING: 'Creating asset folders...',
     FAILED: 'Failed to create asset folders.',
   },
-  [IMPORT_PROCESS_NAMES.ASSET_VERSIONS]: {
+  [PROCESS_NAMES.ASSET_VERSIONS]: {
     IMPORTING: 'Importing asset versions...',
     FAILED: 'Failed to process asset versions.',
   },
-  [IMPORT_PROCESS_NAMES.ASSET_UPLOAD]: {
+  [PROCESS_NAMES.ASSET_UPLOAD]: {
     UPLOADING: 'Uploading asset files...',
     FAILED: 'Failed to upload assets.',
   },
-  [IMPORT_PROCESS_NAMES.ASSET_PUBLISH]: {
+  [PROCESS_NAMES.ASSET_PUBLISH]: {
     PUBLISHING: 'Publishing assets...',
     FAILED: 'Failed to publish assets.',
   },
   // Content Types
-  [IMPORT_PROCESS_NAMES.CONTENT_TYPES_CREATE]: {
+  [PROCESS_NAMES.CONTENT_TYPES_CREATE]: {
     CREATING: 'Creating content types...',
     FAILED: 'Failed to create content types.',
   },
-  [IMPORT_PROCESS_NAMES.CONTENT_TYPES_UPDATE]: {
+  [PROCESS_NAMES.CONTENT_TYPES_UPDATE]: {
     UPDATING: 'Updating content types with references...',
     FAILED: 'Failed to update content types.',
   },
-  [IMPORT_PROCESS_NAMES.CONTENT_TYPES_REPLACE_EXISTING]: {
+  [PROCESS_NAMES.CONTENT_TYPES_REPLACE_EXISTING]: {
     REPLACING: 'Replacing existing content types...',
     FAILED: 'Failed to replace existing content types.',
   },
   // Entries
-  [IMPORT_PROCESS_NAMES.CT_PREPARATION]: {
+  [PROCESS_NAMES.CT_PREPARATION]: {
     PREPARING: 'Preparing content types for entry import...',
     FAILED: 'Failed to prepare content types.',
   },
-  [IMPORT_PROCESS_NAMES.ENTRIES_CREATE]: {
+  [PROCESS_NAMES.ENTRIES_CREATE]: {
     CREATING: 'Creating entries...',
     FAILED: 'Failed to create entries.',
   },
-  [IMPORT_PROCESS_NAMES.ENTRIES_REPLACE_EXISTING]: {
+  [PROCESS_NAMES.ENTRIES_REPLACE_EXISTING]: {
     REPLACING: 'Replacing existing entries...',
     FAILED: 'Failed to replace existing entries.',
   },
-  [IMPORT_PROCESS_NAMES.REFERENCE_UPDATES]: {
+  [PROCESS_NAMES.REFERENCE_UPDATES]: {
     UPDATING: 'Updating entry references...',
     FAILED: 'Failed to update entry references.',
   },
-  [IMPORT_PROCESS_NAMES.CT_RESTORATION]: {
+  [PROCESS_NAMES.CT_RESTORATION]: {
     RESTORING: 'Restoring content type references...',
     FAILED: 'Failed to restore content types.',
   },
-  [IMPORT_PROCESS_NAMES.FIELD_RULES_UPDATE]: {
+  [PROCESS_NAMES.FIELD_RULES_UPDATE]: {
     UPDATING: 'Updating field rules...',
     FAILED: 'Failed to update field rules.',
   },
-  [IMPORT_PROCESS_NAMES.ENTRIES_PUBLISH]: {
+  [PROCESS_NAMES.ENTRIES_PUBLISH]: {
     PUBLISHING: 'Publishing entries...',
     FAILED: 'Failed to publish entries.',
   },
-  [IMPORT_PROCESS_NAMES.CLEANUP]: {
+  [PROCESS_NAMES.CLEANUP]: {
     CLEANING: 'Cleaning up auto-created entries...',
     FAILED: 'Failed to clean up temporary data.',
   },
   // Extensions
-  [IMPORT_PROCESS_NAMES.EXTENSIONS_CREATE]: {
+  [PROCESS_NAMES.EXTENSIONS_CREATE]: {
     CREATING: 'Creating extensions...',
     FAILED: 'Failed to create extensions.',
   },
-  [IMPORT_PROCESS_NAMES.EXTENSIONS_REPLACE_EXISTING]: {
+  [PROCESS_NAMES.EXTENSIONS_REPLACE_EXISTING]: {
     REPLACING: 'Replacing existing extensions...',
     FAILED: 'Failed to replace existing extensions.',
   },
   // Global Fields
-  [IMPORT_PROCESS_NAMES.GLOBAL_FIELDS_CREATE]: {
+  [PROCESS_NAMES.GLOBAL_FIELDS_CREATE]: {
     CREATING: 'Creating global fields...',
     FAILED: 'Failed to create global fields.',
   },
-  [IMPORT_PROCESS_NAMES.GLOBAL_FIELDS_UPDATE]: {
+  [PROCESS_NAMES.GLOBAL_FIELDS_UPDATE]: {
     UPDATING: 'Updating global fields...',
     FAILED: 'Failed to update global fields.',
   },
-  [IMPORT_PROCESS_NAMES.GLOBAL_FIELDS_REPLACE_EXISTING]: {
+  [PROCESS_NAMES.GLOBAL_FIELDS_REPLACE_EXISTING]: {
     REPLACING: 'Replacing existing global fields...',
     FAILED: 'Failed to replace existing global fields.',
   },
   // Labels
-  [IMPORT_PROCESS_NAMES.LABELS_CREATE]: {
+  [PROCESS_NAMES.LABELS_CREATE]: {
     CREATING: 'Creating labels...',
     FAILED: 'Failed to create labels.',
   },
-  [IMPORT_PROCESS_NAMES.LABELS_UPDATE]: {
+  [PROCESS_NAMES.LABELS_UPDATE]: {
     UPDATING: 'Updating labels...',
     FAILED: 'Failed to update labels.',
   },
   // Locales
-  [IMPORT_PROCESS_NAMES.MASTER_LOCALE]: {
+  [PROCESS_NAMES.MASTER_LOCALE]: {
     PROCESSING: 'Processing master locale...',
     FAILED: 'Failed to process master locale.',
   },
-  [IMPORT_PROCESS_NAMES.LOCALES_CREATE]: {
+  [PROCESS_NAMES.LOCALES_CREATE]: {
     CREATING: 'Creating locales...',
     FAILED: 'Failed to create locales.',
   },
-  [IMPORT_PROCESS_NAMES.LOCALES_UPDATE]: {
+  [PROCESS_NAMES.LOCALES_UPDATE]: {
     UPDATING: 'Updating locales...',
     FAILED: 'Failed to update locales.',
   },
   // Marketplace Apps
-  [IMPORT_PROCESS_NAMES.SETUP_ENVIRONMENT]: {
+  [PROCESS_NAMES.SETUP_ENVIRONMENT]: {
     SETTING_UP: 'Setting up marketplace SDK and authentication...',
     FAILED: 'Failed to setup environment.',
   },
-  [IMPORT_PROCESS_NAMES.CREATE_APPS]: {
+  [PROCESS_NAMES.CREATE_APPS]: {
     CREATING: 'Creating private apps...',
     FAILED: 'Failed to create marketplace apps.',
   },
-  [IMPORT_PROCESS_NAMES.INSTALL_APPS]: {
+  [PROCESS_NAMES.INSTALL_APPS]: {
     INSTALLING: 'Installing marketplace apps...',
     FAILED: 'Failed to install marketplace apps.',
   },
   // Workflows
-  [IMPORT_PROCESS_NAMES.GET_ROLES]: {
+  [PROCESS_NAMES.GET_ROLES]: {
     FETCHING: 'Fetching roles for workflow processing...',
     FAILED: 'Failed to fetch workflow roles.',
   },
-  [IMPORT_PROCESS_NAMES.WORKFLOWS_CREATE]: {
+  [PROCESS_NAMES.WORKFLOWS_CREATE]: {
     IMPORTING: 'Importing workflows...',
     FAILED: 'Failed to create workflows.',
   },
 
   // Additional import processes
-  [IMPORT_PROCESS_NAMES.VARIANT_ENTRIES_IMPORT]: {
+  [PROCESS_NAMES.VARIANT_ENTRIES_IMPORT]: {
     IMPORTING: 'Importing variant entries...',
     FAILED: 'Failed to import variant entries.',
   },
-  [IMPORT_PROCESS_NAMES.ENVIRONMENTS_IMPORT]: {
+  [PROCESS_NAMES.ENVIRONMENTS_IMPORT]: {
     IMPORTING: 'Importing environments...',
     FAILED: 'Failed to import environments.',
   },
-  [IMPORT_PROCESS_NAMES.CUSTOM_ROLES_BUILD_MAPPINGS]: {
+  [PROCESS_NAMES.CUSTOM_ROLES_BUILD_MAPPINGS]: {
     BUILDING: 'Building locale mappings...',
     FAILED: 'Failed to build locale mappings.',
   },
-  [IMPORT_PROCESS_NAMES.CUSTOM_ROLES_IMPORT]: {
+  [PROCESS_NAMES.CUSTOM_ROLES_IMPORT]: {
     IMPORTING: 'Importing custom roles...',
     FAILED: 'Failed to import custom roles.',
   },
-  [IMPORT_PROCESS_NAMES.STACK_IMPORT]: {
+  [PROCESS_NAMES.STACK_IMPORT]: {
     IMPORTING: 'Importing stack settings...',
     FAILED: 'Failed to import stack settings.',
   },
-  [IMPORT_PROCESS_NAMES.CONTENT_TYPES_GF_UPDATE]: {
+  [PROCESS_NAMES.CONTENT_TYPES_GF_UPDATE]: {
     UPDATING: 'Updating global fields with content type references...',
     FAILED: 'Failed to update global fields.',
   },
-  [IMPORT_PROCESS_NAMES.CONTENT_TYPES_EXT_UPDATE]: {
+  [PROCESS_NAMES.CONTENT_TYPES_EXT_UPDATE]: {
     UPDATING: 'Updating extensions...',
     FAILED: 'Failed to update extensions.',
   },
-  [IMPORT_PROCESS_NAMES.WEBHOOKS_IMPORT]: {
+  [PROCESS_NAMES.WEBHOOKS_IMPORT]: {
     IMPORTING: 'Importing webhooks...',
     FAILED: 'Failed to import webhooks.',
   },
-  [IMPORT_PROCESS_NAMES.TAXONOMIES_IMPORT]: {
+  [PROCESS_NAMES.TAXONOMIES_IMPORT]: {
     IMPORTING: 'Importing taxonomies...',
     FAILED: 'Failed to import taxonomies.',
   },
-  [IMPORT_PROCESS_NAMES.PERSONALIZE_PROJECTS]: {
+  [PROCESS_NAMES.PERSONALIZE_PROJECTS]: {
     IMPORTING: 'Importing personalization projects...',
     FAILED: 'Failed to import personalization projects.',
   },
 };
 
-export type ImportProcessName = (typeof IMPORT_PROCESS_NAMES)[keyof typeof IMPORT_PROCESS_NAMES];
-export type ImportModuleContext = (typeof IMPORT_MODULE_CONTEXTS)[keyof typeof IMPORT_MODULE_CONTEXTS];
-export type ImportProcessStatus = (typeof IMPORT_PROCESS_STATUS)[keyof typeof IMPORT_PROCESS_STATUS];
+export type ImportProcessName = (typeof PROCESS_NAMES)[keyof typeof PROCESS_NAMES];
+export type ImportModuleContext = (typeof MODULE_CONTEXTS)[keyof typeof MODULE_CONTEXTS];
+export type ImportProcessStatus = (typeof PROCESS_STATUS)[keyof typeof PROCESS_STATUS];

--- a/packages/contentstack-import/src/utils/content-type-helper.ts
+++ b/packages/contentstack-import/src/utils/content-type-helper.ts
@@ -132,8 +132,7 @@ export const removeReferenceFields = async function (
           } catch (error) {
             // Else warn and modify the schema object.
             isContentTypeError = true;
-            log.warn(`Content type does not exist: ${schema[i].reference_to[j]}`);
-            console.warn(`Content-type ${schema[i].reference_to[j]} does not exist. Removing the field from schema`);
+            log.warn(`Content-type ${schema[i].reference_to[j]} does not exist. Removing the field from schema`);
           }
         }
         

--- a/packages/contentstack-import/src/utils/index.ts
+++ b/packages/contentstack-import/src/utils/index.ts
@@ -26,4 +26,4 @@ export {
 export * from './common-helper';
 export * from './log';
 export { lookUpTaxonomy, lookUpTerms } from './taxonomies-helper';
-export { IMPORT_MODULE_CONTEXTS, IMPORT_MODULE_NAMES, IMPORT_PROCESS_NAMES, IMPORT_PROCESS_STATUS } from './constants';
+export { MODULE_CONTEXTS, MODULE_NAMES, PROCESS_NAMES, PROCESS_STATUS } from './constants';

--- a/packages/contentstack-import/src/utils/index.ts
+++ b/packages/contentstack-import/src/utils/index.ts
@@ -26,3 +26,4 @@ export {
 export * from './common-helper';
 export * from './log';
 export { lookUpTaxonomy, lookUpTerms } from './taxonomies-helper';
+export { IMPORT_MODULE_CONTEXTS, IMPORT_MODULE_NAMES, IMPORT_PROCESS_NAMES, IMPORT_PROCESS_STATUS } from './constants';

--- a/packages/contentstack-import/src/utils/marketplace-app-helper.ts
+++ b/packages/contentstack-import/src/utils/marketplace-app-helper.ts
@@ -79,8 +79,7 @@ export const getOrgUid = async (config: ImportConfig): Promise<string> => {
     .stack({ api_key: config.target_stack })
     .fetch()
     .catch((error: any) => {
-      handleAndLogError(error);
-      trace(error, 'error', true);
+      throw error;
     });
 
   const orgUid = tempStackData?.org_uid || '';
@@ -122,7 +121,7 @@ export const getConfirmationToCreateApps = async (privateApps: any, config: Impo
           log.info('User confirmed to create private apps');
           return Promise.resolve(true);
         } else {
-          log.debug('User declined to create private apps (second prompt)');
+          log.warn('User declined to create private apps (second prompt)');
           return Promise.resolve(false);
         }
       }
@@ -131,7 +130,7 @@ export const getConfirmationToCreateApps = async (privateApps: any, config: Impo
       return Promise.resolve(true);
     }
   } else {
-    log.debug('Force prompt disabled, automatically creating private apps');
+    log.info('Force prompt disabled, automatically creating private apps');
     return Promise.resolve(true);
   }
 };

--- a/packages/contentstack-import/src/utils/strategy-registrations.ts
+++ b/packages/contentstack-import/src/utils/strategy-registrations.ts
@@ -4,129 +4,112 @@
  * to ensure correct item counts in the final summary.
  */
 
-import { 
-  ProgressStrategyRegistry, 
-  PrimaryProcessStrategy, 
+import {
+  ProgressStrategyRegistry,
+  PrimaryProcessStrategy,
   CustomProgressStrategy,
-  DefaultProgressStrategy 
+  DefaultProgressStrategy,
 } from '@contentstack/cli-utilities';
+import { MODULE_CONTEXTS, MODULE_NAMES, PROCESS_NAMES } from './constants';
 
 // Register strategy for Content Types - use Create as primary process
 ProgressStrategyRegistry.register(
-  'CONTENT TYPES',
-  new PrimaryProcessStrategy('Create')
+  MODULE_NAMES[MODULE_CONTEXTS.CONTENT_TYPES],
+  new PrimaryProcessStrategy(PROCESS_NAMES.CONTENT_TYPES_CREATE),
 );
 
-// Register strategy for Assets - use Asset Upload as primary process  
+// Register strategy for Assets - use Asset Upload as primary process
 ProgressStrategyRegistry.register(
-  'ASSETS',
-  new PrimaryProcessStrategy('Upload')
+  MODULE_NAMES[MODULE_CONTEXTS.ASSETS],
+  new PrimaryProcessStrategy(PROCESS_NAMES.ASSET_UPLOAD),
 );
 
 // Register strategy for Entries - use Entry Creation as primary process
 ProgressStrategyRegistry.register(
-  'ENTRIES',
-  new PrimaryProcessStrategy('Create')
+  MODULE_NAMES[MODULE_CONTEXTS.ENTRIES],
+  new PrimaryProcessStrategy(PROCESS_NAMES.ENTRIES_CREATE),
 );
 
 // Register strategy for Global Fields - use Create as primary process
 ProgressStrategyRegistry.register(
-  'GLOBAL FIELDS',
-  new PrimaryProcessStrategy('Create')
+  MODULE_NAMES[MODULE_CONTEXTS.GLOBAL_FIELDS],
+  new PrimaryProcessStrategy(PROCESS_NAMES.GLOBAL_FIELDS_CREATE),
 );
 
 // Register strategy for Extensions - simple module
 ProgressStrategyRegistry.register(
-  'EXTENSIONS',
-  new PrimaryProcessStrategy('Create')
+  MODULE_NAMES[MODULE_CONTEXTS.EXTENSIONS],
+  new PrimaryProcessStrategy(PROCESS_NAMES.EXTENSIONS_CREATE),
 );
 
 // Register strategy for Environments - uses default (no nested progress yet)
-ProgressStrategyRegistry.register(
-  'ENVIRONMENTS',
-  new DefaultProgressStrategy()
-);
+ProgressStrategyRegistry.register(MODULE_NAMES[MODULE_CONTEXTS.ENVIRONMENTS], new DefaultProgressStrategy());
 
 // Register strategy for Locales - uses default (no nested progress yet)
 ProgressStrategyRegistry.register(
-  'LOCALES',
-  new PrimaryProcessStrategy('Create')
+  MODULE_NAMES[MODULE_CONTEXTS.LOCALES],
+  new PrimaryProcessStrategy(PROCESS_NAMES.LOCALES_CREATE),
 );
 
 // Register strategy for Labels - uses default (no nested progress yet)
 ProgressStrategyRegistry.register(
-  'LABELS',
-  new PrimaryProcessStrategy('Create')
+  MODULE_NAMES[MODULE_CONTEXTS.LABELS],
+  new PrimaryProcessStrategy(PROCESS_NAMES.LABELS_CREATE),
 );
 
 // Register strategy for Webhooks - uses default (no nested progress yet)
-ProgressStrategyRegistry.register(
-  'WEBHOOKS',
-  new DefaultProgressStrategy()
-);
+ProgressStrategyRegistry.register(MODULE_NAMES[MODULE_CONTEXTS.WEBHOOKS], new DefaultProgressStrategy());
 
 // Register strategy for Workflows - uses default (no nested progress yet)
 ProgressStrategyRegistry.register(
-  'WORKFLOWS',
-  new PrimaryProcessStrategy('Create')
+  MODULE_NAMES[MODULE_CONTEXTS.WORKFLOWS],
+  new PrimaryProcessStrategy(PROCESS_NAMES.WEBHOOKS_IMPORT),
 );
 
 // Register strategy for Custom Roles - uses default (no nested progress yet)
-ProgressStrategyRegistry.register(
-  'CUSTOM ROLES',
-  new DefaultProgressStrategy()
-);
+ProgressStrategyRegistry.register(MODULE_NAMES[MODULE_CONTEXTS.CUSTOM_ROLES], new DefaultProgressStrategy());
 
 // Register strategy for Taxonomies - uses default (no nested progress yet)
-ProgressStrategyRegistry.register(
-  'TAXONOMIES',
-  new DefaultProgressStrategy()
-);
+ProgressStrategyRegistry.register(MODULE_NAMES[MODULE_CONTEXTS.TAXONOMIES], new DefaultProgressStrategy());
 
 // Register strategy for Marketplace Apps - complex module with app installations
 ProgressStrategyRegistry.register(
-  'MARKETPLACE APPS',
-  new PrimaryProcessStrategy('Apps Installation')
+  MODULE_NAMES[MODULE_CONTEXTS.MARKETPLACE_APPS],
+  new PrimaryProcessStrategy(PROCESS_NAMES.CREATE_APPS),
 );
 
 // Register strategy for Stack Settings - simple module
-ProgressStrategyRegistry.register(
-  'STACK',
-  new DefaultProgressStrategy()
-);
+ProgressStrategyRegistry.register(MODULE_NAMES[MODULE_CONTEXTS.STACK], new DefaultProgressStrategy());
 
 // Register strategy for Personalize - complex module with projects/experiences
 ProgressStrategyRegistry.register(
-  'PERSONALIZE',
+  MODULE_NAMES[MODULE_CONTEXTS.PERSONALIZE],
   new CustomProgressStrategy((processes) => {
     // For personalize import, count project imports as primary metric
-    const projectImport = processes.get('Project');
+    const projectImport = processes.get(PROCESS_NAMES.PERSONALIZE_PROJECTS);
     if (projectImport) {
       return {
         total: projectImport.total,
         success: projectImport.successCount,
-        failures: projectImport.failureCount
+        failures: projectImport.failureCount,
       };
     }
-    
+
     // Fallback to any other main process
     const mainProcess = Array.from(processes.values())[0];
     if (mainProcess) {
       return {
         total: mainProcess.total,
         success: mainProcess.successCount,
-        failures: mainProcess.failureCount
+        failures: mainProcess.failureCount,
       };
     }
-    
+
     return null;
-  })
+  }),
 );
 
 // Register strategy for Variant Entries - sub-process of entries
-ProgressStrategyRegistry.register(
-  'VARIANT ENTRIES',
-  new DefaultProgressStrategy()
-);
+ProgressStrategyRegistry.register(MODULE_NAMES[MODULE_CONTEXTS.VARIANT_ENTRIES], new DefaultProgressStrategy());
 
-export default ProgressStrategyRegistry; 
+export default ProgressStrategyRegistry;

--- a/packages/contentstack-variants/src/export/attributes.ts
+++ b/packages/contentstack-variants/src/export/attributes.ts
@@ -3,6 +3,7 @@ import { resolve as pResolve } from 'node:path';
 import { sanitizePath, log, handleAndLogError } from '@contentstack/cli-utilities';
 import { PersonalizeConfig, ExportConfig, AttributesConfig, AttributeStruct } from '../types';
 import { fsUtil, PersonalizationAdapter } from '../utils';
+import { PROCESS_NAMES, MODULE_CONTEXTS, EXPORT_PROCESS_STATUS } from '../utils/constants';
 
 export default class ExportAttributes extends PersonalizationAdapter<ExportConfig> {
   private attributesConfig: AttributesConfig;
@@ -27,7 +28,7 @@ export default class ExportAttributes extends PersonalizationAdapter<ExportConfi
       sanitizePath(this.attributesConfig.dirName),
     );
     this.attributes = [];
-    this.exportConfig.context.module = 'attributes';
+    this.exportConfig.context.module = MODULE_CONTEXTS.ATTRIBUTES;
   }
 
   async start() {
@@ -55,26 +56,25 @@ export default class ExportAttributes extends PersonalizationAdapter<ExportConfi
       }
 
       let progress: any;
-      const processName = 'Attributes';
 
       if (this.parentProgressManager) {
         // Use parent progress manager - we're part of the personalize modules process
         progress = this.parentProgressManager;
         this.progressManager = this.parentProgressManager;
 
-        progress.updateProcessTotal(processName, this.attributes.length); 
+        progress.updateProcessTotal(PROCESS_NAMES.ATTRIBUTES, this.attributes.length);
       } else {
-        progress = this.createSimpleProgress('Attributes', this.attributes.length);
+        progress = this.createSimpleProgress(PROCESS_NAMES.ATTRIBUTES, this.attributes.length);
       }
 
       log.debug(`Processing ${this.attributes.length} attributes`, this.exportConfig.context);
 
-      progress.updateStatus('Sanitizing attributes data...', processName);
+      progress.updateStatus(EXPORT_PROCESS_STATUS[PROCESS_NAMES.ATTRIBUTES].EXPORTING, PROCESS_NAMES.ATTRIBUTES);
 
       this.sanitizeAttribs();
       log.debug('Attributes sanitization completed', this.exportConfig.context);
 
-      progress.updateStatus('Writing attributes data...', processName);
+      progress.updateStatus(EXPORT_PROCESS_STATUS[PROCESS_NAMES.ATTRIBUTES].EXPORTING, PROCESS_NAMES.ATTRIBUTES);
       const attributesFilePath = pResolve(
         sanitizePath(this.attributesFolderPath),
         sanitizePath(this.attributesConfig.fileName),
@@ -111,7 +111,7 @@ export default class ExportAttributes extends PersonalizationAdapter<ExportConfi
 
         // Update progress for each processed attribute
         if (this.progressManager) {
-          const processName = this.parentProgressManager ? 'Attributes' : undefined;
+          const processName = this.parentProgressManager ? PROCESS_NAMES.ATTRIBUTES : undefined;
           this.updateProgress(
             true,
             `attribute ${index + 1}/${this.attributes.length}: ${

--- a/packages/contentstack-variants/src/export/audiences.ts
+++ b/packages/contentstack-variants/src/export/audiences.ts
@@ -3,6 +3,7 @@ import { resolve as pResolve } from 'node:path';
 import { sanitizePath, log, handleAndLogError } from '@contentstack/cli-utilities';
 import { PersonalizeConfig, ExportConfig, AudiencesConfig, AudienceStruct } from '../types';
 import { fsUtil, PersonalizationAdapter } from '../utils';
+import { PROCESS_NAMES, MODULE_CONTEXTS, EXPORT_PROCESS_STATUS } from '../utils/constants';
 
 export default class ExportAudiences extends PersonalizationAdapter<ExportConfig> {
   private audiencesConfig: AudiencesConfig;
@@ -27,7 +28,7 @@ export default class ExportAudiences extends PersonalizationAdapter<ExportConfig
       sanitizePath(this.audiencesConfig.dirName),
     );
     this.audiences = [];
-    this.exportConfig.context.module = 'audiences';
+    this.exportConfig.context.module = MODULE_CONTEXTS.AUDIENCES;
   }
 
   async start() {
@@ -56,24 +57,23 @@ export default class ExportAudiences extends PersonalizationAdapter<ExportConfig
       }
 
       let progress: any;
-      const processName = 'Audiences';
 
       if (this.parentProgressManager) {
         progress = this.parentProgressManager;
         this.progressManager = this.parentProgressManager;
-        progress.updateProcessTotal(processName, this.audiences.length);
+        progress.updateProcessTotal(PROCESS_NAMES.AUDIENCES, this.audiences.length);
       } else {
-        progress = this.createSimpleProgress('Audiences', this.audiences.length);
+        progress = this.createSimpleProgress(PROCESS_NAMES.AUDIENCES, this.audiences.length);
       }
 
       log.debug(`Processing ${this.audiences.length} audiences`, this.exportConfig.context);
-      progress.updateStatus('Sanitizing audiences data...', processName);
+      progress.updateStatus(EXPORT_PROCESS_STATUS[PROCESS_NAMES.AUDIENCES].EXPORTING, PROCESS_NAMES.AUDIENCES);
 
       this.sanitizeAttribs();
       log.debug('Audiences sanitization completed', this.exportConfig.context);
 
       // Write audiences to file
-      progress.updateStatus('Writing audiences data...', processName);
+      progress.updateStatus(EXPORT_PROCESS_STATUS[PROCESS_NAMES.AUDIENCES].EXPORTING, PROCESS_NAMES.AUDIENCES);
       const audiencesFilePath = pResolve(
         sanitizePath(this.audiencesFolderPath),
         sanitizePath(this.audiencesConfig.fileName),
@@ -110,7 +110,7 @@ export default class ExportAudiences extends PersonalizationAdapter<ExportConfig
 
         // Update progress for each processed audience
         if (this.progressManager) {
-          const processName = this.parentProgressManager ? 'Audiences' : undefined;
+          const processName = this.parentProgressManager ? PROCESS_NAMES.AUDIENCES : undefined;
           this.updateProgress(
             true,
             `audience ${index + 1}/${this.audiences.length}: ${

--- a/packages/contentstack-variants/src/export/events.ts
+++ b/packages/contentstack-variants/src/export/events.ts
@@ -3,6 +3,7 @@ import { resolve as pResolve } from 'node:path';
 import { sanitizePath, log, handleAndLogError } from '@contentstack/cli-utilities';
 import { PersonalizeConfig, ExportConfig, EventsConfig, EventStruct } from '../types';
 import { fsUtil, PersonalizationAdapter } from '../utils';
+import { PROCESS_NAMES, MODULE_CONTEXTS, EXPORT_PROCESS_STATUS } from '../utils/constants';
 
 export default class ExportEvents extends PersonalizationAdapter<ExportConfig> {
   private eventsConfig: EventsConfig;
@@ -27,7 +28,7 @@ export default class ExportEvents extends PersonalizationAdapter<ExportConfig> {
       sanitizePath(this.eventsConfig.dirName),
     );
     this.events = [];
-    this.exportConfig.context.module = 'events';
+    this.exportConfig.context.module = MODULE_CONTEXTS.EVENTS;
   }
 
   async start() {
@@ -56,23 +57,22 @@ export default class ExportEvents extends PersonalizationAdapter<ExportConfig> {
       }
 
       let progress: any;
-      const processName = 'Events';
 
       if (this.parentProgressManager) {
         progress = this.parentProgressManager;
         this.progressManager = this.parentProgressManager;
-        progress.updateProcessTotal(processName, this.events.length);
+        progress.updateProcessTotal(PROCESS_NAMES.EVENTS, this.events.length);
       } else {
-        progress = this.createSimpleProgress('Events', this.events.length);
+        progress = this.createSimpleProgress(PROCESS_NAMES.EVENTS, this.events.length);
       }
 
       log.debug(`Processing ${this.events.length} events`, this.exportConfig.context);
-      progress.updateStatus('Sanitizing events data...', processName);
+      progress.updateStatus(EXPORT_PROCESS_STATUS[PROCESS_NAMES.EVENTS].EXPORTING, PROCESS_NAMES.EVENTS);
 
       this.sanitizeAttribs();
       log.debug('Events sanitization completed', this.exportConfig.context);
 
-      progress.updateStatus('Writing events data...', processName);
+      progress.updateStatus(EXPORT_PROCESS_STATUS[PROCESS_NAMES.EVENTS].EXPORTING, PROCESS_NAMES.EVENTS);
       const eventsFilePath = pResolve(sanitizePath(this.eventsFolderPath), sanitizePath(this.eventsConfig.fileName));
       log.debug(`Writing events to: ${eventsFilePath}`, this.exportConfig.context);
       fsUtil.writeFile(eventsFilePath, this.events);
@@ -107,7 +107,7 @@ export default class ExportEvents extends PersonalizationAdapter<ExportConfig> {
         const sanitizedEvent = omit(event, this.eventsConfig.invalidKeys);
 
         if (this.progressManager) {
-          const processName = this.parentProgressManager ? 'Events' : undefined;
+          const processName = this.parentProgressManager ? PROCESS_NAMES.EVENTS : undefined;
           this.updateProgress(
             true,
             `event ${index + 1}/${this.events.length}: ${

--- a/packages/contentstack-variants/src/export/experiences.ts
+++ b/packages/contentstack-variants/src/export/experiences.ts
@@ -2,6 +2,7 @@ import * as path from 'path';
 import { sanitizePath, log, handleAndLogError } from '@contentstack/cli-utilities';
 import { PersonalizeConfig, ExportConfig, ExperienceStruct } from '../types';
 import { fsUtil, PersonalizationAdapter } from '../utils';
+import { PROCESS_NAMES, MODULE_CONTEXTS, EXPORT_PROCESS_STATUS } from '../utils/constants';
 
 export default class ExportExperiences extends PersonalizationAdapter<ExportConfig> {
   private experiencesFolderPath: string;
@@ -26,7 +27,7 @@ export default class ExportExperiences extends PersonalizationAdapter<ExportConf
       sanitizePath(this.personalizeConfig.dirName),
       'experiences',
     );
-    this.exportConfig.context.module = 'experiences';
+    this.exportConfig.context.module = MODULE_CONTEXTS.EXPERIENCES;
   }
 
   async start() {
@@ -65,7 +66,7 @@ export default class ExportExperiences extends PersonalizationAdapter<ExportConf
       }
 
       let progress: any;
-      const processName = 'Experiences';
+      const processName = PROCESS_NAMES.EXPERIENCES;
 
       if (this.parentProgressManager) {
         progress = this.parentProgressManager;
@@ -73,11 +74,11 @@ export default class ExportExperiences extends PersonalizationAdapter<ExportConf
         progress.updateProcessTotal(processName, experiences.length);
       } else {
         // Create our own progress for standalone execution
-        progress = this.createSimpleProgress('Experiences', experiences.length);
+        progress = this.createSimpleProgress(PROCESS_NAMES.EXPERIENCES, experiences.length);
       }
 
       log.debug(`Processing ${experiences.length} experiences`, this.exportConfig.context);
-      progress.updateStatus('Writing experiences data...', processName);
+      progress.updateStatus(EXPORT_PROCESS_STATUS[PROCESS_NAMES.EXPERIENCES].EXPORTING, processName);
 
       const experiencesFilePath = path.resolve(sanitizePath(this.experiencesFolderPath), 'experiences.json');
       log.debug(`Writing experiences to: ${experiencesFilePath}`, this.exportConfig.context);
@@ -91,7 +92,7 @@ export default class ExportExperiences extends PersonalizationAdapter<ExportConf
         this.exportConfig.context,
       );
 
-      progress.updateStatus('Processing experiences variants and content types...', processName);
+      progress.updateStatus(EXPORT_PROCESS_STATUS[PROCESS_NAMES.EXPERIENCES].EXPORTING, processName);
 
       for (let experienceIndex = 0; experienceIndex < experiences.length; experienceIndex++) {
         const experience = experiences[experienceIndex];
@@ -185,7 +186,7 @@ export default class ExportExperiences extends PersonalizationAdapter<ExportConf
         }
       }
 
-      progress.updateStatus('Writing final mapping files...', processName);
+      progress.updateStatus(EXPORT_PROCESS_STATUS[PROCESS_NAMES.EXPERIENCES].EXPORTING, processName);
 
       // Write final mapping files
       const variantsIdsFilePath = path.resolve(

--- a/packages/contentstack-variants/src/export/variant-entries.ts
+++ b/packages/contentstack-variants/src/export/variant-entries.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync } from 'fs';
 import { join, resolve } from 'path';
 import { FsUtility, sanitizePath, log, handleAndLogError, CLIProgressManager } from '@contentstack/cli-utilities';
+import { PROCESS_NAMES, EXPORT_PROCESS_STATUS } from '../utils/constants';
 
 import { APIConfig, AdapterType, ExportConfig } from '../types';
 import VariantAdapter, { VariantHttpClient } from '../utils/variant-api-adapter';
@@ -110,14 +111,15 @@ export default class VariantEntries extends VariantAdapter<VariantHttpClient<Exp
           this.config.context,
         );
         if (variantEntries?.length) {
+          log.info(`Fetched ${variantEntries.length} variant entries for entry: ${entry.uid}`, this.config.context);
           entryHasVariants = true;
           variantCount = variantEntries.length;
-          totalVariantCount += variantCount; 
+          totalVariantCount += variantCount;
 
           // Update progress total only for the first batch (when we have a better estimate)
-          if (processedEntries === 0 && this.parentProgressManager) {
+          if (this.parentProgressManager) {
             // Start with current count, will be updated as we find more
-            this.parentProgressManager.updateProcessTotal('Variant Entries', totalVariantCount);
+            this.parentProgressManager.updateProcessTotal(PROCESS_NAMES.VARIANT_ENTRIES, totalVariantCount);
           }
 
           if (!existsSync(variantEntryBasePath)) {
@@ -155,15 +157,25 @@ export default class VariantEntries extends VariantAdapter<VariantHttpClient<Exp
         // After processing this entry, update the total if we found variants
         if (entryHasVariants && this.parentProgressManager) {
           // Update total with current accumulated count
-          this.parentProgressManager.updateProcessTotal('Variant Entries', totalVariantCount);
-          
+          this.parentProgressManager.updateProcessTotal(PROCESS_NAMES.VARIANT_ENTRIES, totalVariantCount);
+
           // Tick for each variant found in this entry
           for (let i = 0; i < variantCount; i++) {
-            this.updateProgress(true, `Variant ${i + 1}/${variantCount} for entry: ${entry.uid}`, undefined, 'Variant Entries');
+            this.updateProgress(
+              true,
+              `Variant ${i + 1}/${variantCount} for entry: ${entry.uid}`,
+              undefined,
+              PROCESS_NAMES.VARIANT_ENTRIES,
+            );
           }
         } else if (this.parentProgressManager) {
           // No variants found for this entry, but still tick once to show progress
-          this.updateProgress(true, `No variants found for entry: ${entry.uid}`, undefined, 'Variant Entries');
+          this.updateProgress(
+            true,
+            `No variants found for entry: ${entry.uid}`,
+            undefined,
+            PROCESS_NAMES.VARIANT_ENTRIES,
+          );
         }
 
         processedEntries++;
@@ -176,7 +188,7 @@ export default class VariantEntries extends VariantAdapter<VariantHttpClient<Exp
             false,
             `Failed to export variants for entry: ${entry.uid}`,
             (error as any)?.message || 'Unknown error',
-            'Variant Entries',
+            PROCESS_NAMES.VARIANT_ENTRIES,
           );
         }
 

--- a/packages/contentstack-variants/src/import/attribute.ts
+++ b/packages/contentstack-variants/src/import/attribute.ts
@@ -58,6 +58,8 @@ export default class Attribute extends PersonalizationAdapter<ImportConfig> {
       if (this.parentProgressManager) {
         progress = this.parentProgressManager;
         log.debug('Using parent progress manager for attributes import', this.config.context);
+        this.parentProgressManager.updateProcessTotal(PROCESS_NAMES.ATTRIBUTES, attributesCount);
+
       } else {
         progress = this.createSimpleProgress(PROCESS_NAMES.ATTRIBUTES, attributesCount);
         log.debug('Created standalone progress manager for attributes import', this.config.context);
@@ -80,11 +82,7 @@ export default class Attribute extends PersonalizationAdapter<ImportConfig> {
         // skip creating preset attributes, as they are already present in the system
         if (attribute.__type === 'PRESET') {
           log.debug(`Skipping preset attribute: ${name}`, this.config.context);
-          if (this.parentProgressManager) {
-            this.updateProgress(true, `attribute: ${name} (preset - skipped)`);
-          } else {
-            this.updateProgress(true, `attribute: ${name} (preset - skipped)`, undefined, PROCESS_NAMES.ATTRIBUTES);
-          }
+          this.updateProgress(true, `attribute: ${name} (preset - skipped)`, undefined, PROCESS_NAMES.ATTRIBUTES);
           continue;
         }
 
@@ -95,18 +93,10 @@ export default class Attribute extends PersonalizationAdapter<ImportConfig> {
           //mapper file is used to check whether attribute created or not before creating audience
           this.attributesUidMapper[uid] = attributeRes?.uid ?? '';
 
-          if (this.parentProgressManager) {
-            this.updateProgress(true, `attribute: ${name}`);
-          } else {
-            this.updateProgress(true, `attribute: ${name}`, undefined, PROCESS_NAMES.ATTRIBUTES);
-          }
+          this.updateProgress(true, `attribute: ${name}`, undefined, PROCESS_NAMES.ATTRIBUTES);
           log.debug(`Created attribute: ${uid} -> ${attributeRes?.uid}`, this.config.context);
         } catch (error) {
-          if (this.parentProgressManager) {
-            this.updateProgress(false, `attribute: ${name}`);
-          } else {
-            this.updateProgress(false, `attribute: ${name}`, (error as any)?.message, PROCESS_NAMES.ATTRIBUTES);
-          }
+          this.updateProgress(false, `attribute: ${name}`, (error as any)?.message, PROCESS_NAMES.ATTRIBUTES);
           handleAndLogError(error, this.config.context, `Failed to create attribute: ${name}`);
         }
       }

--- a/packages/contentstack-variants/src/import/audiences.ts
+++ b/packages/contentstack-variants/src/import/audiences.ts
@@ -66,6 +66,7 @@ export default class Audiences extends PersonalizationAdapter<ImportConfig> {
       if (this.parentProgressManager) {
         progress = this.parentProgressManager;
         log.debug('Using parent progress manager for audiences import', this.config.context);
+        this.parentProgressManager.updateProcessTotal(PROCESS_NAMES.AUDIENCES, audiencesCount);
       } else {
         progress = this.createSimpleProgress(PROCESS_NAMES.AUDIENCES, audiencesCount);
         log.debug('Created standalone progress manager for audiences import', this.config.context);
@@ -107,11 +108,7 @@ export default class Audiences extends PersonalizationAdapter<ImportConfig> {
           //mapper file is used to check whether audience created or not before creating experience
           this.audiencesUidMapper[uid] = audienceRes?.uid ?? '';
 
-          if (this.parentProgressManager) {
-            this.updateProgress(true, `audience: ${name}`);
-          } else {
-            this.updateProgress(true, `audience: ${name}`, undefined, PROCESS_NAMES.AUDIENCES);
-          }
+          this.updateProgress(true, `audience: ${name}`, undefined, PROCESS_NAMES.AUDIENCES);
           log.debug(`Created audience: ${uid} -> ${audienceRes?.uid}`, this.config.context);
         } catch (error) {
           this.updateProgress(false, `audience: ${name}`, (error as any)?.message, PROCESS_NAMES.AUDIENCES);

--- a/packages/contentstack-variants/src/import/events.ts
+++ b/packages/contentstack-variants/src/import/events.ts
@@ -58,6 +58,7 @@ export default class Events extends PersonalizationAdapter<ImportConfig> {
       if (this.parentProgressManager) {
         progress = this.parentProgressManager;
         log.debug('Using parent progress manager for events import', this.config.context);
+        this.parentProgressManager.updateProcessTotal(PROCESS_NAMES.EVENTS, eventsCount);
       } else {
         progress = this.createSimpleProgress(PROCESS_NAMES.EVENTS, eventsCount);
         log.debug('Created standalone progress manager for events import', this.config.context);

--- a/packages/contentstack-variants/src/import/events.ts
+++ b/packages/contentstack-variants/src/import/events.ts
@@ -3,6 +3,7 @@ import { existsSync } from 'fs';
 import { sanitizePath, log, handleAndLogError } from '@contentstack/cli-utilities';
 import { PersonalizationAdapter, fsUtil } from '../utils';
 import { APIConfig, EventStruct, ImportConfig } from '../types';
+import { PROCESS_NAMES, MODULE_CONTEXTS, IMPORT_PROCESS_STATUS } from '../utils/constants';
 
 export default class Events extends PersonalizationAdapter<ImportConfig> {
   private mapperDirPath: string;
@@ -32,6 +33,7 @@ export default class Events extends PersonalizationAdapter<ImportConfig> {
     this.eventsUidMapperPath = resolve(sanitizePath(this.eventMapperDirPath), 'uid-mapping.json');
     this.eventsUidMapper = {};
     this.events = [];
+    this.config.context.module = MODULE_CONTEXTS.EVENTS;
   }
 
   /**
@@ -46,7 +48,7 @@ export default class Events extends PersonalizationAdapter<ImportConfig> {
         log.info('No events found to import', this.config.context);
         // Still need to mark as complete for parent progress
         if (this.parentProgressManager) {
-          this.parentProgressManager.tick(true, 'events module (no data)', null, 'Events');
+          this.parentProgressManager.tick(true, 'events module (no data)', null, PROCESS_NAMES.EVENTS);
         }
         return;
       }
@@ -57,7 +59,7 @@ export default class Events extends PersonalizationAdapter<ImportConfig> {
         progress = this.parentProgressManager;
         log.debug('Using parent progress manager for events import', this.config.context);
       } else {
-        progress = this.createSimpleProgress('Events', eventsCount);
+        progress = this.createSimpleProgress(PROCESS_NAMES.EVENTS, eventsCount);
         log.debug('Created standalone progress manager for events import', this.config.context);
       }
 
@@ -70,7 +72,7 @@ export default class Events extends PersonalizationAdapter<ImportConfig> {
       for (const event of this.events) {
         const { key, description, uid } = event;
         if (!this.parentProgressManager) {
-          progress.updateStatus(`Processing event: ${key}...`);
+          progress.updateStatus(IMPORT_PROCESS_STATUS[PROCESS_NAMES.EVENTS].CREATING);
         }
         log.debug(`Processing event: ${key} (${uid})`, this.config.context);
 
@@ -83,14 +85,14 @@ export default class Events extends PersonalizationAdapter<ImportConfig> {
           if (this.parentProgressManager) {
             this.updateProgress(true, `event: ${key}`);
           } else {
-            this.updateProgress(true, `event: ${key}`, undefined, 'Events');
+            this.updateProgress(true, `event: ${key}`, undefined, PROCESS_NAMES.EVENTS);
           }
           log.debug(`Created event: ${uid} -> ${eventRes?.uid}`, this.config.context);
         } catch (error) {
           if (this.parentProgressManager) {
             this.updateProgress(false, `event: ${key}`, (error as any)?.message);
           } else {
-            this.updateProgress(false, `event: ${key}`, (error as any)?.message, 'Events');
+            this.updateProgress(false, `event: ${key}`, (error as any)?.message, PROCESS_NAMES.EVENTS);
           }
           handleAndLogError(error, this.config.context, `Failed to create event: ${key} (${uid})`);
         }

--- a/packages/contentstack-variants/src/import/experiences.ts
+++ b/packages/contentstack-variants/src/import/experiences.ts
@@ -130,6 +130,7 @@ export default class Experiences extends PersonalizationAdapter<ImportConfig> {
       if (this.parentProgressManager) {
         progress = this.parentProgressManager;
         log.debug('Using parent progress manager for experiences import', this.config.context);
+        this.parentProgressManager.updateProcessTotal(PROCESS_NAMES.EXPERIENCES, experiencesCount);
       } else {
         progress = this.createSimpleProgress(PROCESS_NAMES.EXPERIENCES, experiencesCount);
         log.debug('Created standalone progress manager for experiences import', this.config.context);

--- a/packages/contentstack-variants/src/import/project.ts
+++ b/packages/contentstack-variants/src/import/project.ts
@@ -81,6 +81,12 @@ export default class Project extends PersonalizationAdapter<ImportConfig> {
               cliux.print('\n');
               const projectName = await askProjectName('Copy Of ' + (newName || project.name));
               cliux.print('\n');
+              if (this.parentProgressManager) {
+                this.parentProgressManager.updateStatus(
+                  IMPORT_PROCESS_STATUS[PROCESS_NAMES.PROJECTS].CREATING,
+                  PROCESS_NAMES.PROJECTS,
+                );
+              }
 
               return await createProject(projectName);
             }

--- a/packages/contentstack-variants/src/index.ts
+++ b/packages/contentstack-variants/src/index.ts
@@ -2,4 +2,5 @@ export * from './types';
 export * from './utils';
 export * from './export';
 export * from './import';
-export * from './messages'
+export * from './messages';
+export * from './utils/constants';

--- a/packages/contentstack-variants/src/utils/constants.ts
+++ b/packages/contentstack-variants/src/utils/constants.ts
@@ -1,0 +1,98 @@
+export const PROCESS_NAMES = {
+  PROJECTS: 'Projects',
+  ATTRIBUTES: 'Attributes', 
+  AUDIENCES: 'Audiences',
+  EVENTS: 'Events',
+  EXPERIENCES: 'Experiences',
+  VARIANT_ENTRIES: 'Variant Entries',
+} as const;
+
+export const MODULE_DISPLAY_MAPPER = {
+  events: PROCESS_NAMES.EVENTS,
+  attributes: PROCESS_NAMES.ATTRIBUTES,
+  audiences: PROCESS_NAMES.AUDIENCES,
+  experiences: PROCESS_NAMES.EXPERIENCES,
+  projects: PROCESS_NAMES.PROJECTS,
+  'variant-entries': PROCESS_NAMES.VARIANT_ENTRIES,
+} as const;
+
+export const MODULE_CONTEXTS = {
+  PROJECTS: 'projects',
+  ATTRIBUTES: 'attributes',
+  AUDIENCES: 'audiences', 
+  EVENTS: 'events',
+  EXPERIENCES: 'experiences',
+  VARIANT_ENTRIES: 'variant-entries',
+} as const;
+
+// Export process status messages
+export const EXPORT_PROCESS_STATUS = {
+  [PROCESS_NAMES.PROJECTS]: {
+    FETCHING: 'Fetching projects...',
+    EXPORTING: 'Exporting projects...',
+    FAILED: 'Failed to export projects.',
+  },
+  [PROCESS_NAMES.ATTRIBUTES]: {
+    FETCHING: 'Fetching attributes...',
+    EXPORTING: 'Exporting attributes...',
+    FAILED: 'Failed to export attributes.',
+  },
+  [PROCESS_NAMES.AUDIENCES]: {
+    FETCHING: 'Fetching audiences...',
+    EXPORTING: 'Exporting audiences...',
+    FAILED: 'Failed to export audiences.',
+  },
+  [PROCESS_NAMES.EVENTS]: {
+    FETCHING: 'Fetching events...',
+    EXPORTING: 'Exporting events...',
+    FAILED: 'Failed to export events.',
+  },
+  [PROCESS_NAMES.EXPERIENCES]: {
+    FETCHING: 'Fetching experiences...',
+    EXPORTING: 'Exporting experiences...',
+    FAILED: 'Failed to export experiences.',
+  },
+  [PROCESS_NAMES.VARIANT_ENTRIES]: {
+    PROCESSING: 'Processing variant entries...',
+    EXPORTING: 'Exporting variant entries...',
+    FAILED: 'Failed to export variant entries.',
+  },
+} as const;
+
+// Import process status messages
+export const IMPORT_PROCESS_STATUS = {
+  [PROCESS_NAMES.PROJECTS]: {
+    CREATING: 'Creating projects...',
+    IMPORTING: 'Importing projects...',
+    FAILED: 'Failed to import projects.',
+  },
+  [PROCESS_NAMES.ATTRIBUTES]: {
+    CREATING: 'Creating attributes...',
+    IMPORTING: 'Importing attributes...',
+    FAILED: 'Failed to import attributes.',
+  },
+  [PROCESS_NAMES.AUDIENCES]: {
+    CREATING: 'Creating audiences...',
+    IMPORTING: 'Importing audiences...',
+    FAILED: 'Failed to import audiences.',
+  },
+  [PROCESS_NAMES.EVENTS]: {
+    CREATING: 'Creating events...',
+    IMPORTING: 'Importing events...',
+    FAILED: 'Failed to import events.',
+  },
+  [PROCESS_NAMES.EXPERIENCES]: {
+    CREATING: 'Creating experiences...',
+    IMPORTING: 'Importing experiences...',
+    FAILED: 'Failed to import experiences.',
+  },
+  [PROCESS_NAMES.VARIANT_ENTRIES]: {
+    PROCESSING: 'Processing variant entries...',
+    IMPORTING: 'Importing variant entries...',
+    FAILED: 'Failed to import variant entries.',
+  },
+} as const;
+
+export type ProcessName = typeof PROCESS_NAMES[keyof typeof PROCESS_NAMES];
+export type ModuleKey = keyof typeof MODULE_DISPLAY_MAPPER;
+export type ModuleContext = typeof MODULE_CONTEXTS[keyof typeof MODULE_CONTEXTS]; 

--- a/packages/contentstack-variants/tsconfig.json
+++ b/packages/contentstack-variants/tsconfig.json
@@ -15,5 +15,5 @@
       "es2020.promise"
     ],
   },
-  "include": ["src/*"]
+  "include": ["src/*", "src/utils/constants.ts"]
 }


### PR DESCRIPTION
- **Centralized Constants:** Refactored progress manager to use centralized constants for:
   Process names
   Status messages
   Both export and import operations
- **Progress Manager Fixes:** Addressed summary and progress manager issues in import operations
- **Variant Import Fixes:** Resolved variant import file-related issues