### PR TITLE
fix: Progress Manager shows duplicate module counts and inaccurate personalize stats in --show-console output

### DIFF
--- a/packages/contentstack-import/src/utils/progress-strategy-registry.ts
+++ b/packages/contentstack-import/src/utils/progress-strategy-registry.ts
@@ -21,7 +21,18 @@ ProgressStrategyRegistry.register(
 // Register strategy for Assets - use Asset Upload as primary process
 ProgressStrategyRegistry.register(
   MODULE_NAMES[MODULE_CONTEXTS.ASSETS],
-  new PrimaryProcessStrategy(PROCESS_NAMES.ASSET_UPLOAD),
+  new CustomProgressStrategy((processes) => {
+    const uploadsProcess = processes.get(PROCESS_NAMES.ASSET_UPLOAD);
+    if (uploadsProcess) {
+      return {
+        total: uploadsProcess.total,
+        success: uploadsProcess.successCount,
+        failures: uploadsProcess.failureCount,
+      };
+    }
+
+    return null; // Fall back to default aggregation
+  }),
 );
 
 // Register strategy for Entries - use Entry Creation as primary process

--- a/packages/contentstack-variants/src/export/projects.ts
+++ b/packages/contentstack-variants/src/export/projects.ts
@@ -33,9 +33,6 @@ export default class ExportProjects extends PersonalizationAdapter<ExportConfig>
       log.debug('Starting projects export process...', this.exportConfig.context);
       log.info('Starting projects export', this.exportConfig.context);
 
-      // Set project personalization config before starting
-      this.exportConfig.personalizationEnabled = false;
-
       // Initial setup with loading spinner
       await this.withLoadingSpinner('PROJECTS: Initializing export and fetching data...', async () => {
         log.debug('Initializing personalization adapter...', this.exportConfig.context);
@@ -69,7 +66,8 @@ export default class ExportProjects extends PersonalizationAdapter<ExportConfig>
       if (this.parentProgressManager) {
         progress = this.parentProgressManager;
         this.progressManager = this.parentProgressManager;
-        progress.updateProcessTotal(PROCESS_NAMES.PROJECTS, this.projectsData?.length);
+        // Parent already has correct count, just update status
+        progress.updateStatus(EXPORT_PROCESS_STATUS[PROCESS_NAMES.PROJECTS].EXPORTING, PROCESS_NAMES.PROJECTS);
       } else {
         progress = this.createNestedProgress(PROCESS_NAMES.PROJECTS);
         progress.addProcess(PROCESS_NAMES.PROJECTS, this.projectsData?.length);


### PR DESCRIPTION
- [x] fix Progress Manager shows duplicate module counts.
- [x] fix inaccurate personalize stats in case personalize disabled org.

**NOTE:-** Ignore failed workflow issue. It's fixed in development.