### PR TITLE
enh: increased log file size threshold from 1 MB to 5 MB and number of log files from 20 to 50

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26585,7 +26585,7 @@
         "@contentstack/cli-config": "~1.15.2",
         "@contentstack/cli-launch": "^1.9.2",
         "@contentstack/cli-migration": "~1.8.1",
-        "@contentstack/cli-utilities": "~1.14.3",
+        "@contentstack/cli-utilities": "~1.14.4",
         "@contentstack/cli-variants": "~1.3.1",
         "@contentstack/management": "~1.22.0",
         "@oclif/core": "^4.3.0",
@@ -26642,7 +26642,7 @@
       "license": "MIT",
       "dependencies": {
         "@contentstack/cli-command": "~1.6.1",
-        "@contentstack/cli-utilities": "~1.14.3",
+        "@contentstack/cli-utilities": "~1.14.4",
         "@oclif/core": "^4.3.0",
         "@oclif/plugin-help": "^6.2.28",
         "@oclif/plugin-plugins": "^5.4.38",
@@ -26716,7 +26716,7 @@
       "license": "MIT",
       "dependencies": {
         "@contentstack/cli-command": "~1.6.1",
-        "@contentstack/cli-utilities": "~1.14.1",
+        "@contentstack/cli-utilities": "~1.14.4",
         "@oclif/core": "^4.3.0",
         "@oclif/plugin-help": "^6.2.28",
         "otplib": "^12.0.1"
@@ -26868,7 +26868,7 @@
       "dependencies": {
         "@contentstack/cli-cm-seed": "~1.12.2",
         "@contentstack/cli-command": "~1.6.1",
-        "@contentstack/cli-utilities": "~1.14.1",
+        "@contentstack/cli-utilities": "~1.14.4",
         "@oclif/core": "^4.3.0",
         "@oclif/plugin-help": "^6.2.28",
         "inquirer": "8.2.6",
@@ -26949,7 +26949,7 @@
       "license": "MIT",
       "dependencies": {
         "@contentstack/cli-command": "~1.6.1",
-        "@contentstack/cli-utilities": "~1.14.1",
+        "@contentstack/cli-utilities": "~1.14.4",
         "@oclif/core": "^4.3.0",
         "@oclif/plugin-help": "^6.2.28",
         "chalk": "^4.1.2",
@@ -26983,7 +26983,7 @@
       "dependencies": {
         "@contentstack/cli-command": "~1.6.1",
         "@contentstack/cli-config": "~1.15.0",
-        "@contentstack/cli-utilities": "~1.14.1",
+        "@contentstack/cli-utilities": "~1.14.4",
         "@oclif/core": "^4.3.0",
         "@oclif/plugin-help": "^6.2.28",
         "chalk": "^4.1.2",
@@ -27014,7 +27014,7 @@
         "@contentstack/cli-cm-export": "~1.20.1",
         "@contentstack/cli-cm-import": "~1.28.2",
         "@contentstack/cli-command": "~1.6.1",
-        "@contentstack/cli-utilities": "~1.14.1",
+        "@contentstack/cli-utilities": "~1.14.4",
         "@oclif/core": "^4.3.0",
         "@oclif/plugin-help": "^6.2.28",
         "chalk": "^4.1.2",
@@ -27045,7 +27045,7 @@
       "version": "1.6.1",
       "license": "MIT",
       "dependencies": {
-        "@contentstack/cli-utilities": "~1.14.1",
+        "@contentstack/cli-utilities": "~1.14.4",
         "@oclif/core": "^4.3.0",
         "@oclif/plugin-help": "^6.2.28",
         "contentstack": "^3.25.3"
@@ -27120,7 +27120,7 @@
       "license": "MIT",
       "dependencies": {
         "@contentstack/cli-command": "~1.6.1",
-        "@contentstack/cli-utilities": "~1.14.1",
+        "@contentstack/cli-utilities": "~1.14.4",
         "@oclif/core": "^4.3.0",
         "@oclif/plugin-help": "^6.2.28",
         "lodash": "^4.17.21"
@@ -27454,7 +27454,7 @@
       "license": "MIT",
       "dependencies": {
         "@contentstack/cli-command": "~1.6.1",
-        "@contentstack/cli-utilities": "~1.14.1",
+        "@contentstack/cli-utilities": "~1.14.4",
         "@contentstack/cli-variants": "~1.3.3",
         "@oclif/core": "^4.3.3",
         "async": "^3.2.6",
@@ -27497,7 +27497,7 @@
       "license": "MIT",
       "dependencies": {
         "@contentstack/cli-command": "~1.6.1",
-        "@contentstack/cli-utilities": "~1.14.1",
+        "@contentstack/cli-utilities": "~1.14.4",
         "@oclif/core": "^4.3.0",
         "@oclif/plugin-help": "^6.2.32",
         "fast-csv": "^4.3.6",
@@ -27944,7 +27944,7 @@
       "dependencies": {
         "@contentstack/cli-audit": "~1.15.0",
         "@contentstack/cli-command": "~1.6.1",
-        "@contentstack/cli-utilities": "~1.14.1",
+        "@contentstack/cli-utilities": "~1.14.4",
         "@contentstack/cli-variants": "~1.3.3",
         "@contentstack/management": "~1.22.0",
         "@oclif/core": "^4.3.0",
@@ -27992,7 +27992,7 @@
       "license": "MIT",
       "dependencies": {
         "@contentstack/cli-command": "~1.6.1",
-        "@contentstack/cli-utilities": "~1.14.1",
+        "@contentstack/cli-utilities": "~1.14.4",
         "@oclif/core": "^4.3.0",
         "big-json": "^3.2.0",
         "chalk": "^4.1.2",
@@ -28035,7 +28035,7 @@
       "license": "MIT",
       "dependencies": {
         "@contentstack/cli-command": "~1.6.1",
-        "@contentstack/cli-utilities": "~1.14.1",
+        "@contentstack/cli-utilities": "~1.14.4",
         "@contentstack/json-rte-serializer": "~2.1.0",
         "@oclif/core": "^4.3.0",
         "@oclif/plugin-help": "^6.2.28",
@@ -28067,7 +28067,7 @@
       "license": "MIT",
       "dependencies": {
         "@contentstack/cli-command": "~1.6.1",
-        "@contentstack/cli-utilities": "~1.14.1",
+        "@contentstack/cli-utilities": "~1.14.4",
         "@oclif/core": "^4.3.0",
         "@oclif/plugin-help": "^6.2.28",
         "async": "^3.2.6",
@@ -28099,7 +28099,7 @@
       "dependencies": {
         "@contentstack/cli-cm-import": "~1.28.2",
         "@contentstack/cli-command": "~1.6.1",
-        "@contentstack/cli-utilities": "~1.14.1",
+        "@contentstack/cli-utilities": "~1.14.4",
         "@contentstack/management": "~1.22.0",
         "inquirer": "8.2.6",
         "mkdirp": "^1.0.4",
@@ -28176,7 +28176,7 @@
     },
     "packages/contentstack-utilities": {
       "name": "@contentstack/cli-utilities",
-      "version": "1.14.3",
+      "version": "1.14.4",
       "license": "MIT",
       "dependencies": {
         "@contentstack/management": "~1.22.0",
@@ -28241,7 +28241,7 @@
       "version": "1.3.3",
       "license": "MIT",
       "dependencies": {
-        "@contentstack/cli-utilities": "~1.14.1",
+        "@contentstack/cli-utilities": "~1.14.4",
         "@oclif/core": "^4.3.0",
         "@oclif/plugin-help": "^6.2.28",
         "lodash": "^4.17.21",

--- a/packages/contentstack-audit/package.json
+++ b/packages/contentstack-audit/package.json
@@ -19,7 +19,7 @@
   ],
   "dependencies": {
     "@contentstack/cli-command": "~1.6.1",
-    "@contentstack/cli-utilities": "~1.14.3",
+    "@contentstack/cli-utilities": "~1.14.4",
     "@oclif/core": "^4.3.0",
     "@oclif/plugin-help": "^6.2.28",
     "@oclif/plugin-plugins": "^5.4.38",

--- a/packages/contentstack-auth/package.json
+++ b/packages/contentstack-auth/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@contentstack/cli-command": "~1.6.1",
-    "@contentstack/cli-utilities": "~1.14.1",
+    "@contentstack/cli-utilities": "~1.14.4",
     "@oclif/core": "^4.3.0",
     "@oclif/plugin-help": "^6.2.28",
     "otplib": "^12.0.1"

--- a/packages/contentstack-bootstrap/package.json
+++ b/packages/contentstack-bootstrap/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@contentstack/cli-cm-seed": "~1.12.2",
     "@contentstack/cli-command": "~1.6.1",
-    "@contentstack/cli-utilities": "~1.14.1",
+    "@contentstack/cli-utilities": "~1.14.4",
     "@oclif/core": "^4.3.0",
     "@oclif/plugin-help": "^6.2.28",
     "inquirer": "8.2.6",

--- a/packages/contentstack-branches/package.json
+++ b/packages/contentstack-branches/package.json
@@ -8,7 +8,7 @@
     "@contentstack/cli-command": "~1.6.1",
     "@oclif/core": "^4.3.0",
     "@oclif/plugin-help": "^6.2.28",
-    "@contentstack/cli-utilities": "~1.14.1",
+    "@contentstack/cli-utilities": "~1.14.4",
     "chalk": "^4.1.2",
     "just-diff": "^6.0.2",
     "lodash": "^4.17.21"

--- a/packages/contentstack-bulk-publish/package.json
+++ b/packages/contentstack-bulk-publish/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@contentstack/cli-command": "~1.6.1",
     "@contentstack/cli-config": "~1.15.0",
-    "@contentstack/cli-utilities": "~1.14.1",
+    "@contentstack/cli-utilities": "~1.14.4",
     "@oclif/core": "^4.3.0",
     "@oclif/plugin-help": "^6.2.28",
     "chalk": "^4.1.2",

--- a/packages/contentstack-clone/package.json
+++ b/packages/contentstack-clone/package.json
@@ -9,7 +9,7 @@
     "@contentstack/cli-cm-export": "~1.20.1",
     "@contentstack/cli-cm-import": "~1.28.2",
     "@contentstack/cli-command": "~1.6.1",
-    "@contentstack/cli-utilities": "~1.14.1",
+    "@contentstack/cli-utilities": "~1.14.4",
     "@oclif/core": "^4.3.0",
     "@oclif/plugin-help": "^6.2.28",
     "chalk": "^4.1.2",

--- a/packages/contentstack-command/package.json
+++ b/packages/contentstack-command/package.json
@@ -19,7 +19,7 @@
     "test:unit": "mocha --timeout 10000 --forbid-only \"test/unit/**/*.test.ts\""
   },
   "dependencies": {
-    "@contentstack/cli-utilities": "~1.14.1",
+    "@contentstack/cli-utilities": "~1.14.4",
     "contentstack": "^3.25.3",
     "@oclif/core": "^4.3.0",
     "@oclif/plugin-help": "^6.2.28"

--- a/packages/contentstack-config/package.json
+++ b/packages/contentstack-config/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@contentstack/cli-command": "~1.6.1",
-    "@contentstack/cli-utilities": "~1.14.1",
+    "@contentstack/cli-utilities": "~1.14.4",
     "@oclif/core": "^4.3.0",
     "@oclif/plugin-help": "^6.2.28",
     "lodash": "^4.17.21"

--- a/packages/contentstack-export-to-csv/package.json
+++ b/packages/contentstack-export-to-csv/package.json
@@ -6,7 +6,7 @@
   "bugs": "https://github.com/contentstack/cli/issues",
   "dependencies": {
     "@contentstack/cli-command": "~1.6.1",
-    "@contentstack/cli-utilities": "~1.14.1",
+    "@contentstack/cli-utilities": "~1.14.4",
     "@oclif/core": "^4.3.0",
     "@oclif/plugin-help": "^6.2.32",
     "fast-csv": "^4.3.6",

--- a/packages/contentstack-export/package.json
+++ b/packages/contentstack-export/package.json
@@ -8,7 +8,7 @@
     "@contentstack/cli-command": "~1.6.1",
     "@contentstack/cli-variants": "~1.3.3",
     "@oclif/core": "^4.3.3",
-    "@contentstack/cli-utilities": "~1.14.1",
+    "@contentstack/cli-utilities": "~1.14.4",
     "async": "^3.2.6",
     "big-json": "^3.2.0",
     "bluebird": "^3.7.2",

--- a/packages/contentstack-import-setup/package.json
+++ b/packages/contentstack-import-setup/package.json
@@ -6,7 +6,7 @@
   "bugs": "https://github.com/contentstack/cli/issues",
   "dependencies": {
     "@contentstack/cli-command": "~1.6.1",
-    "@contentstack/cli-utilities": "~1.14.1",
+    "@contentstack/cli-utilities": "~1.14.4",
     "@oclif/core": "^4.3.0",
     "big-json": "^3.2.0",
     "chalk": "^4.1.2",

--- a/packages/contentstack-import/package.json
+++ b/packages/contentstack-import/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@contentstack/cli-audit": "~1.15.0",
     "@contentstack/cli-command": "~1.6.1",
-    "@contentstack/cli-utilities": "~1.14.1",
+"@contentstack/cli-utilities": "~1.14.4",
     "@contentstack/management": "~1.22.0",
     "@contentstack/cli-variants": "~1.3.3",
     "@oclif/core": "^4.3.0",

--- a/packages/contentstack-import/package.json
+++ b/packages/contentstack-import/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@contentstack/cli-audit": "~1.15.0",
     "@contentstack/cli-command": "~1.6.1",
-"@contentstack/cli-utilities": "~1.14.4",
+    "@contentstack/cli-utilities": "~1.14.4",
     "@contentstack/management": "~1.22.0",
     "@contentstack/cli-variants": "~1.3.3",
     "@oclif/core": "^4.3.0",

--- a/packages/contentstack-migrate-rte/package.json
+++ b/packages/contentstack-migrate-rte/package.json
@@ -6,7 +6,7 @@
   "bugs": "https://github.com/contentstack/cli/issues",
   "dependencies": {
     "@contentstack/cli-command": "~1.6.1",
-    "@contentstack/cli-utilities": "~1.14.1",
+    "@contentstack/cli-utilities": "~1.14.4",
     "@contentstack/json-rte-serializer": "~2.1.0",
     "@oclif/core": "^4.3.0",
     "@oclif/plugin-help": "^6.2.28",

--- a/packages/contentstack-migration/package.json
+++ b/packages/contentstack-migration/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/contentstack/cli/issues",
   "dependencies": {
     "@contentstack/cli-command": "~1.6.1",
-    "@contentstack/cli-utilities": "~1.14.1",
+    "@contentstack/cli-utilities": "~1.14.4",
     "@oclif/core": "^4.3.0",
     "@oclif/plugin-help": "^6.2.28",
     "async": "^3.2.6",

--- a/packages/contentstack-seed/package.json
+++ b/packages/contentstack-seed/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@contentstack/cli-cm-import": "~1.28.2",
     "@contentstack/cli-command": "~1.6.1",
-    "@contentstack/cli-utilities": "~1.14.1",
+    "@contentstack/cli-utilities": "~1.14.4",
     "@contentstack/management": "~1.22.0",
     "inquirer": "8.2.6",
     "mkdirp": "^1.0.4",

--- a/packages/contentstack-utilities/package.json
+++ b/packages/contentstack-utilities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentstack/cli-utilities",
-  "version": "1.14.3",
+  "version": "1.14.4",
   "description": "Utilities for contentstack projects",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/contentstack-utilities/src/logger/logger.ts
+++ b/packages/contentstack-utilities/src/logger/logger.ts
@@ -43,9 +43,9 @@ export default class Logger {
   private get loggerOptions(): winston.transports.FileTransportOptions {
     return {
       filename: '',
-      maxFiles: 20,
+      maxFiles: 50,
       tailable: true,
-      maxsize: 1000000,
+      maxsize: 5000000, // 5MB
     };
   }
 
@@ -119,7 +119,7 @@ export default class Logger {
     if (target === 'console' && this.config.consoleLoggingEnabled === false) {
       return false;
     }
-    
+
     const configLevel = target === 'console' ? this.config.consoleLogLevel : this.config.logLevel;
     const minLevel = configLevel ? logLevels[configLevel] : 2;
     return logLevels[level] <= minLevel;

--- a/packages/contentstack-variants/package.json
+++ b/packages/contentstack-variants/package.json
@@ -27,7 +27,7 @@
     "typescript": "^5.8.3"
   },
   "dependencies": {
-    "@contentstack/cli-utilities": "~1.14.1",
+    "@contentstack/cli-utilities": "~1.14.4",
     "@oclif/core": "^4.3.0",
     "@oclif/plugin-help": "^6.2.28",
     "lodash": "^4.17.21",

--- a/packages/contentstack/package.json
+++ b/packages/contentstack/package.json
@@ -38,7 +38,7 @@
     "@contentstack/cli-config": "~1.15.2",
     "@contentstack/cli-launch": "^1.9.2",
     "@contentstack/cli-migration": "~1.8.1",
-    "@contentstack/cli-utilities": "~1.14.3",
+    "@contentstack/cli-utilities": "~1.14.4",
     "@contentstack/cli-variants": "~1.3.1",
     "@contentstack/management": "~1.22.0",
     "@oclif/core": "^4.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,7 +28,7 @@ importers:
       '@contentstack/cli-config': ~1.15.2
       '@contentstack/cli-launch': ^1.9.2
       '@contentstack/cli-migration': ~1.8.1
-      '@contentstack/cli-utilities': ~1.14.3
+      '@contentstack/cli-utilities': ~1.14.4
       '@contentstack/cli-variants': ~1.3.1
       '@contentstack/management': ~1.22.0
       '@oclif/core': ^4.3.0
@@ -132,7 +132,7 @@ importers:
   packages/contentstack-audit:
     specifiers:
       '@contentstack/cli-command': ~1.6.1
-      '@contentstack/cli-utilities': ~1.14.3
+      '@contentstack/cli-utilities': ~1.14.4
       '@oclif/core': ^4.3.0
       '@oclif/plugin-help': ^6.2.28
       '@oclif/plugin-plugins': ^5.4.38
@@ -193,7 +193,7 @@ importers:
   packages/contentstack-auth:
     specifiers:
       '@contentstack/cli-command': ~1.6.1
-      '@contentstack/cli-utilities': ~1.14.1
+      '@contentstack/cli-utilities': ~1.14.4
       '@fancy-test/nock': ^0.1.1
       '@oclif/core': ^4.3.0
       '@oclif/plugin-help': ^6.2.28
@@ -245,7 +245,7 @@ importers:
     specifiers:
       '@contentstack/cli-cm-seed': ~1.12.2
       '@contentstack/cli-command': ~1.6.1
-      '@contentstack/cli-utilities': ~1.14.1
+      '@contentstack/cli-utilities': ~1.14.4
       '@oclif/core': ^4.3.0
       '@oclif/plugin-help': ^6.2.28
       '@oclif/test': ^4.1.13
@@ -296,7 +296,7 @@ importers:
     specifiers:
       '@contentstack/cli-command': ~1.6.1
       '@contentstack/cli-dev-dependencies': ~1.3.0
-      '@contentstack/cli-utilities': ~1.14.1
+      '@contentstack/cli-utilities': ~1.14.4
       '@oclif/core': ^4.3.0
       '@oclif/plugin-help': ^6.2.28
       '@types/flat': ^5.0.5
@@ -341,7 +341,7 @@ importers:
     specifiers:
       '@contentstack/cli-command': ~1.6.1
       '@contentstack/cli-config': ~1.15.0
-      '@contentstack/cli-utilities': ~1.14.1
+      '@contentstack/cli-utilities': ~1.14.4
       '@oclif/core': ^4.3.0
       '@oclif/plugin-help': ^6.2.28
       '@oclif/test': ^4.1.13
@@ -382,7 +382,7 @@ importers:
       '@contentstack/cli-cm-export': ~1.20.1
       '@contentstack/cli-cm-import': ~1.28.2
       '@contentstack/cli-command': ~1.6.1
-      '@contentstack/cli-utilities': ~1.14.1
+      '@contentstack/cli-utilities': ~1.14.4
       '@oclif/core': ^4.3.0
       '@oclif/plugin-help': ^6.2.28
       '@oclif/test': ^4.1.13
@@ -429,7 +429,7 @@ importers:
 
   packages/contentstack-command:
     specifiers:
-      '@contentstack/cli-utilities': ~1.14.1
+      '@contentstack/cli-utilities': ~1.14.4
       '@oclif/core': ^4.3.0
       '@oclif/plugin-help': ^6.2.28
       '@oclif/test': ^4.1.13
@@ -465,7 +465,7 @@ importers:
   packages/contentstack-config:
     specifiers:
       '@contentstack/cli-command': ~1.6.1
-      '@contentstack/cli-utilities': ~1.14.1
+      '@contentstack/cli-utilities': ~1.14.4
       '@oclif/core': ^4.3.0
       '@oclif/plugin-help': ^6.2.28
       '@oclif/test': ^4.1.13
@@ -538,7 +538,7 @@ importers:
       '@contentstack/cli-command': ~1.6.1
       '@contentstack/cli-config': ~1.15.1
       '@contentstack/cli-dev-dependencies': ~1.3.1
-      '@contentstack/cli-utilities': ~1.14.1
+      '@contentstack/cli-utilities': ~1.14.4
       '@contentstack/cli-variants': ~1.3.3
       '@oclif/core': ^4.3.3
       '@oclif/plugin-help': ^6.2.28
@@ -602,7 +602,7 @@ importers:
   packages/contentstack-export-to-csv:
     specifiers:
       '@contentstack/cli-command': ~1.6.1
-      '@contentstack/cli-utilities': ~1.14.1
+      '@contentstack/cli-utilities': ~1.14.4
       '@oclif/core': ^4.3.0
       '@oclif/plugin-help': ^6.2.32
       '@oclif/test': ^4.1.13
@@ -644,7 +644,7 @@ importers:
     specifiers:
       '@contentstack/cli-audit': ~1.15.0
       '@contentstack/cli-command': ~1.6.1
-      '@contentstack/cli-utilities': ~1.14.1
+      '@contentstack/cli-utilities': ~1.14.4
       '@contentstack/cli-variants': ~1.3.3
       '@contentstack/management': ~1.22.0
       '@oclif/core': ^4.3.0
@@ -722,7 +722,7 @@ importers:
   packages/contentstack-import-setup:
     specifiers:
       '@contentstack/cli-command': ~1.6.1
-      '@contentstack/cli-utilities': ~1.14.1
+      '@contentstack/cli-utilities': ~1.14.4
       '@oclif/core': ^4.3.0
       '@types/big-json': ^3.2.5
       '@types/bluebird': ^3.5.42
@@ -789,7 +789,7 @@ importers:
   packages/contentstack-migrate-rte:
     specifiers:
       '@contentstack/cli-command': ~1.6.1
-      '@contentstack/cli-utilities': ~1.14.1
+      '@contentstack/cli-utilities': ~1.14.4
       '@contentstack/json-rte-serializer': ~2.1.0
       '@oclif/core': ^4.3.0
       '@oclif/plugin-help': ^6.2.28
@@ -834,7 +834,7 @@ importers:
   packages/contentstack-migration:
     specifiers:
       '@contentstack/cli-command': ~1.6.1
-      '@contentstack/cli-utilities': ~1.14.1
+      '@contentstack/cli-utilities': ~1.14.4
       '@oclif/core': ^4.3.0
       '@oclif/plugin-help': ^6.2.28
       '@oclif/test': ^4.1.13
@@ -878,7 +878,7 @@ importers:
     specifiers:
       '@contentstack/cli-cm-import': ~1.28.2
       '@contentstack/cli-command': ~1.6.1
-      '@contentstack/cli-utilities': ~1.14.1
+      '@contentstack/cli-utilities': ~1.14.4
       '@contentstack/management': ~1.22.0
       '@types/inquirer': ^9.0.8
       '@types/jest': ^26.0.24
@@ -1025,7 +1025,7 @@ importers:
   packages/contentstack-variants:
     specifiers:
       '@contentstack/cli-dev-dependencies': ^1.3.0
-      '@contentstack/cli-utilities': ~1.14.1
+      '@contentstack/cli-utilities': ~1.14.4
       '@oclif/core': ^4.3.0
       '@oclif/plugin-help': ^6.2.28
       '@oclif/test': ^4.1.13


### PR DESCRIPTION
**Description:**
This PR enhances the logging configuration by:

- Increasing the maximum log file size from 1 MB to 5 MB.
- Increasing the number of retained log files from 20 to 50.

**Changes Made:**

Updated log rotation configuration:

maxFileSize: 1MB → 5MB

maxFiles: 20 → 50

**Testing:**

Verified logging behavior with the new configuration.

Confirmed that log rotation occurs correctly at 5 MB.

Ensured 50 log files are retained as expected.

**Impact:**
Low-risk configuration change. No functional code changes.