### PR TITLE
feat: validate referenced entry content types in entries audit

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -3,9 +3,9 @@ fileignoreconfig:
 - filename: packages/contentstack-import/src/import/modules/environments.ts
   checksum: f61c635eaec8026e0cfa80a5ab8272f7946531f6d89505dc0d247b4c7ab0eab7
 - filename: pnpm-lock.yaml
-  checksum: c3020538089092e55f086c39cc4c027ef3d48f6c786a217db9c5e49f55ab8380
+  checksum: 33b0a88264d099a2594bf8f18b8b025b0e15443dce340cd2ab5021ccc9aa84b0
 - filename: package-lock.json
-  checksum: 099edd9ec7ed92eb61ce916511ac87e2fc1ff985efe64a25749ac88ba0d3fa7d
+  checksum: 38142d4c1159342957985368de6d5caf77ab3198a926fe55cdfd95c7c7343100
 - filename: packages/contentstack-bootstrap/src/bootstrap/utils.ts
   checksum: 5ab20e057fa9c4c300f7a882d30e1c68bbc91ed19de520488107e8c37239682a
 - filename: packages/contentstack-migration/README.md

--- a/.talismanrc
+++ b/.talismanrc
@@ -14,4 +14,6 @@ fileignoreconfig:
   checksum: f4f44b6031d2936ec2da98b39bb5f5c1bd0f3be34dbe498c75e64a35b7d25a33
 - filename: packages/contentstack/README.md
   checksum: 3a0fab964797476a71d2149ce261d265f410bd756eb9cde9400be9e5250fdc35
+- filename: packages/contentstack-audit/src/modules/entries.ts
+  checksum: 8ad10d72522433bc5ce66079248aa2dabae1758ee63335024efd8526d76dd885
 version: '1.0'

--- a/package-lock.json
+++ b/package-lock.json
@@ -280,9 +280,9 @@
       }
     },
     "node_modules/@aws-sdk/client-cloudfront": {
-      "version": "3.993.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudfront/-/client-cloudfront-3.993.0.tgz",
-      "integrity": "sha512-8jCdRFDWJSyeAtAMuynUPy+3Bz9aRaunxhUluxCK9aLCadj9J19mvxsMHvdumObeYam4NYVi2GYVs8GFZ0ET1g==",
+      "version": "3.995.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudfront/-/client-cloudfront-3.995.0.tgz",
+      "integrity": "sha512-hTyUaVs0hKPSlQyreyxmj6g9sPRs9XWNzDCozYfU5rbAcqS1E0AVTFAjbgNvKIOEbY5iL4UuiIFdFG7m5z9SAQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -296,9 +296,9 @@
         "@aws-sdk/middleware-user-agent": "^3.972.11",
         "@aws-sdk/region-config-resolver": "^3.972.3",
         "@aws-sdk/types": "^3.973.1",
-        "@aws-sdk/util-endpoints": "3.993.0",
+        "@aws-sdk/util-endpoints": "3.995.0",
         "@aws-sdk/util-user-agent-browser": "^3.972.3",
-        "@aws-sdk/util-user-agent-node": "^3.972.9",
+        "@aws-sdk/util-user-agent-node": "^3.972.10",
         "@smithy/config-resolver": "^4.4.6",
         "@smithy/core": "^3.23.2",
         "@smithy/fetch-http-handler": "^5.3.9",
@@ -333,9 +333,9 @@
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.993.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.993.0.tgz",
-      "integrity": "sha512-0slCxdbo9O3rfzqD7/PsBOrZ6vcwFzPAvGeUu5NZApI5WyjEfMLLi2T9QW8R9N9TQeUfiUQiHkg/NV0LPS61/g==",
+      "version": "3.995.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.995.0.tgz",
+      "integrity": "sha512-r+t8qrQ0m9zoovYOH+wilp/glFRB/E+blsDyWzq2C+9qmyhCAQwaxjLaHM8T/uluAmhtZQIYqOH9ILRnvWtRNw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -355,11 +355,11 @@
         "@aws-sdk/middleware-ssec": "^3.972.3",
         "@aws-sdk/middleware-user-agent": "^3.972.11",
         "@aws-sdk/region-config-resolver": "^3.972.3",
-        "@aws-sdk/signature-v4-multi-region": "3.993.0",
+        "@aws-sdk/signature-v4-multi-region": "3.995.0",
         "@aws-sdk/types": "^3.973.1",
-        "@aws-sdk/util-endpoints": "3.993.0",
+        "@aws-sdk/util-endpoints": "3.995.0",
         "@aws-sdk/util-user-agent-browser": "^3.972.3",
-        "@aws-sdk/util-user-agent-node": "^3.972.9",
+        "@aws-sdk/util-user-agent-node": "^3.972.10",
         "@smithy/config-resolver": "^4.4.6",
         "@smithy/core": "^3.23.2",
         "@smithy/eventstream-serde-browser": "^4.2.8",
@@ -443,6 +443,23 @@
         "@smithy/util-middleware": "^4.2.8",
         "@smithy/util-retry": "^4.2.8",
         "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.993.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.993.0.tgz",
+      "integrity": "sha512-j6vioBeRZ4eHX4SWGvGPpwGg/xSOcK7f1GL0VM+rdf3ZFTIsUEhCFmD78B+5r2PgztcECSzEfvHQX01k8dPQPw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.1",
+        "@smithy/types": "^4.12.0",
+        "@smithy/url-parser": "^4.2.8",
+        "@smithy/util-endpoints": "^3.2.8",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -838,6 +855,23 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@aws-sdk/middleware-user-agent/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.993.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.993.0.tgz",
+      "integrity": "sha512-j6vioBeRZ4eHX4SWGvGPpwGg/xSOcK7f1GL0VM+rdf3ZFTIsUEhCFmD78B+5r2PgztcECSzEfvHQX01k8dPQPw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.1",
+        "@smithy/types": "^4.12.0",
+        "@smithy/url-parser": "^4.2.8",
+        "@smithy/util-endpoints": "^3.2.8",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/nested-clients": {
       "version": "3.993.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.993.0.tgz",
@@ -888,6 +922,23 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.993.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.993.0.tgz",
+      "integrity": "sha512-j6vioBeRZ4eHX4SWGvGPpwGg/xSOcK7f1GL0VM+rdf3ZFTIsUEhCFmD78B+5r2PgztcECSzEfvHQX01k8dPQPw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.1",
+        "@smithy/types": "^4.12.0",
+        "@smithy/url-parser": "^4.2.8",
+        "@smithy/util-endpoints": "^3.2.8",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/region-config-resolver": {
       "version": "3.972.3",
       "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.3.tgz",
@@ -906,9 +957,9 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.993.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.993.0.tgz",
-      "integrity": "sha512-6l20k27TJdqTozJOm+s20/1XDey3aj+yaeIdbtqXuYNhQiWHajvYThcI1sHx2I1W4NelZTOmYEF+dj1mya01eg==",
+      "version": "3.995.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.995.0.tgz",
+      "integrity": "sha512-9Qx5JcAucnxnomREPb2D6L8K8GLG0rknt3+VK/BU3qTUynAcV4W21DQ04Z2RKDw+DYpW88lsZpXbVetWST2WUg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -970,9 +1021,9 @@
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.993.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.993.0.tgz",
-      "integrity": "sha512-j6vioBeRZ4eHX4SWGvGPpwGg/xSOcK7f1GL0VM+rdf3ZFTIsUEhCFmD78B+5r2PgztcECSzEfvHQX01k8dPQPw==",
+      "version": "3.995.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.995.0.tgz",
+      "integrity": "sha512-aym/pjB8SLbo9w2nmkrDdAAVKVlf7CM71B9mKhjDbJTzwpSFBPHqJIMdDyj0mLumKC0aIVDr1H6U+59m9GvMFw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1013,9 +1064,9 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.972.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.972.9.tgz",
-      "integrity": "sha512-JNswdsLdQemxqaSIBL2HRhsHPUBBziAgoi5RQv6/9avmE5g5RSdt1hWr3mHJ7OxqRYf+KeB11ExWbiqfrnoeaA==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.972.10.tgz",
+      "integrity": "sha512-LVXzICPlsheET+sE6tkcS47Q5HkSTrANIlqL1iFxGAY/wRQ236DX/PCAK56qMh9QJoXAfXfoRW0B0Og4R+X7Nw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2077,9 +2128,9 @@
       }
     },
     "node_modules/@contentstack/management": {
-      "version": "1.27.5",
-      "resolved": "https://registry.npmjs.org/@contentstack/management/-/management-1.27.5.tgz",
-      "integrity": "sha512-eiv3NeGHGtjRhbOKotbfvHOL+RQv24aaZVb/gxxkyFVE0wyQmagtUzz4nRURDy0qnYttdkGxx65r4hzNZbxq8Q==",
+      "version": "1.27.6",
+      "resolved": "https://registry.npmjs.org/@contentstack/management/-/management-1.27.6.tgz",
+      "integrity": "sha512-92h8YzKZ2EDzMogf0fmBHapCjVpzHkDBIj0Eb/MhPFIhlybDlAZhcM/di6zwgicEJj5UjTJ+ETXXQMEJZouDew==",
       "license": "MIT",
       "dependencies": {
         "@contentstack/utils": "^1.7.0",
@@ -2090,7 +2141,7 @@
         "husky": "^9.1.7",
         "lodash": "^4.17.23",
         "otplib": "^12.0.1",
-        "qs": "6.14.1",
+        "qs": "^6.15.0",
         "stream-browserify": "^3.0.0"
       },
       "engines": {
@@ -2113,6 +2164,21 @@
         "node": ">= 6"
       }
     },
+    "node_modules/@contentstack/management/node_modules/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/@contentstack/marketplace-sdk": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@contentstack/marketplace-sdk/-/marketplace-sdk-1.5.0.tgz",
@@ -2124,9 +2190,9 @@
       }
     },
     "node_modules/@contentstack/utils": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@contentstack/utils/-/utils-1.7.0.tgz",
-      "integrity": "sha512-wNWNt+wkoGJzCr5ZhAMKWJ5ND5xbD7N3t++Y6s1O+FB+AFzJszqCT740j6VqwjhQzw5sGfHoGjHIvlQA9dCcBw==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@contentstack/utils/-/utils-1.7.1.tgz",
+      "integrity": "sha512-b/0t1malpJeFCNd9+1uN3BuO8mRn2b5+aNtrYEZ6YlSNjYNRu9IjqSxZ5Clhs5267950UV1ayhgFE8z3qre2eQ==",
       "license": "MIT"
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -2736,6 +2802,13 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@eslint/config-array/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -2748,9 +2821,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
+      "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -2880,9 +2953,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2895,6 +2968,13 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
       "version": "1.1.12",
@@ -2915,9 +2995,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
+      "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -3092,6 +3172,13 @@
         "node": ">=10.10.0"
       }
     },
+    "node_modules/@humanwhocodes/config-array/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -3104,9 +3191,9 @@
       }
     },
     "node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
+      "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -3977,13 +4064,13 @@
       }
     },
     "node_modules/@jsdoc/salty": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/@jsdoc/salty/-/salty-0.2.9.tgz",
-      "integrity": "sha512-yYxMVH7Dqw6nO0d5NIV8OQWnitU8k6vXH8NtgqAfIa/IUqRMxRv/NUJJ08VEKbAakwxlgBl5PJdrU0dMPStsnw==",
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/@jsdoc/salty/-/salty-0.2.10.tgz",
+      "integrity": "sha512-VFHSsQAQp8y1NJvAJBpLs9I2shHE6hz9TwukocDObuUgGVAq62yZGbTgJg04Z3Fj0XSMWe0sJqGg5dhKGTV92A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "lodash": "^4.17.21"
+        "lodash": "^4.17.23"
       },
       "engines": {
         "node": ">=v12.0.0"
@@ -4051,9 +4138,9 @@
       }
     },
     "node_modules/@oclif/core": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-4.8.0.tgz",
-      "integrity": "sha512-jteNUQKgJHLHFbbz806aGZqf+RJJ7t4gwF4MYa8fCwCxQ8/klJNWc0MvaJiBebk7Mc+J39mdlsB4XraaCKznFw==",
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-4.8.1.tgz",
+      "integrity": "sha512-07mq0vKCWNsB85ZHeBMlTAiO0KLFqHyAeRK3bD2K8CI1tX3tiwkWw1lZQZkiw8MUBrhxdROhMkYMY4Q0l7JHqA==",
       "license": "MIT",
       "dependencies": {
         "ansi-escapes": "^4.3.2",
@@ -4066,7 +4153,7 @@
         "indent-string": "^4.0.0",
         "is-wsl": "^2.2.0",
         "lilconfig": "^3.1.3",
-        "minimatch": "^9.0.5",
+        "minimatch": "^10.2.1",
         "semver": "^7.7.3",
         "string-width": "^4.2.3",
         "supports-color": "^8",
@@ -4782,9 +4869,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.57.1.tgz",
-      "integrity": "sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
+      "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
       "cpu": [
         "arm"
       ],
@@ -4795,9 +4882,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.57.1.tgz",
-      "integrity": "sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
+      "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
       "cpu": [
         "arm64"
       ],
@@ -4808,9 +4895,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.57.1.tgz",
-      "integrity": "sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
+      "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
       "cpu": [
         "arm64"
       ],
@@ -4821,9 +4908,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.57.1.tgz",
-      "integrity": "sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
+      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
       "cpu": [
         "x64"
       ],
@@ -4834,9 +4921,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.57.1.tgz",
-      "integrity": "sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
+      "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
       "cpu": [
         "arm64"
       ],
@@ -4847,9 +4934,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.57.1.tgz",
-      "integrity": "sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
+      "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
       "cpu": [
         "x64"
       ],
@@ -4860,9 +4947,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.57.1.tgz",
-      "integrity": "sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
+      "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
       "cpu": [
         "arm"
       ],
@@ -4873,9 +4960,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.57.1.tgz",
-      "integrity": "sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
+      "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
       "cpu": [
         "arm"
       ],
@@ -4886,9 +4973,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.57.1.tgz",
-      "integrity": "sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
+      "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
       "cpu": [
         "arm64"
       ],
@@ -4899,9 +4986,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.57.1.tgz",
-      "integrity": "sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
+      "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
       "cpu": [
         "arm64"
       ],
@@ -4912,9 +4999,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.57.1.tgz",
-      "integrity": "sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
+      "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
       "cpu": [
         "loong64"
       ],
@@ -4925,9 +5012,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.57.1.tgz",
-      "integrity": "sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
+      "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
       "cpu": [
         "loong64"
       ],
@@ -4938,9 +5025,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.57.1.tgz",
-      "integrity": "sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
+      "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
       "cpu": [
         "ppc64"
       ],
@@ -4951,9 +5038,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.57.1.tgz",
-      "integrity": "sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
+      "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
       "cpu": [
         "ppc64"
       ],
@@ -4964,9 +5051,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.57.1.tgz",
-      "integrity": "sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
+      "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
       "cpu": [
         "riscv64"
       ],
@@ -4977,9 +5064,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.57.1.tgz",
-      "integrity": "sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
+      "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
       "cpu": [
         "riscv64"
       ],
@@ -4990,9 +5077,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.57.1.tgz",
-      "integrity": "sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
+      "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
       "cpu": [
         "s390x"
       ],
@@ -5003,9 +5090,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.57.1.tgz",
-      "integrity": "sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
       "cpu": [
         "x64"
       ],
@@ -5016,9 +5103,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.57.1.tgz",
-      "integrity": "sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
+      "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
       "cpu": [
         "x64"
       ],
@@ -5029,9 +5116,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.57.1.tgz",
-      "integrity": "sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
+      "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
       "cpu": [
         "x64"
       ],
@@ -5042,9 +5129,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.57.1.tgz",
-      "integrity": "sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
+      "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
       "cpu": [
         "arm64"
       ],
@@ -5055,9 +5142,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.57.1.tgz",
-      "integrity": "sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
+      "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
       "cpu": [
         "arm64"
       ],
@@ -5068,9 +5155,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.57.1.tgz",
-      "integrity": "sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
+      "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
       "cpu": [
         "ia32"
       ],
@@ -5081,9 +5168,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.57.1.tgz",
-      "integrity": "sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
       "cpu": [
         "x64"
       ],
@@ -5094,9 +5181,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.57.1.tgz",
-      "integrity": "sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
+      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
       "cpu": [
         "x64"
       ],
@@ -5261,9 +5348,9 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.23.2",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.2.tgz",
-      "integrity": "sha512-HaaH4VbGie4t0+9nY3tNBRSxVTr96wzIqexUa6C2qx3MPePAuz7lIxPxYtt1Wc//SPfJLNoZJzfdt0B6ksj2jA==",
+      "version": "3.23.3",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.3.tgz",
+      "integrity": "sha512-5IETfbqrTuGs0fC22ZnTW6df+PHlrWpSbAbySzTozsUROWPiOXDIWt1Y4dCDzhJUQ6H3ig/dFOZaEeLsTjNGRQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -5273,7 +5360,7 @@
         "@smithy/util-base64": "^4.3.0",
         "@smithy/util-body-length-browser": "^4.2.0",
         "@smithy/util-middleware": "^4.2.8",
-        "@smithy/util-stream": "^4.5.12",
+        "@smithy/util-stream": "^4.5.13",
         "@smithy/util-utf8": "^4.2.0",
         "@smithy/uuid": "^1.1.0",
         "tslib": "^2.6.2"
@@ -5496,13 +5583,13 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.4.16",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.16.tgz",
-      "integrity": "sha512-L5GICFCSsNhbJ5JSKeWFGFy16Q2OhoBizb3X2DrxaJwXSEujVvjG9Jt386dpQn2t7jINglQl0b4K/Su69BdbMA==",
+      "version": "4.4.17",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.17.tgz",
+      "integrity": "sha512-QP8wuZ7iSNEQ4/HyihTHlDUlQ3eBrCo+HoMm8l2gPcNrR4TA1RCC10jR7IyCnn3ASTrUwEnRaQ062vFC2/eYJw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.2",
+        "@smithy/core": "^3.23.3",
         "@smithy/middleware-serde": "^4.2.9",
         "@smithy/node-config-provider": "^4.3.8",
         "@smithy/shared-ini-file-loader": "^4.4.3",
@@ -5516,16 +5603,16 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "4.4.33",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.33.tgz",
-      "integrity": "sha512-jLqZOdJhtIL4lnA9hXnAG6GgnJlo1sD3FqsTxm9wSfjviqgWesY/TMBVnT84yr4O0Vfe0jWoXlfFbzsBVph3WA==",
+      "version": "4.4.34",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.34.tgz",
+      "integrity": "sha512-ROmCX/ev7ryOzgsQ6dnJ46gbVSrvR2HX7ioxkfXlrgfKEMMOUCWgl/OMOi7PZn95CXTxMMNJTbP3nkvWGFTz+w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/node-config-provider": "^4.3.8",
         "@smithy/protocol-http": "^5.3.8",
         "@smithy/service-error-classification": "^4.2.8",
-        "@smithy/smithy-client": "^4.11.5",
+        "@smithy/smithy-client": "^4.11.6",
         "@smithy/types": "^4.12.0",
         "@smithy/util-middleware": "^4.2.8",
         "@smithy/util-retry": "^4.2.8",
@@ -5703,18 +5790,18 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.11.5",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.11.5.tgz",
-      "integrity": "sha512-xixwBRqoeP2IUgcAl3U9dvJXc+qJum4lzo3maaJxifsZxKUYLfVfCXvhT4/jD01sRrHg5zjd1cw2Zmjr4/SuKQ==",
+      "version": "4.11.6",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.11.6.tgz",
+      "integrity": "sha512-g9FNlCTfQzkSpHW3ILOm+TWZfXuOj2UcrNWNBHLnY3Ch+67mLVmiu3fGWPWbs1XiRK174q5tGphnPCTHvImQUA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.2",
-        "@smithy/middleware-endpoint": "^4.4.16",
+        "@smithy/core": "^3.23.3",
+        "@smithy/middleware-endpoint": "^4.4.17",
         "@smithy/middleware-stack": "^4.2.8",
         "@smithy/protocol-http": "^5.3.8",
         "@smithy/types": "^4.12.0",
-        "@smithy/util-stream": "^4.5.12",
+        "@smithy/util-stream": "^4.5.13",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5818,14 +5905,14 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.3.32",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.32.tgz",
-      "integrity": "sha512-092sjYfFMQ/iaPH798LY/OJFBcYu0sSK34Oy9vdixhsU36zlZu8OcYjF3TD4e2ARupyK7xaxPXl+T0VIJTEkkg==",
+      "version": "4.3.33",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.33.tgz",
+      "integrity": "sha512-VutP/lyBWaTNUzNjI+NC3Kwts4Grhb8CTUyGZNQadf5lujqNy2IIM739D31qplSdbxqYBLOPvMXwy4CIKOArrg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/property-provider": "^4.2.8",
-        "@smithy/smithy-client": "^4.11.5",
+        "@smithy/smithy-client": "^4.11.6",
         "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
@@ -5834,9 +5921,9 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.2.35",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.35.tgz",
-      "integrity": "sha512-miz/ggz87M8VuM29y7jJZMYkn7+IErM5p5UgKIf8OtqVs/h2bXr1Bt3uTsREsI/4nK8a0PQERbAPsVPVNIsG7Q==",
+      "version": "4.2.36",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.36.tgz",
+      "integrity": "sha512-x73FjvOgG8XBtxu4auMnMDhLi6bUVBLHgNAv8xU0noDGks0KF59JNSzgVQ0oOSuf/D6pVJ5tMEkajwz6IavBUg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -5844,7 +5931,7 @@
         "@smithy/credential-provider-imds": "^4.2.8",
         "@smithy/node-config-provider": "^4.3.8",
         "@smithy/property-provider": "^4.2.8",
-        "@smithy/smithy-client": "^4.11.5",
+        "@smithy/smithy-client": "^4.11.6",
         "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
@@ -5910,9 +5997,9 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "4.5.12",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.12.tgz",
-      "integrity": "sha512-D8tgkrmhAX/UNeCZbqbEO3uqyghUnEmmoO9YEvRuwxjlkKKUE7FOgCJnqpTlQPe9MApdWPky58mNQQHbnCzoNg==",
+      "version": "4.5.13",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.13.tgz",
+      "integrity": "sha512-ZJQh++mmjO7JiWAW4SdWFrsde1VE038g4uGtkTlvCGcpytMLsxIAg9o9blorLYaQG47EfY9QjLP38od88NLL8w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -6117,9 +6204,9 @@
       }
     },
     "node_modules/@stylistic/eslint-plugin/node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.0.tgz",
-      "integrity": "sha512-A0XeIi7CXU7nPlfHS9loMYEKxUaONu/hTEzHTGba9Huu94Cq1hPivf+DE5erJozZOky0LfvXAyrV/tcswpLI0Q==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -6158,6 +6245,22 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin/node_modules/minimatch": {
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.6.tgz",
+      "integrity": "sha512-kQAVowdR33euIqeA0+VZTDqU+qo1IeVY+hrKYtZMio3Pg0P0vuh/kwRylLUddJhB6pf3q/botcOvRtx4IN1wqQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@szmarczak/http-timer": {
@@ -6472,9 +6575,9 @@
       "license": "MIT"
     },
     "node_modules/@types/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-RDvF6wTulMPjrNdCoYRC8gNR880JNGT8uB+REUpC2Ns4pRqQJhGz90wh7rgdXDPpCczF3VGktDuFGVnz8zP7HA==",
+      "version": "4.17.24",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.24.tgz",
+      "integrity": "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==",
       "license": "MIT"
     },
     "node_modules/@types/markdown-it": {
@@ -7323,9 +7426,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -7346,9 +7449,9 @@
       }
     },
     "node_modules/acorn-walk": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
-      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8005,10 +8108,13 @@
       }
     },
     "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "license": "MIT"
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -8031,13 +8137,16 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.9.19",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
-      "integrity": "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
+      "integrity": "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
-        "baseline-browser-mapping": "dist/cli.js"
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/big-json": {
@@ -8155,12 +8264,15 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
+      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -8497,9 +8609,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001770",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001770.tgz",
-      "integrity": "sha512-x/2CLQ1jHENRbHg5PSId2sXq1CIO1CISvwWAj027ltMVG2UNgW+w9oH2+HzgEIRFembL8bUlXtfbBHR1fCg2xw==",
+      "version": "1.0.30001774",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001774.tgz",
+      "integrity": "sha512-DDdwPGz99nmIEv216hKSgLD+D4ikHQHjBC/seF98N9CPqRX4M5mSxT9eTV6oyisnJcuzxtZy4n17yKKQYmYQOA==",
       "dev": true,
       "funding": [
         {
@@ -9936,9 +10048,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.286",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.286.tgz",
-      "integrity": "sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==",
+      "version": "1.5.302",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.302.tgz",
+      "integrity": "sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==",
       "dev": true,
       "license": "ISC"
     },
@@ -10353,9 +10465,9 @@
       }
     },
     "node_modules/eslint-config-oclif": {
-      "version": "6.0.140",
-      "resolved": "https://registry.npmjs.org/eslint-config-oclif/-/eslint-config-oclif-6.0.140.tgz",
-      "integrity": "sha512-e+tZJ+PM+keWV/yZoaURDH8i2jIpvQD28She9Sz4x6+zHUQjRw13AR78NDeI+HdfixDuTrlPI2eTxYWxmpg7FQ==",
+      "version": "6.0.144",
+      "resolved": "https://registry.npmjs.org/eslint-config-oclif/-/eslint-config-oclif-6.0.144.tgz",
+      "integrity": "sha512-87Zn12V0wnkxPSsm9TdIyZ4v5uNceqjMilyyR8Snk/oxCtOaawy/6mU1DwzS1zv4tnspZgeLJn+Y1ZI8Mf7BQw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10372,10 +10484,10 @@
         "eslint-plugin-import": "^2.32.0",
         "eslint-plugin-jsdoc": "^50.8.0",
         "eslint-plugin-mocha": "^10.5.0",
-        "eslint-plugin-n": "^17.23.2",
+        "eslint-plugin-n": "^17.24.0",
         "eslint-plugin-perfectionist": "^4",
         "eslint-plugin-unicorn": "^56.0.1",
-        "typescript-eslint": "^8.55.0"
+        "typescript-eslint": "^8.56.0"
       },
       "engines": {
         "node": ">=18.18.0"
@@ -10600,6 +10712,23 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/eslint-config-oclif-typescript/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint-config-oclif-typescript/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
     "node_modules/eslint-config-oclif-typescript/node_modules/eslint-import-resolver-typescript": {
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.10.1.tgz",
@@ -10673,9 +10802,9 @@
       }
     },
     "node_modules/eslint-config-oclif-typescript/node_modules/eslint-plugin-n/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
+      "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -10793,9 +10922,9 @@
       }
     },
     "node_modules/eslint-config-oclif/node_modules/@eslint/js": {
-      "version": "9.39.2",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.2.tgz",
-      "integrity": "sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==",
+      "version": "9.39.3",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.3.tgz",
+      "integrity": "sha512-1B1VkCq6FuUNlQvlBYb+1jDu/gV297TIs/OeiaSR9l1H27SVW55ONE1e1Vp16NqP683+xEGzxYtv4XCiDPaQiw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10955,13 +11084,13 @@
       }
     },
     "node_modules/eslint-config-oclif/node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.6.tgz",
+      "integrity": "sha512-kQAVowdR33euIqeA0+VZTDqU+qo1IeVY+hrKYtZMio3Pg0P0vuh/kwRylLUddJhB6pf3q/botcOvRtx4IN1wqQ==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^5.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -11013,9 +11142,9 @@
       }
     },
     "node_modules/eslint-config-oclif/node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11028,6 +11157,13 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/eslint-config-oclif/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/eslint-config-oclif/node_modules/ci-info": {
       "version": "3.9.0",
@@ -11046,9 +11182,9 @@
       }
     },
     "node_modules/eslint-config-oclif/node_modules/eslint": {
-      "version": "9.39.2",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.2.tgz",
-      "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
+      "version": "9.39.3",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.3.tgz",
+      "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -11059,7 +11195,7 @@
         "@eslint/config-helpers": "^0.4.2",
         "@eslint/core": "^0.17.0",
         "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.39.2",
+        "@eslint/js": "9.39.3",
         "@eslint/plugin-kit": "^0.4.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
@@ -11205,14 +11341,14 @@
       }
     },
     "node_modules/eslint-config-oclif/node_modules/eslint-config-xo/node_modules/@stylistic/eslint-plugin": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-5.8.0.tgz",
-      "integrity": "sha512-WNPVF/FfBAjyi3OA7gok8swRiImNLKI4dmV3iK/GC/0xSJR7eCzBFsw9hLZVgb1+MYNLy7aDsjohxN1hA/FIfQ==",
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-5.9.0.tgz",
+      "integrity": "sha512-FqqSkvDMYJReydrMhlugc71M76yLLQWNfmGq+SIlLa7N3kHp8Qq8i2PyWrVNAfjOyOIY+xv9XaaYwvVW7vroMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/types": "^8.54.0",
+        "@typescript-eslint/types": "^8.56.0",
         "eslint-visitor-keys": "^4.2.1",
         "espree": "^10.4.0",
         "estraverse": "^5.3.0",
@@ -11222,7 +11358,7 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "peerDependencies": {
-        "eslint": ">=9.0.0"
+        "eslint": "^9.0.0 || ^10.0.0"
       }
     },
     "node_modules/eslint-config-oclif/node_modules/eslint-config-xo/node_modules/eslint-visitor-keys": {
@@ -11305,9 +11441,9 @@
       }
     },
     "node_modules/eslint-config-oclif/node_modules/eslint-visitor-keys": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.0.tgz",
-      "integrity": "sha512-A0XeIi7CXU7nPlfHS9loMYEKxUaONu/hTEzHTGba9Huu94Cq1hPivf+DE5erJozZOky0LfvXAyrV/tcswpLI0Q==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -11412,9 +11548,9 @@
       "license": "MIT"
     },
     "node_modules/eslint-config-oclif/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
+      "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -11625,6 +11761,13 @@
         "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9"
       }
     },
+    "node_modules/eslint-plugin-import/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -11660,9 +11803,9 @@
       }
     },
     "node_modules/eslint-plugin-import/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
+      "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -11917,9 +12060,9 @@
       }
     },
     "node_modules/eslint-plugin-perfectionist/node_modules/eslint-visitor-keys": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.0.tgz",
-      "integrity": "sha512-A0XeIi7CXU7nPlfHS9loMYEKxUaONu/hTEzHTGba9Huu94Cq1hPivf+DE5erJozZOky0LfvXAyrV/tcswpLI0Q==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -11927,6 +12070,22 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-plugin-perfectionist/node_modules/minimatch": {
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.6.tgz",
+      "integrity": "sha512-kQAVowdR33euIqeA0+VZTDqU+qo1IeVY+hrKYtZMio3Pg0P0vuh/kwRylLUddJhB6pf3q/botcOvRtx4IN1wqQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/eslint-plugin-unicorn": {
@@ -12043,9 +12202,9 @@
       }
     },
     "node_modules/eslint/node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12058,6 +12217,13 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/eslint/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/eslint/node_modules/brace-expansion": {
       "version": "1.1.12",
@@ -12095,9 +12261,9 @@
       "license": "MIT"
     },
     "node_modules/eslint/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
+      "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -12609,24 +12775,15 @@
       }
     },
     "node_modules/filelist": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
-      "integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.5.tgz",
+      "integrity": "sha512-ct/ckWBV/9Dg3MlvCXsLcSUyoWwv9mCKqlhLNB2DAuXR/NZolSXlQqP5dyy6guWlPXBhodZyZ5lGPQcbQDxrEQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "minimatch": "^5.0.1"
-      }
-    },
-    "node_modules/filelist/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "minimatch": "^10.2.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": "20 || >=22"
       }
     },
     "node_modules/fill-range": {
@@ -13286,6 +13443,13 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/glob/node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -13298,9 +13462,9 @@
       }
     },
     "node_modules/glob/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
+      "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -17739,15 +17903,15 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "license": "ISC",
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
+      "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^5.0.2"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -17858,6 +18022,23 @@
         "node": ">= 14.0.0"
       }
     },
+    "node_modules/mocha/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mocha/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
     "node_modules/mocha/node_modules/cliui": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -17922,9 +18103,9 @@
       }
     },
     "node_modules/mocha/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.7.tgz",
+      "integrity": "sha512-FjiwU9HaHW6YB3H4a1sFudnv93lvydNjz2lmyUXR6IwKhGI+bgL3SOZrBGn6kvvX2pJvhEkGSGjyTHN47O4rqA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -21110,14 +21291,14 @@
       }
     },
     "node_modules/oclif": {
-      "version": "4.22.79",
-      "resolved": "https://registry.npmjs.org/oclif/-/oclif-4.22.79.tgz",
-      "integrity": "sha512-yMhiVsMdOOhqNc62ZOehPGNoLIWYc6MUHtb9AVlCgML45Jrfr3NlXi5LiOEOm0Xe37FVNZYiJJJM8O31cYLhdQ==",
+      "version": "4.22.81",
+      "resolved": "https://registry.npmjs.org/oclif/-/oclif-4.22.81.tgz",
+      "integrity": "sha512-MO2bupt/3wWYqt05F8ZLwMYKN58YqDfRVdJxAvCdg/wZJg6/sDXVKoMSTSzwqsnIaJGjru2LBNvk8lH+p+1uMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@aws-sdk/client-cloudfront": "^3.990.0",
-        "@aws-sdk/client-s3": "^3.990.0",
+        "@aws-sdk/client-cloudfront": "^3.995.0",
+        "@aws-sdk/client-s3": "^3.995.0",
         "@inquirer/confirm": "^3.1.22",
         "@inquirer/input": "^2.2.4",
         "@inquirer/select": "^2.5.0",
@@ -21733,16 +21914,16 @@
       "license": "MIT"
     },
     "node_modules/path-scurry": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz",
-      "integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^11.0.0",
         "minipass": "^7.1.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -23093,9 +23274,9 @@
       }
     },
     "node_modules/rewire/node_modules/@eslint/js": {
-      "version": "9.39.2",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.2.tgz",
-      "integrity": "sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==",
+      "version": "9.39.3",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.3.tgz",
+      "integrity": "sha512-1B1VkCq6FuUNlQvlBYb+1jDu/gV297TIs/OeiaSR9l1H27SVW55ONE1e1Vp16NqP683+xEGzxYtv4XCiDPaQiw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -23106,9 +23287,9 @@
       }
     },
     "node_modules/rewire/node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -23122,6 +23303,13 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/rewire/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/rewire/node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -23134,9 +23322,9 @@
       }
     },
     "node_modules/rewire/node_modules/eslint": {
-      "version": "9.39.2",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.2.tgz",
-      "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
+      "version": "9.39.3",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.3.tgz",
+      "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -23146,7 +23334,7 @@
         "@eslint/config-helpers": "^0.4.2",
         "@eslint/core": "^0.17.0",
         "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.39.2",
+        "@eslint/js": "9.39.3",
         "@eslint/plugin-kit": "^0.4.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
@@ -23289,9 +23477,9 @@
       "license": "MIT"
     },
     "node_modules/rewire/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
+      "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -23363,6 +23551,22 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/rimraf/node_modules/minimatch": {
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.6.tgz",
+      "integrity": "sha512-kQAVowdR33euIqeA0+VZTDqU+qo1IeVY+hrKYtZMio3Pg0P0vuh/kwRylLUddJhB6pf3q/botcOvRtx4IN1wqQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/rimraf/node_modules/minipass": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
@@ -23404,9 +23608,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
-      "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
+      "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.8"
@@ -23419,31 +23623,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.57.1",
-        "@rollup/rollup-android-arm64": "4.57.1",
-        "@rollup/rollup-darwin-arm64": "4.57.1",
-        "@rollup/rollup-darwin-x64": "4.57.1",
-        "@rollup/rollup-freebsd-arm64": "4.57.1",
-        "@rollup/rollup-freebsd-x64": "4.57.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.57.1",
-        "@rollup/rollup-linux-arm-musleabihf": "4.57.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.57.1",
-        "@rollup/rollup-linux-arm64-musl": "4.57.1",
-        "@rollup/rollup-linux-loong64-gnu": "4.57.1",
-        "@rollup/rollup-linux-loong64-musl": "4.57.1",
-        "@rollup/rollup-linux-ppc64-gnu": "4.57.1",
-        "@rollup/rollup-linux-ppc64-musl": "4.57.1",
-        "@rollup/rollup-linux-riscv64-gnu": "4.57.1",
-        "@rollup/rollup-linux-riscv64-musl": "4.57.1",
-        "@rollup/rollup-linux-s390x-gnu": "4.57.1",
-        "@rollup/rollup-linux-x64-gnu": "4.57.1",
-        "@rollup/rollup-linux-x64-musl": "4.57.1",
-        "@rollup/rollup-openbsd-x64": "4.57.1",
-        "@rollup/rollup-openharmony-arm64": "4.57.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.57.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.57.1",
-        "@rollup/rollup-win32-x64-gnu": "4.57.1",
-        "@rollup/rollup-win32-x64-msvc": "4.57.1",
+        "@rollup/rollup-android-arm-eabi": "4.59.0",
+        "@rollup/rollup-android-arm64": "4.59.0",
+        "@rollup/rollup-darwin-arm64": "4.59.0",
+        "@rollup/rollup-darwin-x64": "4.59.0",
+        "@rollup/rollup-freebsd-arm64": "4.59.0",
+        "@rollup/rollup-freebsd-x64": "4.59.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.59.0",
+        "@rollup/rollup-linux-arm64-musl": "4.59.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.59.0",
+        "@rollup/rollup-linux-loong64-musl": "4.59.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.59.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.59.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-musl": "4.59.0",
+        "@rollup/rollup-openbsd-x64": "4.59.0",
+        "@rollup/rollup-openharmony-arm64": "4.59.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.59.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.59.0",
+        "@rollup/rollup-win32-x64-gnu": "4.59.0",
+        "@rollup/rollup-win32-x64-msvc": "4.59.0",
         "fsevents": "~2.3.2"
       }
     },
@@ -24506,9 +24710,9 @@
       }
     },
     "node_modules/spdx-license-ids": {
-      "version": "3.0.22",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.22.tgz",
-      "integrity": "sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ==",
+      "version": "3.0.23",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
+      "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
       "dev": true,
       "license": "CC0-1.0"
     },
@@ -25042,6 +25246,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/test-exclude/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/test-exclude/node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -25054,9 +25265,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
+      "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -25908,9 +26119,9 @@
       }
     },
     "node_modules/typescript-eslint/node_modules/eslint-visitor-keys": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.0.tgz",
-      "integrity": "sha512-A0XeIi7CXU7nPlfHS9loMYEKxUaONu/hTEzHTGba9Huu94Cq1hPivf+DE5erJozZOky0LfvXAyrV/tcswpLI0Q==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -25928,6 +26139,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/typescript-eslint/node_modules/minimatch": {
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.6.tgz",
+      "integrity": "sha512-kQAVowdR33euIqeA0+VZTDqU+qo1IeVY+hrKYtZMio3Pg0P0vuh/kwRylLUddJhB6pf3q/botcOvRtx4IN1wqQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/typical": {
@@ -25977,9 +26204,9 @@
       }
     },
     "node_modules/underscore": {
-      "version": "1.13.7",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.7.tgz",
-      "integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==",
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -26724,10 +26951,10 @@
     },
     "packages/contentstack": {
       "name": "@contentstack/cli",
-      "version": "2.0.0-beta.12",
+      "version": "2.0.0-beta.13",
       "license": "MIT",
       "dependencies": {
-        "@contentstack/cli-audit": "~2.0.0-beta.4",
+        "@contentstack/cli-audit": "~2.0.0-beta.5",
         "@contentstack/cli-auth": "~2.0.0-beta.5",
         "@contentstack/cli-bulk-operations": "^1.0.0-beta",
         "@contentstack/cli-cm-bootstrap": "~2.0.0-beta.9",
@@ -26798,7 +27025,7 @@
     },
     "packages/contentstack-audit": {
       "name": "@contentstack/cli-audit",
-      "version": "2.0.0-beta.4",
+      "version": "2.0.0-beta.5",
       "license": "MIT",
       "dependencies": {
         "@contentstack/cli-command": "~2.0.0-beta",
@@ -26915,6 +27142,13 @@
         "@types/sinonjs__fake-timers": "*"
       }
     },
+    "packages/contentstack-auth/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "packages/contentstack-auth/node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -27018,9 +27252,9 @@
       }
     },
     "packages/contentstack-auth/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
+      "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -27183,39 +27417,18 @@
       "dev": true,
       "license": "MIT"
     },
-    "packages/contentstack-clone/node_modules/balanced-match": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.3.tgz",
-      "integrity": "sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g==",
-      "license": "MIT",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "packages/contentstack-clone/node_modules/brace-expansion": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
-      "integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "packages/contentstack-clone/node_modules/glob": {
-      "version": "13.0.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.5.tgz",
-      "integrity": "sha512-BzXxZg24Ibra1pbQ/zE7Kys4Ua1ks7Bn6pKLkVPZ9FZe4JQS6/Q7ef3LG1H+k7lUf5l4T3PLSyYyYJVYUvfgTw==",
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "minimatch": "^10.2.1",
-        "minipass": "^7.1.2",
-        "path-scurry": "^2.0.0"
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -27256,21 +27469,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "packages/contentstack-clone/node_modules/minimatch": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.1.tgz",
-      "integrity": "sha512-MClCe8IL5nRRmawL6ib/eT4oLyeKMGCghibcDWK+J0hh0Q8kqSdia6BvbRMVk6mPa6WqUa5uR2oxt6C5jd533A==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "packages/contentstack-clone/node_modules/minipass": {
@@ -27518,9 +27716,9 @@
       }
     },
     "packages/contentstack-dev-dependencies/node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -27543,6 +27741,13 @@
       "dependencies": {
         "sprintf-js": "~1.0.2"
       }
+    },
+    "packages/contentstack-dev-dependencies/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
     },
     "packages/contentstack-dev-dependencies/node_modules/brace-expansion": {
       "version": "1.1.12",
@@ -27720,9 +27925,9 @@
       "license": "MIT"
     },
     "packages/contentstack-dev-dependencies/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
+      "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -27911,7 +28116,7 @@
       "version": "2.0.0-beta.9",
       "license": "MIT",
       "dependencies": {
-        "@contentstack/cli-audit": "~2.0.0-beta.4",
+        "@contentstack/cli-audit": "~2.0.0-beta.5",
         "@contentstack/cli-command": "~2.0.0-beta",
         "@contentstack/cli-utilities": "~2.0.0-beta",
         "@contentstack/cli-variants": "~2.0.0-beta.5",

--- a/packages/contentstack-audit/package.json
+++ b/packages/contentstack-audit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentstack/cli-audit",
-  "version": "2.0.0-beta.4",
+  "version": "2.0.0-beta.5",
   "description": "Contentstack audit plugin",
   "author": "Contentstack CLI",
   "homepage": "https://github.com/contentstack/cli",

--- a/packages/contentstack-audit/src/modules/entries.ts
+++ b/packages/contentstack-audit/src/modules/entries.ts
@@ -92,6 +92,27 @@ export default class Entries extends BaseClass {
   }
 
   /**
+   * Returns whether a referenced entry's content type is allowed by the schema's reference_to.
+   * @param refCtUid - Content type UID of the referenced entry (e.g. from _content_type_uid)
+   * @param referenceTo - Schema's reference_to (string or string[])
+   * @param configOverride - Optional config with skipRefs; falls back to this.config
+   * @returns true if allowed or check cannot be performed; false if refCtUid is not in reference_to
+   */
+  protected isRefContentTypeAllowed(
+    refCtUid: string | undefined,
+    referenceTo: string | string[] | undefined,
+    configOverride?: { skipRefs?: string[] },
+  ): boolean {
+    if (refCtUid === undefined) return true;
+    const skipRefs = configOverride?.skipRefs ?? (this.config as any).skipRefs ?? [];
+    if (Array.isArray(skipRefs) && skipRefs.includes(refCtUid)) return true;
+    if (referenceTo === undefined || referenceTo === null) return true;
+    const refToList = Array.isArray(referenceTo) ? referenceTo : [referenceTo];
+    if (refToList.length === 0) return false;
+    return refToList.includes(refCtUid);
+  }
+
+  /**
    * The `run` function checks if a folder path exists, sets the schema based on the module name,
    * iterates over the schema and looks for references, and returns a list of missing references.
    * @param totalCount - Total number of entries to process (for progress tracking)
@@ -896,8 +917,9 @@ export default class Entries extends BaseClass {
 
     const missingRefs: Record<string, any>[] = [];
     const { uid: data_type, display_name, reference_to } = fieldStructure;
+    const refToList = Array.isArray(reference_to) ? reference_to : reference_to != null ? [reference_to] : [];
     log.debug(`Reference field UID: ${data_type}`);
-    log.debug(`Reference to: ${reference_to?.join(', ') || 'none'}`);
+    log.debug(`Reference to: ${refToList.join(', ') || 'none'}`);
     log.debug(`Found ${field?.length || 0} references to validate`);
 
     for (const index in field ?? []) {
@@ -916,7 +938,13 @@ export default class Entries extends BaseClass {
             missingRefs.push(reference);
           }
         } else {
-          log.debug(`Reference ${reference} is valid`);
+          const refCtUid = refExist.ctUid;
+          if (!this.isRefContentTypeAllowed(refCtUid, reference_to)) {
+            log.debug(`Reference ${reference} has wrong content type: ${refCtUid} not in reference_to`);
+            missingRefs.push(refToList.length === 1 ? { uid: reference, _content_type_uid: refCtUid } : reference);
+          } else {
+            log.debug(`Reference ${reference} is valid`);
+          }
         }
       }
       // NOTE Can skip specific references keys (Ex, system defined keys can be skipped)
@@ -929,7 +957,13 @@ export default class Entries extends BaseClass {
           log.debug(`Missing reference: ${uid}`);
           missingRefs.push(reference);
         } else {
-          log.debug(`Reference ${uid} is valid`);
+          const refCtUid = reference._content_type_uid ?? refExist.ctUid;
+          if (!this.isRefContentTypeAllowed(refCtUid, reference_to)) {
+            log.debug(`Reference ${uid} has wrong content type: ${refCtUid} not in reference_to`);
+            missingRefs.push(refToList.length === 1 ? { uid, _content_type_uid: refCtUid } : reference);
+          } else {
+            log.debug(`Reference ${uid} is valid`);
+          }
         }
       }
     }
@@ -1704,6 +1738,16 @@ export default class Entries extends BaseClass {
               missingRefs.push(reference);
             }
           } else {
+            const refCtUid = reference._content_type_uid ?? refExist.ctUid;
+            if (!this.isRefContentTypeAllowed(refCtUid, reference_to)) {
+              log.debug(`Blt reference ${reference} has wrong content type: ${refCtUid} not in reference_to`);
+              missingRefs.push(
+                Array.isArray(reference_to) && reference_to.length === 1
+                  ? { uid: reference, _content_type_uid: refCtUid }
+                  : reference,
+              );
+              return null;
+            }
             log.debug(`Blt reference ${reference} is valid`);
             return { uid: reference, _content_type_uid: refExist.ctUid };
           }
@@ -1715,6 +1759,16 @@ export default class Entries extends BaseClass {
             missingRefs.push(reference);
             return null;
           } else {
+            const refCtUid = reference._content_type_uid ?? refExist.ctUid;
+            if (!this.isRefContentTypeAllowed(refCtUid, reference_to)) {
+              log.debug(`Reference ${uid} has wrong content type: ${refCtUid} not in reference_to`);
+              missingRefs.push(
+                Array.isArray(reference_to) && reference_to.length === 1
+                  ? { uid, _content_type_uid: refCtUid }
+                  : reference,
+              );
+              return null;
+            }
             log.debug(`Reference ${uid} is valid`);
             return reference;
           }
@@ -1846,6 +1900,25 @@ export default class Entries extends BaseClass {
         log.debug(`JSON reference check failed for entry: ${entryUid}`);
         return null;
       } else {
+        const refCtUid = contentTypeUid ?? refExist.ctUid;
+        const referenceTo = (schema as any).reference_to;
+        if (!this.isRefContentTypeAllowed(refCtUid, referenceTo)) {
+          log.debug(`JSON RTE embed ${entryUid} has wrong content type: ${refCtUid} not in reference_to`);
+          this.missingRefs[this.currentUid].push({
+            tree,
+            uid: this.currentUid,
+            name: this.currentTitle,
+            data_type: schema.data_type,
+            display_name: schema.display_name,
+            fixStatus: this.fix ? 'Fixed' : undefined,
+            treeStr: tree
+              .map(({ name }) => name)
+              .filter((val) => val)
+              .join(' ➜ '),
+            missingRefs: [{ uid: entryUid, 'content-type-uid': refCtUid }],
+          });
+          return this.fix ? null : true;
+        }
         log.debug(`Entry reference ${entryUid} is valid`);
       }
     } else {

--- a/packages/contentstack-audit/src/modules/entries.ts
+++ b/packages/contentstack-audit/src/modules/entries.ts
@@ -81,12 +81,12 @@ export default class Entries extends BaseClass {
   ): keyof typeof auditConfig.moduleConfig {
     log.debug(`Validating module: ${moduleName}`, this.config.auditContext);
     log.debug(`Available modules in config: ${Object.keys(moduleConfig).join(', ')}`, this.config.auditContext);
-    
+
     if (Object.keys(moduleConfig).includes(moduleName)) {
       log.debug(`Module ${moduleName} found in config, returning: ${moduleName}`, this.config.auditContext);
       return moduleName;
     }
-    
+
     log.debug(`Module ${moduleName} not found in config, defaulting to: entries`, this.config.auditContext);
     return 'entries';
   }
@@ -110,6 +110,25 @@ export default class Entries extends BaseClass {
     const refToList = Array.isArray(referenceTo) ? referenceTo : [referenceTo];
     if (refToList.length === 0) return false;
     return refToList.includes(refCtUid);
+  }
+
+  /**
+   * If ref CT is not allowed, pushes to missingRefs.
+   * @returns true if invalid (pushed), false if valid
+   */
+  private addInvalidRefIfNeeded(
+    missingRefs: Record<string, any>[],
+    uidValue: string,
+    refCtUid: string | undefined,
+    referenceTo: string | string[] | undefined,
+    fullRef: any,
+    logLabel: string,
+  ): boolean {
+    if (this.isRefContentTypeAllowed(refCtUid, referenceTo)) return false;
+    log.debug(`${logLabel} has wrong content type: ${refCtUid} not in reference_to`);
+    const refList = Array.isArray(referenceTo) ? referenceTo : referenceTo != null ? [referenceTo] : [];
+    missingRefs.push(refList.length === 1 ? { uid: uidValue, _content_type_uid: refCtUid } : fullRef);
+    return true;
   }
 
   /**
@@ -148,206 +167,250 @@ export default class Entries extends BaseClass {
         progress.updateStatus('Validating entries...');
       }
 
-    log.debug(`Processing ${this.locales.length} locales and ${this.ctSchema.length} content types`, this.config.auditContext);
-    for (const { code } of this.locales) {
-      log.debug(`Processing locale: ${code}`, this.config.auditContext);
-      for (const ctSchema of this.ctSchema) {
-        log.debug(`Processing content type: ${ctSchema.uid} in locale ${code}`, this.config.auditContext);
-        const basePath = join(this.folderPath, ctSchema.uid, code);
-        log.debug(`Base path for entries: ${basePath}`, this.config.auditContext);
-        
-        const fsUtility = new FsUtility({ basePath, indexFileName: 'index.json', createDirIfNotExist: false });
-        const indexer = fsUtility.indexFileContent;
-        log.debug(`Found ${Object.keys(indexer).length} entry files to process`, this.config.auditContext);
+      log.debug(
+        `Processing ${this.locales.length} locales and ${this.ctSchema.length} content types`,
+        this.config.auditContext,
+      );
+      for (const { code } of this.locales) {
+        log.debug(`Processing locale: ${code}`, this.config.auditContext);
+        for (const ctSchema of this.ctSchema) {
+          log.debug(`Processing content type: ${ctSchema.uid} in locale ${code}`, this.config.auditContext);
+          const basePath = join(this.folderPath, ctSchema.uid, code);
+          log.debug(`Base path for entries: ${basePath}`, this.config.auditContext);
 
-        for (const fileIndex in indexer) {
-          log.debug(`Processing entry file: ${indexer[fileIndex]}`, this.config.auditContext);
-          const entries = (await fsUtility.readChunkFiles.next()) as Record<string, EntryStruct>;
-          this.entries = entries;
-          log.debug(`Loaded ${Object.keys(entries).length} entries from file`, this.config.auditContext);
+          const fsUtility = new FsUtility({ basePath, indexFileName: 'index.json', createDirIfNotExist: false });
+          const indexer = fsUtility.indexFileContent;
+          log.debug(`Found ${Object.keys(indexer).length} entry files to process`, this.config.auditContext);
 
-          for (const entryUid in this.entries) {
-            const entry = this.entries[entryUid];
-            const { uid, title } = entry;
-            this.currentUid = uid;
-            this.currentTitle = title;
-            if (this.currentTitle) {
-              this.currentTitle = this.removeEmojiAndImages(this.currentTitle);
-            }
+          for (const fileIndex in indexer) {
+            log.debug(`Processing entry file: ${indexer[fileIndex]}`, this.config.auditContext);
+            const entries = (await fsUtility.readChunkFiles.next()) as Record<string, EntryStruct>;
+            this.entries = entries;
+            log.debug(`Loaded ${Object.keys(entries).length} entries from file`, this.config.auditContext);
 
-            log.debug(`Processing entry - title:${this.currentTitle} with uid:(${uid})`, this.config.auditContext);
-
-            if (!this.missingRefs[this.currentUid]) {
-              this.missingRefs[this.currentUid] = [];
-            }
-
-            if (!this.missingSelectFeild[this.currentUid]) {
-              this.missingSelectFeild[this.currentUid] = [];
-            }
-
-            if (!this.missingMandatoryFields[this.currentUid]) {
-              this.missingMandatoryFields[this.currentUid] = [];
-            }
-            if (this.fix) {
-              log.debug(`Removing missing keys from entry ${uid}`, this.config.auditContext);
-              this.removeMissingKeysOnEntry(ctSchema.schema as ContentTypeSchemaType[], this.entries[entryUid]);
-            }
-
-            log.debug(`Looking for references in entry ${uid}`, this.config.auditContext);
-            this.lookForReference(
-              [{ locale: code, uid, name: this.removeEmojiAndImages(this.currentTitle) }],
-              ctSchema,
-              this.entries[entryUid],
-            );
-
-            if (this.missingRefs[this.currentUid]?.length) {
-              log.debug(`Found ${this.missingRefs[this.currentUid].length} missing references for entry ${uid}`, this.config.auditContext);
-              this.missingRefs[this.currentUid].forEach((entry: any) => {
-                entry.ct = ctSchema.uid;
-                entry.locale = code;
-              });
-            }
-
-            if (this.missingSelectFeild[this.currentUid]?.length) {
-              log.debug(`Found ${this.missingSelectFeild[this.currentUid].length} missing select fields for entry ${uid}`, this.config.auditContext);
-              this.missingSelectFeild[this.currentUid].forEach((entry: any) => {
-                entry.ct = ctSchema.uid;
-                entry.locale = code;
-              });
-            }
-
-            if (this.missingMandatoryFields[this.currentUid]?.length) {
-              log.debug(`Found ${this.missingMandatoryFields[this.currentUid].length} missing mandatory fields for entry ${uid}`, this.config.auditContext);
-              this.missingMandatoryFields[this.currentUid].forEach((entry: any) => {
-                entry.ct = ctSchema.uid;
-                entry.locale = code;
-              });
-            }
-
-            const fields = this.missingMandatoryFields[uid];
-            const isPublished = entry.publish_details?.length > 0;
-            log.debug(`Entry ${uid} published status: ${isPublished}, missing mandatory fields: ${fields?.length || 0}`, this.config.auditContext);
-            
-            if ((this.fix && fields.length && isPublished) || (!this.fix && fields)) {
-              const fixStatus = this.fix ? 'Fixed' : '';
-              log.debug(`Applying fix status: ${fixStatus} to ${fields.length} fields`, this.config.auditContext);
-              
-              fields?.forEach((field: { isPublished: boolean; fixStatus?: string }, index: number) => {
-                log.debug(`Processing field ${index + 1}/${fields.length}`, this.config.auditContext);
-                field.isPublished = isPublished;
-                if (this.fix && isPublished) {
-                  field.fixStatus = fixStatus;
-                  log.debug(`Field ${index + 1} marked as published and fixed`, this.config.auditContext);
-                }
-              });
-
-              if (this.fix && isPublished) {
-                log.debug(`Fixing mandatory field issue for entry ${uid}`, this.config.auditContext);
-                log.error($t(auditFixMsg.ENTRY_MANDATORY_FIELD_FIX, { uid, locale: code }), this.config.auditContext);
-                entry.publish_details = [];
+            for (const entryUid in this.entries) {
+              const entry = this.entries[entryUid];
+              const { uid, title } = entry;
+              this.currentUid = uid;
+              this.currentTitle = title;
+              if (this.currentTitle) {
+                this.currentTitle = this.removeEmojiAndImages(this.currentTitle);
               }
-            } else {
-              delete this.missingMandatoryFields[uid];
-            }
 
-            const localKey = this.locales.map((locale: any) => locale.code);
-            log.debug(`Available locales: ${localKey.join(', ')}, environments: ${this.environments.join(', ')}`, this.config.auditContext);
+              log.debug(`Processing entry - title:${this.currentTitle} with uid:(${uid})`, this.config.auditContext);
 
-            if (this.entries[entryUid]?.publish_details && !Array.isArray(this.entries[entryUid].publish_details)) {
-              log.debug(`Entry ${entryUid} has invalid publish_details format`, this.config.auditContext);
-              log.debug($t(auditMsg.ENTRY_PUBLISH_DETAILS_NOT_EXIST, { uid: entryUid }), this.config.auditContext);
-            }
+              if (!this.missingRefs[this.currentUid]) {
+                this.missingRefs[this.currentUid] = [];
+              }
 
-            const originalPublishDetails = this.entries[entryUid]?.publish_details?.length || 0;
-            this.entries[entryUid].publish_details = this.entries[entryUid]?.publish_details.filter((pd: any) => {
-              log.debug(`Checking publish detail: locale=${pd.locale}, environment=${pd.environment}`, this.config.auditContext);
-              
-              if (localKey?.includes(pd.locale) && this.environments?.includes(pd.environment)) {
-                log.debug(`Publish detail valid for entry ${entryUid}: locale=${pd.locale}, environment=${pd.environment}`, this.config.auditContext);
-                return true;
-              } else {
-                log.debug(`Publish detail invalid for entry ${entryUid}: locale=${pd.locale}, environment=${pd.environment}`, this.config.auditContext);
+              if (!this.missingSelectFeild[this.currentUid]) {
+                this.missingSelectFeild[this.currentUid] = [];
+              }
+
+              if (!this.missingMandatoryFields[this.currentUid]) {
+                this.missingMandatoryFields[this.currentUid] = [];
+              }
+              if (this.fix) {
+                log.debug(`Removing missing keys from entry ${uid}`, this.config.auditContext);
+                this.removeMissingKeysOnEntry(ctSchema.schema as ContentTypeSchemaType[], this.entries[entryUid]);
+              }
+
+              log.debug(`Looking for references in entry ${uid}`, this.config.auditContext);
+              this.lookForReference(
+                [{ locale: code, uid, name: this.removeEmojiAndImages(this.currentTitle) }],
+                ctSchema,
+                this.entries[entryUid],
+              );
+
+              if (this.missingRefs[this.currentUid]?.length) {
                 log.debug(
-                  $t(auditMsg.ENTRY_PUBLISH_DETAILS, {
-                    uid: entryUid,
-                    ctuid: ctSchema.uid,
-                    locale: code,
-                    publocale: pd.locale,
-                    environment: pd.environment,
-                  }),
-                  this.config.auditContext
+                  `Found ${this.missingRefs[this.currentUid].length} missing references for entry ${uid}`,
+                  this.config.auditContext,
                 );
-                if (!Object.keys(this.missingEnvLocale).includes(entryUid)) {
-                  log.debug(`Creating new missing environment/locale entry for ${entryUid}`, this.config.auditContext);
-                  this.missingEnvLocale[entryUid] = [
-                    {
+                this.missingRefs[this.currentUid].forEach((entry: any) => {
+                  entry.ct = ctSchema.uid;
+                  entry.locale = code;
+                });
+              }
+
+              if (this.missingSelectFeild[this.currentUid]?.length) {
+                log.debug(
+                  `Found ${this.missingSelectFeild[this.currentUid].length} missing select fields for entry ${uid}`,
+                  this.config.auditContext,
+                );
+                this.missingSelectFeild[this.currentUid].forEach((entry: any) => {
+                  entry.ct = ctSchema.uid;
+                  entry.locale = code;
+                });
+              }
+
+              if (this.missingMandatoryFields[this.currentUid]?.length) {
+                log.debug(
+                  `Found ${this.missingMandatoryFields[this.currentUid].length} missing mandatory fields for entry ${uid}`,
+                  this.config.auditContext,
+                );
+                this.missingMandatoryFields[this.currentUid].forEach((entry: any) => {
+                  entry.ct = ctSchema.uid;
+                  entry.locale = code;
+                });
+              }
+
+              const fields = this.missingMandatoryFields[uid];
+              const isPublished = entry.publish_details?.length > 0;
+              log.debug(
+                `Entry ${uid} published status: ${isPublished}, missing mandatory fields: ${fields?.length || 0}`,
+                this.config.auditContext,
+              );
+
+              if ((this.fix && fields.length && isPublished) || (!this.fix && fields)) {
+                const fixStatus = this.fix ? 'Fixed' : '';
+                log.debug(`Applying fix status: ${fixStatus} to ${fields.length} fields`, this.config.auditContext);
+
+                fields?.forEach((field: { isPublished: boolean; fixStatus?: string }, index: number) => {
+                  log.debug(`Processing field ${index + 1}/${fields.length}`, this.config.auditContext);
+                  field.isPublished = isPublished;
+                  if (this.fix && isPublished) {
+                    field.fixStatus = fixStatus;
+                    log.debug(`Field ${index + 1} marked as published and fixed`, this.config.auditContext);
+                  }
+                });
+
+                if (this.fix && isPublished) {
+                  log.debug(`Fixing mandatory field issue for entry ${uid}`, this.config.auditContext);
+                  log.error($t(auditFixMsg.ENTRY_MANDATORY_FIELD_FIX, { uid, locale: code }), this.config.auditContext);
+                  entry.publish_details = [];
+                }
+              } else {
+                delete this.missingMandatoryFields[uid];
+              }
+
+              const localKey = this.locales.map((locale: any) => locale.code);
+              log.debug(
+                `Available locales: ${localKey.join(', ')}, environments: ${this.environments.join(', ')}`,
+                this.config.auditContext,
+              );
+
+              if (this.entries[entryUid]?.publish_details && !Array.isArray(this.entries[entryUid].publish_details)) {
+                log.debug(`Entry ${entryUid} has invalid publish_details format`, this.config.auditContext);
+                log.debug($t(auditMsg.ENTRY_PUBLISH_DETAILS_NOT_EXIST, { uid: entryUid }), this.config.auditContext);
+              }
+
+              const originalPublishDetails = this.entries[entryUid]?.publish_details?.length || 0;
+              this.entries[entryUid].publish_details = this.entries[entryUid]?.publish_details.filter((pd: any) => {
+                log.debug(
+                  `Checking publish detail: locale=${pd.locale}, environment=${pd.environment}`,
+                  this.config.auditContext,
+                );
+
+                if (localKey?.includes(pd.locale) && this.environments?.includes(pd.environment)) {
+                  log.debug(
+                    `Publish detail valid for entry ${entryUid}: locale=${pd.locale}, environment=${pd.environment}`,
+                    this.config.auditContext,
+                  );
+                  return true;
+                } else {
+                  log.debug(
+                    `Publish detail invalid for entry ${entryUid}: locale=${pd.locale}, environment=${pd.environment}`,
+                    this.config.auditContext,
+                  );
+                  log.debug(
+                    $t(auditMsg.ENTRY_PUBLISH_DETAILS, {
+                      uid: entryUid,
+                      ctuid: ctSchema.uid,
+                      locale: code,
+                      publocale: pd.locale,
+                      environment: pd.environment,
+                    }),
+                    this.config.auditContext,
+                  );
+                  if (!Object.keys(this.missingEnvLocale).includes(entryUid)) {
+                    log.debug(
+                      `Creating new missing environment/locale entry for ${entryUid}`,
+                      this.config.auditContext,
+                    );
+                    this.missingEnvLocale[entryUid] = [
+                      {
+                        entry_uid: entryUid,
+                        publish_locale: pd.locale,
+                        publish_environment: pd.environment,
+                        ctUid: ctSchema.uid,
+                        ctLocale: code,
+                      },
+                    ];
+                  } else {
+                    log.debug(
+                      `Adding to existing missing environment/locale entry for ${entryUid}`,
+                      this.config.auditContext,
+                    );
+                    this.missingEnvLocale[entryUid].push({
                       entry_uid: entryUid,
                       publish_locale: pd.locale,
                       publish_environment: pd.environment,
                       ctUid: ctSchema.uid,
                       ctLocale: code,
-                    },
-                  ];
-                } else {
-                  log.debug(`Adding to existing missing environment/locale entry for ${entryUid}`, this.config.auditContext);
-                  this.missingEnvLocale[entryUid].push({
-                    entry_uid: entryUid,
-                    publish_locale: pd.locale,
-                    publish_environment: pd.environment,
-                    ctUid: ctSchema.uid,
-                    ctLocale: code,
-                  });
+                    });
+                  }
+                  return false;
                 }
-                return false;
+              });
+
+              const remainingPublishDetails = this.entries[entryUid].publish_details?.length || 0;
+              log.debug(
+                `Entry ${entryUid} publish details: ${originalPublishDetails} -> ${remainingPublishDetails}`,
+                this.config.auditContext,
+              );
+
+              const message = $t(auditMsg.SCAN_ENTRY_SUCCESS_MSG, {
+                title,
+                local: code,
+                module: this.config.moduleConfig.entries.name,
+              });
+              log.debug(message, this.config.auditContext);
+              log.info(message, this.config.auditContext);
+
+              // Track progress for each entry processed
+              if (this.progressManager) {
+                this.progressManager.tick(true, `entry: ${title || uid}`, null);
               }
-            });
-
-            const remainingPublishDetails = this.entries[entryUid].publish_details?.length || 0;
-            log.debug(`Entry ${entryUid} publish details: ${originalPublishDetails} -> ${remainingPublishDetails}`, this.config.auditContext);
-
-            const message = $t(auditMsg.SCAN_ENTRY_SUCCESS_MSG, {
-              title,
-              local: code,
-              module: this.config.moduleConfig.entries.name,
-            });
-            log.debug(message, this.config.auditContext);
-            log.info(message, this.config.auditContext);
-            
-            // Track progress for each entry processed
-            if (this.progressManager) {
-              this.progressManager.tick(true, `entry: ${title || uid}`, null);
             }
-          }
 
-          if (this.fix) {
-            log.debug(`Writing fix content for ${Object.keys(this.entries).length} entries`, this.config.auditContext);
-            await this.writeFixContent(`${basePath}/${indexer[fileIndex]}`, this.entries);
+            if (this.fix) {
+              log.debug(
+                `Writing fix content for ${Object.keys(this.entries).length} entries`,
+                this.config.auditContext,
+              );
+              await this.writeFixContent(`${basePath}/${indexer[fileIndex]}`, this.entries);
+            }
           }
         }
       }
-    }
 
+      log.debug('Cleaning up empty missing references', this.config.auditContext);
+      this.removeEmptyVal();
 
-    log.debug('Cleaning up empty missing references', this.config.auditContext);
-    this.removeEmptyVal();
-    
-    const result = {
-      missingEntryRefs: this.missingRefs,
-      missingSelectFeild: this.missingSelectFeild,
-      missingMandatoryFields: this.missingMandatoryFields,
-      missingTitleFields: this.missingTitleFields,
-      missingEnvLocale: this.missingEnvLocale,
-      missingMultipleFields: this.missingMultipleField,
-    };
-    
+      const result = {
+        missingEntryRefs: this.missingRefs,
+        missingSelectFeild: this.missingSelectFeild,
+        missingMandatoryFields: this.missingMandatoryFields,
+        missingTitleFields: this.missingTitleFields,
+        missingEnvLocale: this.missingEnvLocale,
+        missingMultipleFields: this.missingMultipleField,
+      };
+
       log.debug(`Entries audit completed. Found issues:`, this.config.auditContext);
       log.debug(`- Missing references: ${Object.keys(this.missingRefs).length}`, this.config.auditContext);
       log.debug(`- Missing select fields: ${Object.keys(this.missingSelectFeild).length}`, this.config.auditContext);
-      log.debug(`- Missing mandatory fields: ${Object.keys(this.missingMandatoryFields).length}`, this.config.auditContext);
+      log.debug(
+        `- Missing mandatory fields: ${Object.keys(this.missingMandatoryFields).length}`,
+        this.config.auditContext,
+      );
       log.debug(`- Missing title fields: ${Object.keys(this.missingTitleFields).length}`, this.config.auditContext);
       log.debug(`- Missing environment/locale: ${Object.keys(this.missingEnvLocale).length}`, this.config.auditContext);
-      log.debug(`- Missing multiple fields: ${Object.keys(this.missingMultipleField).length}`, this.config.auditContext);
-      
+      log.debug(
+        `- Missing multiple fields: ${Object.keys(this.missingMultipleField).length}`,
+        this.config.auditContext,
+      );
+
       this.completeProgress(true);
       return result;
     } catch (error: any) {
@@ -361,7 +424,7 @@ export default class Entries extends BaseClass {
    */
   removeEmptyVal() {
     log.debug('Removing empty missing reference arrays', this.config.auditContext);
-    
+
     let removedRefs = 0;
     for (let propName in this.missingRefs) {
       if (!this.missingRefs[propName].length) {
@@ -370,7 +433,7 @@ export default class Entries extends BaseClass {
         removedRefs++;
       }
     }
-    
+
     let removedSelectFields = 0;
     for (let propName in this.missingSelectFeild) {
       if (!this.missingSelectFeild[propName].length) {
@@ -379,7 +442,7 @@ export default class Entries extends BaseClass {
         removedSelectFields++;
       }
     }
-    
+
     let removedMandatoryFields = 0;
     for (let propName in this.missingMandatoryFields) {
       if (!this.missingMandatoryFields[propName].length) {
@@ -388,8 +451,11 @@ export default class Entries extends BaseClass {
         removedMandatoryFields++;
       }
     }
-    
-    log.debug(`Cleanup completed: removed ${removedRefs} empty refs, ${removedSelectFields} empty select fields, ${removedMandatoryFields} empty mandatory fields`, this.config.auditContext);
+
+    log.debug(
+      `Cleanup completed: removed ${removedRefs} empty refs, ${removedSelectFields} empty select fields, ${removedMandatoryFields} empty mandatory fields`,
+      this.config.auditContext,
+    );
   }
 
   /**
@@ -398,7 +464,7 @@ export default class Entries extends BaseClass {
    */
   async fixPrerequisiteData() {
     log.debug('Starting prerequisite data fix process', this.config.auditContext);
-    
+
     log.debug('Fixing content type schema', this.config.auditContext);
     this.ctSchema = (await new ContentType({
       fix: true,
@@ -408,7 +474,7 @@ export default class Entries extends BaseClass {
       gfSchema: this.gfSchema,
     }).run(true)) as ContentTypeStruct[];
     log.debug(`Content type schema fixed: ${this.ctSchema.length} schemas`, this.config.auditContext);
-    
+
     log.debug('Fixing global field schema', this.config.auditContext);
     this.gfSchema = (await new GlobalField({
       fix: true,
@@ -421,7 +487,7 @@ export default class Entries extends BaseClass {
 
     const extensionPath = resolve(this.config.basePath, 'extensions', 'extensions.json');
     const marketplacePath = resolve(this.config.basePath, 'marketplace_apps', 'marketplace_apps.json');
-    
+
     log.debug(`Loading extensions from: ${extensionPath}`, this.config.auditContext);
     if (existsSync(extensionPath)) {
       try {
@@ -445,7 +511,10 @@ export default class Entries extends BaseClass {
             (val) => val,
           ) as string[];
           this.extensions.push(...metaData);
-          log.debug(`Added ${metaData.length} extension UIDs from app: ${app.manifest?.name || app.uid}`, this.config.auditContext);
+          log.debug(
+            `Added ${metaData.length} extension UIDs from app: ${app.manifest?.name || app.uid}`,
+            this.config.auditContext,
+          );
         }
       } catch (error) {
         log.debug(`Failed to load marketplace apps: ${error}`, this.config.auditContext);
@@ -453,7 +522,7 @@ export default class Entries extends BaseClass {
     } else {
       log.debug('No marketplace_apps.json found', this.config.auditContext);
     }
-    
+
     log.debug(`Total extensions loaded: ${this.extensions.length}`, this.config.auditContext);
     log.debug('Prerequisite data fix process completed', this.config.auditContext);
   }
@@ -469,9 +538,9 @@ export default class Entries extends BaseClass {
 
     if (this.fix) {
       log.debug('Fix mode enabled, checking write permissions', this.config.auditContext);
-      
+
       const skipConfirm = this.config.flags['copy-dir'] || this.config.flags['external-config']?.skipConfirm;
-      
+
       if (skipConfirm) {
         log.debug('Skipping confirmation due to copy-dir or external-config flags', this.config.auditContext);
       } else {
@@ -479,7 +548,7 @@ export default class Entries extends BaseClass {
       }
 
       const canWrite = skipConfirm || this.config.flags.yes || (await cliux.confirm(commonMsg.FIX_CONFIRMATION));
-      
+
       if (canWrite) {
         log.debug(`Writing fixed entries to: ${filePath}`, this.config.auditContext);
         writeFileSync(filePath, JSON.stringify(schema));
@@ -509,7 +578,10 @@ export default class Entries extends BaseClass {
     field: ContentTypeStruct | GlobalFieldDataType | ModularBlockType | GroupFieldDataType,
     entry: EntryFieldType,
   ) {
-    log.debug(`Looking for references in field: ${(field as any).uid || (field as any).title || 'unknown'}`, this.config.auditContext);
+    log.debug(
+      `Looking for references in field: ${(field as any).uid || (field as any).title || 'unknown'}`,
+      this.config.auditContext,
+    );
     const schemaFields = field?.schema ?? [];
     log.debug(`Processing ${schemaFields.length} fields in schema`, this.config.auditContext);
 
@@ -541,7 +613,7 @@ export default class Entries extends BaseClass {
             .join(' ➜ '),
         });
       }
-      
+
       log.debug(`Validating mandatory fields for: ${display_name}`, this.config.auditContext);
       this.missingMandatoryFields[this.currentUid].push(
         ...this.validateMandatoryFields(
@@ -565,7 +637,10 @@ export default class Entries extends BaseClass {
             entry[uid] as EntryReferenceFieldDataType[],
           );
           this.missingRefs[this.currentUid].push(...refResults);
-          log.debug(`Found ${refResults.length} missing references in field: ${display_name}`, this.config.auditContext);
+          log.debug(
+            `Found ${refResults.length} missing references in field: ${display_name}`,
+            this.config.auditContext,
+          );
           break;
         case 'global_field':
           log.debug(`Validating global field: ${display_name}`, this.config.auditContext);
@@ -597,7 +672,10 @@ export default class Entries extends BaseClass {
               entry as EntryExtensionOrAppFieldDataType,
             );
             this.missingRefs[this.currentUid].push(...extResults);
-            log.debug(`Found ${extResults.length} missing extension references in field: ${display_name}`, this.config.auditContext);
+            log.debug(
+              `Found ${extResults.length} missing extension references in field: ${display_name}`,
+              this.config.auditContext,
+            );
           } else if ('allow_json_rte' in child.field_metadata && child.field_metadata.allow_json_rte) {
             // NOTE JSON RTE field type
             log.debug(`Validating JSON RTE field: ${display_name}`, this.config.auditContext);
@@ -634,12 +712,18 @@ export default class Entries extends BaseClass {
               entry[uid],
             );
             this.missingSelectFeild[this.currentUid].push(...selectResults);
-            log.debug(`Found ${selectResults.length} missing select field values in field: ${display_name}`, this.config.auditContext);
+            log.debug(
+              `Found ${selectResults.length} missing select field values in field: ${display_name}`,
+              this.config.auditContext,
+            );
           }
           break;
       }
     }
-    log.debug(`Field reference validation completed: ${(field as any).uid || (field as any).title || 'unknown'}`, this.config.auditContext);
+    log.debug(
+      `Field reference validation completed: ${(field as any).uid || (field as any).title || 'unknown'}`,
+      this.config.auditContext,
+    );
   }
 
   /**
@@ -661,16 +745,19 @@ export default class Entries extends BaseClass {
     field: EntryReferenceFieldDataType[],
   ) {
     log.debug(`Validating reference field: ${fieldStructure.display_name}`, this.config.auditContext);
-    
+
     if (typeof field === 'string') {
       log.debug(`Converting string reference to JSON: ${field}`, this.config.auditContext);
       let stringReference = field as string;
       stringReference = stringReference.replace(/'/g, '"');
       field = JSON.parse(stringReference);
     }
-    
+
     const result = this.validateReferenceValues(tree, fieldStructure, field);
-    log.debug(`Reference field validation completed: ${result?.length || 0} missing references found`, this.config.auditContext);
+    log.debug(
+      `Reference field validation completed: ${result?.length || 0} missing references found`,
+      this.config.auditContext,
+    );
     return result;
   }
 
@@ -693,7 +780,7 @@ export default class Entries extends BaseClass {
     field: EntryExtensionOrAppFieldDataType,
   ) {
     log.debug(`Validating extension/app field: ${fieldStructure.display_name}`, this.config.auditContext);
-    
+
     if (this.fix) {
       log.debug('Fix mode enabled, skipping extension/app validation', this.config.auditContext);
       return [];
@@ -733,8 +820,11 @@ export default class Entries extends BaseClass {
           },
         ]
       : [];
-    
-    log.debug(`Extension/app field validation completed: ${result.length} missing references found`, this.config.auditContext);
+
+    log.debug(
+      `Extension/app field validation completed: ${result.length} missing references found`,
+      this.config.auditContext,
+    );
     return result;
   }
 
@@ -757,10 +847,10 @@ export default class Entries extends BaseClass {
   ) {
     log.debug(`Validating global field: ${fieldStructure.display_name}`, this.config.auditContext);
     log.debug(`Global field UID: ${fieldStructure.uid}`, this.config.auditContext);
-    
+
     // NOTE Any GlobalField related logic can be added here
     this.lookForReference(tree, fieldStructure, field);
-    
+
     log.debug(`Global field validation completed for: ${fieldStructure.display_name}`, this.config.auditContext);
   }
 
@@ -784,7 +874,7 @@ export default class Entries extends BaseClass {
     log.debug(`Validating JSON RTE field: ${fieldStructure.display_name}`, this.config.auditContext);
     log.debug(`JSON RTE field UID: ${fieldStructure.uid}`, this.config.auditContext);
     log.debug(`Found ${field?.children?.length || 0} children in JSON RTE field`, this.config.auditContext);
-    
+
     // NOTE Other possible reference logic will be added related to JSON RTE (Ex missing assets, extensions etc.,)
     for (const index in field?.children ?? []) {
       const child = field.children[index];
@@ -801,7 +891,7 @@ export default class Entries extends BaseClass {
         this.validateJsonRTEFields(tree, fieldStructure, field.children[index]);
       }
     }
-    
+
     log.debug(`JSON RTE field validation completed for: ${fieldStructure.display_name}`, this.config.auditContext);
   }
 
@@ -826,8 +916,8 @@ export default class Entries extends BaseClass {
     log.debug(`Validating modular blocks field: ${fieldStructure.display_name}`, this.config.auditContext);
     log.debug(`Modular blocks field UID: ${fieldStructure.uid}`, this.config.auditContext);
     log.debug(`Found ${field.length} modular blocks`, this.config.auditContext);
-    log.debug(`Available blocks: ${fieldStructure.blocks.map(b => b.title).join(', ')}`);
-    
+    log.debug(`Available blocks: ${fieldStructure.blocks.map((b) => b.title).join(', ')}`);
+
     if (!this.fix) {
       log.debug('Checking modular block references (non-fix mode)');
       for (const index in field) {
@@ -847,7 +937,7 @@ export default class Entries extends BaseClass {
         }
       }
     }
-    
+
     log.debug(`Modular blocks field validation completed for: ${fieldStructure.display_name}`);
   }
 
@@ -868,7 +958,7 @@ export default class Entries extends BaseClass {
     log.debug(`Validating group field: ${fieldStructure.display_name}`);
     log.debug(`Group field UID: ${fieldStructure.uid}`);
     log.debug(`Group field type: ${Array.isArray(field) ? 'array' : 'single'}`);
-    
+
     // NOTE Any Group Field related logic can be added here (Ex data serialization or picking any metadata for report etc.,)
     if (Array.isArray(field)) {
       log.debug(`Processing ${field.length} group field entries`);
@@ -884,7 +974,7 @@ export default class Entries extends BaseClass {
       log.debug('Processing single group field entry');
       this.lookForReference(tree, fieldStructure, field);
     }
-    
+
     log.debug(`Group field validation completed for: ${fieldStructure.display_name}`);
   }
 
@@ -909,7 +999,7 @@ export default class Entries extends BaseClass {
     field: EntryReferenceFieldDataType[],
   ): EntryRefErrorReturnType[] {
     log.debug(`Validating reference values for field: ${fieldStructure.display_name}`);
-    
+
     if (this.fix) {
       log.debug('Fix mode enabled, skipping reference validation');
       return [];
@@ -926,7 +1016,7 @@ export default class Entries extends BaseClass {
       const reference: any = field[index];
       const { uid } = reference;
       log.debug(`Processing reference ${index}: ${uid || reference}`);
-      
+
       if (!uid && reference.startsWith('blt')) {
         log.debug(`Checking reference: ${reference}`);
         const refExist = find(this.entryMetaData, { uid: reference });
@@ -939,10 +1029,7 @@ export default class Entries extends BaseClass {
           }
         } else {
           const refCtUid = refExist.ctUid;
-          if (!this.isRefContentTypeAllowed(refCtUid, reference_to)) {
-            log.debug(`Reference ${reference} has wrong content type: ${refCtUid} not in reference_to`);
-            missingRefs.push(refToList.length === 1 ? { uid: reference, _content_type_uid: refCtUid } : reference);
-          } else {
+          if (!this.addInvalidRefIfNeeded(missingRefs, reference, refCtUid, reference_to, reference, `Reference ${reference}`)) {
             log.debug(`Reference ${reference} is valid`);
           }
         }
@@ -958,10 +1045,7 @@ export default class Entries extends BaseClass {
           missingRefs.push(reference);
         } else {
           const refCtUid = reference._content_type_uid ?? refExist.ctUid;
-          if (!this.isRefContentTypeAllowed(refCtUid, reference_to)) {
-            log.debug(`Reference ${uid} has wrong content type: ${refCtUid} not in reference_to`);
-            missingRefs.push(refToList.length === 1 ? { uid, _content_type_uid: refCtUid } : reference);
-          } else {
+          if (!this.addInvalidRefIfNeeded(missingRefs, uid, refCtUid, reference_to, reference, `Reference ${uid}`)) {
             log.debug(`Reference ${uid} is valid`);
           }
         }
@@ -984,14 +1068,14 @@ export default class Entries extends BaseClass {
           },
         ]
       : [];
-    
+
     log.debug(`Reference values validation completed: ${result.length} missing references found`);
     return result;
   }
 
   removeMissingKeysOnEntry(schema: ContentTypeSchemaType[], entry: EntryFieldType) {
     log.debug(`Removing missing keys from entry: ${this.currentUid}`);
-    
+
     // NOTE remove invalid entry keys
     const ctFields = map(schema, 'uid');
     const entryFields = Object.keys(entry ?? {});
@@ -1005,7 +1089,7 @@ export default class Entries extends BaseClass {
         delete entry[eKey];
       }
     });
-    
+
     log.debug(`Missing keys removal completed for entry: ${this.currentUid}`);
   }
 
@@ -1026,7 +1110,7 @@ export default class Entries extends BaseClass {
   runFixOnSchema(tree: Record<string, unknown>[], schema: ContentTypeSchemaType[], entry: EntryFieldType) {
     log.debug(`Running fix on schema for entry: ${this.currentUid}`);
     log.debug(`Schema fields: ${schema.length}, Entry fields: ${Object.keys(entry).length}`);
-    
+
     // NOTE Global field Fix
     schema.forEach((field) => {
       const { uid, data_type, multiple } = field;
@@ -1170,7 +1254,7 @@ export default class Entries extends BaseClass {
     log.debug(`Select field UID: ${fieldStructure.uid}`);
     log.debug(`Field value: ${JSON.stringify(field)}`);
     log.debug(`Multiple: ${fieldStructure.multiple}, Display type: ${fieldStructure.display_type}`);
-    
+
     const { display_name, enum: selectOptions, multiple, min_instance, display_type, data_type } = fieldStructure;
     if (
       field === null ||
@@ -1257,13 +1341,15 @@ export default class Entries extends BaseClass {
     log.debug(`Fixing select field: ${field.display_name}`);
     log.debug(`Select field UID: ${field.uid}`);
     log.debug(`Current entry value: ${JSON.stringify(entry)}`);
-    
+
     if (!this.config.fixSelectField) {
       log.debug('Select field fixing is disabled in config');
       return entry;
     }
     const { enum: selectOptions, multiple, min_instance, display_type, display_name, uid } = field;
-    log.debug(`Select options: ${selectOptions.choices.length} choices, Multiple: ${multiple}, Min instance: ${min_instance}`);
+    log.debug(
+      `Select options: ${selectOptions.choices.length} choices, Multiple: ${multiple}, Min instance: ${min_instance}`,
+    );
 
     let missingCTSelectFieldValues;
     let isMissingValuePresent = false;
@@ -1272,7 +1358,10 @@ export default class Entries extends BaseClass {
       log.debug('Processing multiple select field', this.config.auditContext);
       let obj = this.findNotPresentSelectField(entry, selectOptions);
       let { notPresent, filteredFeild } = obj;
-      log.debug(`Found ${notPresent.length} invalid values, filtered to ${filteredFeild.length} values`, this.config.auditContext);
+      log.debug(
+        `Found ${notPresent.length} invalid values, filtered to ${filteredFeild.length} values`,
+        this.config.auditContext,
+      );
       entry = filteredFeild;
       missingCTSelectFieldValues = notPresent;
       if (missingCTSelectFieldValues.length) {
@@ -1281,17 +1370,26 @@ export default class Entries extends BaseClass {
       }
       if (min_instance && Array.isArray(entry)) {
         const missingInstances = min_instance - entry.length;
-        log.debug(`Checking min instance requirement: ${min_instance}, current: ${entry.length}, missing: ${missingInstances}`, this.config.auditContext);
+        log.debug(
+          `Checking min instance requirement: ${min_instance}, current: ${entry.length}, missing: ${missingInstances}`,
+          this.config.auditContext,
+        );
         if (missingInstances > 0) {
           isMissingValuePresent = true;
           const newValues = selectOptions.choices
             .filter((choice) => !entry.includes(choice.value))
             .slice(0, missingInstances)
             .map((choice) => choice.value);
-          log.debug(`Adding ${newValues.length} values to meet min instance requirement: ${newValues.join(', ')}`, this.config.auditContext);
+          log.debug(
+            `Adding ${newValues.length} values to meet min instance requirement: ${newValues.join(', ')}`,
+            this.config.auditContext,
+          );
           entry.push(...newValues);
           selectedValue = newValues;
-          log.error($t(auditFixMsg.ENTRY_SELECT_FIELD_FIX, { value: newValues.join(' '), uid }), this.config.auditContext);
+          log.error(
+            $t(auditFixMsg.ENTRY_SELECT_FIELD_FIX, { value: newValues.join(' '), uid }),
+            this.config.auditContext,
+          );
         }
       } else {
         if (entry.length === 0) {
@@ -1300,7 +1398,10 @@ export default class Entries extends BaseClass {
           log.debug(`Empty multiple select field, adding default value: ${defaultValue}`, this.config.auditContext);
           entry.push(defaultValue);
           selectedValue = defaultValue;
-          log.error($t(auditFixMsg.ENTRY_SELECT_FIELD_FIX, { value: defaultValue as string, uid }), this.config.auditContext);
+          log.error(
+            $t(auditFixMsg.ENTRY_SELECT_FIELD_FIX, { value: defaultValue as string, uid }),
+            this.config.auditContext,
+          );
         }
       }
     } else {
@@ -1314,7 +1415,10 @@ export default class Entries extends BaseClass {
         log.debug(`Replacing with default value: ${defaultValue}`, this.config.auditContext);
         entry = defaultValue;
         selectedValue = defaultValue;
-        log.error($t(auditFixMsg.ENTRY_SELECT_FIELD_FIX, { value: defaultValue as string, uid }), this.config.auditContext);
+        log.error(
+          $t(auditFixMsg.ENTRY_SELECT_FIELD_FIX, { value: defaultValue as string, uid }),
+          this.config.auditContext,
+        );
       } else {
         log.debug(`Single select value is valid: ${entry}`, this.config.auditContext);
       }
@@ -1344,7 +1448,7 @@ export default class Entries extends BaseClass {
   validateMandatoryFields(tree: Record<string, unknown>[], fieldStructure: any, entry: any) {
     log.debug(`Validating mandatory field: ${fieldStructure.display_name}`);
     log.debug(`Field UID: ${fieldStructure.uid}, Mandatory: ${fieldStructure.mandatory}`);
-    
+
     const { display_name, multiple, data_type, mandatory, field_metadata, uid } = fieldStructure;
 
     const isJsonRteEmpty = () => {
@@ -1408,7 +1512,7 @@ export default class Entries extends BaseClass {
     log.debug(`Finding not present select field values`);
     log.debug(`Field values: ${JSON.stringify(field)}`);
     log.debug(`Available choices: ${selectOptions.choices.length}`);
-    
+
     if (!field) {
       log.debug('Field is null/undefined, initializing as empty array');
       field = [];
@@ -1417,7 +1521,7 @@ export default class Entries extends BaseClass {
     let notPresent = [];
     const choicesMap = new Map(selectOptions.choices.map((choice: { value: any }) => [choice.value, choice]));
     log.debug(`Created choices map with ${choicesMap.size} entries`);
-    
+
     for (const value of field) {
       const choice: any = choicesMap.get(value);
       log.debug(`Checking value: ${value}`);
@@ -1430,7 +1534,7 @@ export default class Entries extends BaseClass {
         notPresent.push(value);
       }
     }
-    
+
     log.debug(`Result: ${present.length} present, ${notPresent.length} not present`);
     return { filteredFeild: present, notPresent };
   }
@@ -1454,9 +1558,13 @@ export default class Entries extends BaseClass {
     log.debug(`Fixing global field references: ${field.display_name}`);
     log.debug(`Global field UID: ${field.uid}`);
     log.debug(`Schema fields: ${field.schema?.length || 0}`);
-    
-    const result = this.runFixOnSchema([...tree, { uid: field.uid, display_name: field.display_name }], field.schema, entry);
-    
+
+    const result = this.runFixOnSchema(
+      [...tree, { uid: field.uid, display_name: field.display_name }],
+      field.schema,
+      entry,
+    );
+
     log.debug(`Global field references fix completed: ${field.display_name}`);
     return result;
   }
@@ -1480,7 +1588,7 @@ export default class Entries extends BaseClass {
   ) {
     log.debug(`Fixing modular blocks references`);
     log.debug(`Available blocks: ${blocks.length}, Entry blocks: ${entry?.length || 0}`);
-    
+
     entry = entry
       ?.map((block, index) => {
         log.debug(`Checking modular block ${index}`);
@@ -1540,7 +1648,7 @@ export default class Entries extends BaseClass {
   ) {
     log.debug(`Fixing missing extension/app: ${field.display_name}`);
     log.debug(`Extension/app field UID: ${field.uid}`);
-    
+
     const missingRefs = [];
 
     let { uid, display_name, data_type } = field || {};
@@ -1603,7 +1711,7 @@ export default class Entries extends BaseClass {
     log.debug(`Group field UID: ${field.uid}`);
     log.debug(`Schema fields: ${field.schema?.length || 0}`);
     log.debug(`Entry type: ${Array.isArray(entry) ? 'array' : 'single'}`);
-    
+
     if (!isEmpty(field.schema)) {
       log.debug(`Group field has schema, applying fixes`);
       if (Array.isArray(entry)) {
@@ -1650,7 +1758,7 @@ export default class Entries extends BaseClass {
     log.debug(`Fixing JSON RTE missing references`);
     log.debug(`Field UID: ${field.uid}`);
     log.debug(`Entry type: ${Array.isArray(entry) ? 'array' : 'single'}`);
-    
+
     if (Array.isArray(entry)) {
       log.debug(`Processing ${entry.length} JSON RTE entries`);
       entry = entry.map((child: any, index) => {
@@ -1712,7 +1820,7 @@ export default class Entries extends BaseClass {
     log.debug(`Field UID: ${field.uid}`);
     log.debug(`Reference to: ${(field as any).reference_to?.join(', ') || 'none'}`);
     log.debug(`Entry type: ${typeof entry}, length: ${Array.isArray(entry) ? entry.length : 'N/A'}`);
-    
+
     const missingRefs: Record<string, any>[] = [];
     if (typeof entry === 'string') {
       log.debug(`Entry is string, parsing JSON`);
@@ -1726,7 +1834,7 @@ export default class Entries extends BaseClass {
         const { uid } = reference;
         const { reference_to } = field;
         log.debug(`Processing reference ${index}: ${uid || reference}`);
-        
+
         if (!uid && reference.startsWith('blt')) {
           log.debug(`Checking blt reference: ${reference}`);
           const refExist = find(this.entryMetaData, { uid: reference });
@@ -1739,13 +1847,7 @@ export default class Entries extends BaseClass {
             }
           } else {
             const refCtUid = reference._content_type_uid ?? refExist.ctUid;
-            if (!this.isRefContentTypeAllowed(refCtUid, reference_to)) {
-              log.debug(`Blt reference ${reference} has wrong content type: ${refCtUid} not in reference_to`);
-              missingRefs.push(
-                Array.isArray(reference_to) && reference_to.length === 1
-                  ? { uid: reference, _content_type_uid: refCtUid }
-                  : reference,
-              );
+            if (this.addInvalidRefIfNeeded(missingRefs, reference, refCtUid, reference_to, reference, `Blt reference ${reference}`)) {
               return null;
             }
             log.debug(`Blt reference ${reference} is valid`);
@@ -1760,13 +1862,7 @@ export default class Entries extends BaseClass {
             return null;
           } else {
             const refCtUid = reference._content_type_uid ?? refExist.ctUid;
-            if (!this.isRefContentTypeAllowed(refCtUid, reference_to)) {
-              log.debug(`Reference ${uid} has wrong content type: ${refCtUid} not in reference_to`);
-              missingRefs.push(
-                Array.isArray(reference_to) && reference_to.length === 1
-                  ? { uid, _content_type_uid: refCtUid }
-                  : reference,
-              );
+            if (this.addInvalidRefIfNeeded(missingRefs, uid, refCtUid, reference_to, reference, `Reference ${uid}`)) {
               return null;
             }
             log.debug(`Reference ${uid} is valid`);
@@ -1824,9 +1920,9 @@ export default class Entries extends BaseClass {
     index: number,
   ) {
     log.debug(`Checking modular block references for block ${index}`);
-    log.debug(`Available block UIDs: ${blocks.map(b => b.uid).join(', ')}`);
+    log.debug(`Available block UIDs: ${blocks.map((b) => b.uid).join(', ')}`);
     log.debug(`Entry block keys: ${Object.keys(entryBlock).join(', ')}`);
-    
+
     const validBlockUid = blocks.map((block) => block.uid);
     const invalidKeys = Object.keys(entryBlock).filter((key) => !validBlockUid.includes(key));
     log.debug(`Found ${invalidKeys.length} invalid keys: ${invalidKeys.join(', ')}`);
@@ -1871,7 +1967,7 @@ export default class Entries extends BaseClass {
   jsonRefCheck(tree: Record<string, unknown>[], schema: JsonRTEFieldDataType, child: EntryJsonRTEFieldDataType) {
     log.debug(`Checking JSON reference for child: ${(child as any).type || 'unknown type'}`);
     log.debug(`Child UID: ${child.uid}`);
-    
+
     const { uid: childrenUid } = child;
     const { 'entry-uid': entryUid, 'content-type-uid': contentTypeUid } = child.attrs || {};
     log.debug(`Entry UID: ${entryUid}, Content type UID: ${contentTypeUid}`);
@@ -1939,7 +2035,7 @@ export default class Entries extends BaseClass {
     const localesFolderPath = resolve(this.config.basePath, this.config.moduleConfig.locales.dirName);
     const localesPath = join(localesFolderPath, this.config.moduleConfig.locales.fileName);
     const masterLocalesPath = join(localesFolderPath, 'master-locale.json');
-    
+
     log.debug(`Loading locales from: ${masterLocalesPath}`);
     this.locales = existsSync(masterLocalesPath) ? values(JSON.parse(readFileSync(masterLocalesPath, 'utf8'))) : [];
     log.debug(`Loaded ${this.locales.length} master locales`);
@@ -1960,16 +2056,22 @@ export default class Entries extends BaseClass {
     );
     log.debug(`Loading environments from: ${environmentPath}`);
     this.environments = existsSync(environmentPath) ? keys(JSON.parse(readFileSync(environmentPath, 'utf8'))) : [];
-    log.debug(`Loaded ${this.environments.length} environments: ${this.environments.join(', ')}`, this.config.auditContext);
-    
-    log.debug(`Processing ${this.locales.length} locales and ${this.ctSchema.length} content types for entry metadata`, this.config.auditContext);
+    log.debug(
+      `Loaded ${this.environments.length} environments: ${this.environments.join(', ')}`,
+      this.config.auditContext,
+    );
+
+    log.debug(
+      `Processing ${this.locales.length} locales and ${this.ctSchema.length} content types for entry metadata`,
+      this.config.auditContext,
+    );
     for (const { code } of this.locales) {
       log.debug(`Processing locale: ${code}`, this.config.auditContext);
       for (const { uid } of this.ctSchema) {
         log.debug(`Processing content type: ${uid} in locale ${code}`, this.config.auditContext);
         let basePath = join(this.folderPath, uid, code);
         log.debug(`Entry base path: ${basePath}`, this.config.auditContext);
-        
+
         let fsUtility = new FsUtility({ basePath, indexFileName: 'index.json' });
         let indexer = fsUtility.indexFileContent;
         log.debug(`Found ${Object.keys(indexer).length} entry files for ${uid}/${code}`, this.config.auditContext);
@@ -1977,7 +2079,7 @@ export default class Entries extends BaseClass {
         for (const _ in indexer) {
           const entries = (await fsUtility.readChunkFiles.next()) as Record<string, EntryStruct>;
           log.debug(`Processing ${Object.keys(entries).length} entries from file`, this.config.auditContext);
-          
+
           for (const entryUid in entries) {
             let { title } = entries[entryUid];
             log.debug(`Processing entry metadata: ${entryUid} (${title || 'no title'})`, this.config.auditContext);
@@ -2005,8 +2107,11 @@ export default class Entries extends BaseClass {
         }
       }
     }
-    
-    log.debug(`Entry metadata preparation completed: ${this.entryMetaData.length} entries processed`, this.config.auditContext);
+
+    log.debug(
+      `Entry metadata preparation completed: ${this.entryMetaData.length} entries processed`,
+      this.config.auditContext,
+    );
     log.debug(`Missing title fields found: ${Object.keys(this.missingTitleFields).length}`, this.config.auditContext);
   }
 }

--- a/packages/contentstack-audit/test/unit/modules/entries.test.ts
+++ b/packages/contentstack-audit/test/unit/modules/entries.test.ts
@@ -1041,6 +1041,55 @@ describe('Entries module', () => {
 
         expect(result).to.be.an('array'); // Should return array of missing references
       });
+
+    fancy
+      .stdout({ print: process.env.PRINT === 'true' || false })
+      .it('should flag reference when ref entry has wrong content type (ct2 ref when reference_to is ct1)', () => {
+        const ctInstance = new Entries(constructorParam);
+        (ctInstance as any).currentUid = 'test-entry';
+        (ctInstance as any).entryMetaData = [{ uid: 'blt123', ctUid: 'ct2' }]; // Entry exists but is ct2
+
+        const referenceFieldSchema = { uid: 'ref', display_name: 'Ref', data_type: 'reference', reference_to: ['ct1'] };
+        const entryData = [{ uid: 'blt123', _content_type_uid: 'ct2' }];
+        const tree = [{ uid: 'test-entry', name: 'Test Entry' }];
+
+        const result = ctInstance.validateReferenceValues(tree, referenceFieldSchema as any, entryData);
+
+        expect(result).to.have.length(1);
+        expect(result[0].missingRefs).to.deep.include({ uid: 'blt123', _content_type_uid: 'ct2' });
+      });
+
+    fancy
+      .stdout({ print: process.env.PRINT === 'true' || false })
+      .it('should not flag reference when ref entry has correct content type (ct1 ref when reference_to is ct1)', () => {
+        const ctInstance = new Entries(constructorParam);
+        (ctInstance as any).currentUid = 'test-entry';
+        (ctInstance as any).entryMetaData = [{ uid: 'blt123', ctUid: 'ct1' }];
+
+        const referenceFieldSchema = { uid: 'ref', display_name: 'Ref', data_type: 'reference', reference_to: ['ct1'] };
+        const entryData = [{ uid: 'blt123', _content_type_uid: 'ct1' }];
+        const tree = [{ uid: 'test-entry', name: 'Test Entry' }];
+
+        const result = ctInstance.validateReferenceValues(tree, referenceFieldSchema as any, entryData);
+
+        expect(result).to.have.length(0);
+      });
+
+    fancy
+      .stdout({ print: process.env.PRINT === 'true' || false })
+      .it('should normalize reference_to string and allow matching ref (ct1 when reference_to is string ct1)', () => {
+        const ctInstance = new Entries(constructorParam);
+        (ctInstance as any).currentUid = 'test-entry';
+        (ctInstance as any).entryMetaData = [{ uid: 'blt456', ctUid: 'ct1' }];
+
+        const referenceFieldSchema = { uid: 'ref', display_name: 'Ref', data_type: 'reference', reference_to: 'ct1' };
+        const entryData = [{ uid: 'blt456', _content_type_uid: 'ct1' }];
+        const tree = [{ uid: 'test-entry', name: 'Test Entry' }];
+
+        const result = ctInstance.validateReferenceValues(tree, referenceFieldSchema as any, entryData);
+
+        expect(result).to.have.length(0);
+      });
   });
 
   describe('validateModularBlocksField method', () => {
@@ -1365,5 +1414,130 @@ describe('Entries module', () => {
 
         // Should not throw - method is void
       });
+
+    fancy
+      .stdout({ print: process.env.PRINT === 'true' || false })
+      .it('should flag JSON RTE embed when ref has wrong content type (ct2 when reference_to is ct1,sys_assets)', () => {
+        const ctInstance = new Entries(constructorParam);
+        (ctInstance as any).currentUid = 'test-entry';
+        (ctInstance as any).missingRefs = { 'test-entry': [] };
+        (ctInstance as any).entryMetaData = [{ uid: 'blt123', ctUid: 'ct2' }];
+
+        const schema = {
+          uid: 'json_rte',
+          display_name: 'JSON RTE',
+          data_type: 'richtext',
+          reference_to: ['ct1', 'sys_assets'],
+        };
+        const child = {
+          type: 'embed',
+          uid: 'child-uid',
+          attrs: { 'entry-uid': 'blt123', 'content-type-uid': 'ct2' },
+          children: [],
+        };
+        const tree: Record<string, unknown>[] = [];
+
+        (ctInstance as any).jsonRefCheck(tree, schema, child);
+
+        expect((ctInstance as any).missingRefs['test-entry']).to.have.length(1);
+        expect((ctInstance as any).missingRefs['test-entry'][0].missingRefs).to.deep.include({
+          uid: 'blt123',
+          'content-type-uid': 'ct2',
+        });
+      });
+  });
+
+  describe('fixMissingReferences method', () => {
+    fancy
+      .stdout({ print: process.env.PRINT === 'true' || false })
+      .it('should filter out ref when ref has wrong content type (ct2 when reference_to is ct1)', () => {
+        const ctInstance = new Entries({ ...constructorParam, fix: true });
+        (ctInstance as any).currentUid = 'test-entry';
+        (ctInstance as any).missingRefs = { 'test-entry': [] };
+        (ctInstance as any).entryMetaData = [{ uid: 'blt123', ctUid: 'ct2' }];
+
+        const field = {
+          uid: 'ref_field',
+          display_name: 'Ref',
+          data_type: 'reference',
+          reference_to: ['ct1'],
+        };
+        const entry = [{ uid: 'blt123', _content_type_uid: 'ct2' }];
+        const tree = [{ uid: 'test-entry', name: 'Test Entry' }];
+
+        const result = ctInstance.fixMissingReferences(tree, field as any, entry);
+
+        expect(result).to.have.length(0);
+        expect((ctInstance as any).missingRefs['test-entry']).to.have.length(1);
+        expect((ctInstance as any).missingRefs['test-entry'][0].missingRefs).to.deep.include({
+          uid: 'blt123',
+          _content_type_uid: 'ct2',
+        });
+      });
+  });
+
+  describe('jsonRefCheck in fix mode', () => {
+    fancy
+      .stdout({ print: process.env.PRINT === 'true' || false })
+      .it('should return null when ref has wrong content type (fix mode)', () => {
+        const ctInstance = new Entries({ ...constructorParam, fix: true });
+        (ctInstance as any).currentUid = 'test-entry';
+        (ctInstance as any).missingRefs = { 'test-entry': [] };
+        (ctInstance as any).entryMetaData = [{ uid: 'blt123', ctUid: 'ct2' }];
+
+        const schema = {
+          uid: 'json_rte',
+          display_name: 'JSON RTE',
+          data_type: 'richtext',
+          reference_to: ['ct1'],
+        };
+        const child = {
+          type: 'embed',
+          uid: 'child-uid',
+          attrs: { 'entry-uid': 'blt123', 'content-type-uid': 'ct2' },
+          children: [],
+        };
+        const tree: Record<string, unknown>[] = [];
+
+        const result = (ctInstance as any).jsonRefCheck(tree, schema, child);
+
+        expect(result).to.be.null;
+      });
+  });
+
+  describe('isRefContentTypeAllowed helper', () => {
+    const callHelper = (refCtUid: string | undefined, referenceTo: string | string[] | undefined) => {
+      const ctInstance = new Entries(constructorParam);
+      return (ctInstance as any).isRefContentTypeAllowed(refCtUid, referenceTo);
+    };
+
+    fancy.stdout({ print: process.env.PRINT === 'true' || false }).it('returns true when refCtUid is in reference_to', () => {
+      expect(callHelper('ct1', ['ct1', 'ct2'])).to.be.true;
+    });
+
+    fancy.stdout({ print: process.env.PRINT === 'true' || false }).it('returns false when refCtUid is not in reference_to', () => {
+      expect(callHelper('ct2', ['ct1'])).to.be.false;
+    });
+
+    fancy.stdout({ print: process.env.PRINT === 'true' || false }).it('returns true when reference_to is undefined', () => {
+      expect(callHelper('ct1', undefined)).to.be.true;
+    });
+
+    fancy.stdout({ print: process.env.PRINT === 'true' || false }).it('normalizes reference_to string and allows matching refCtUid', () => {
+      expect(callHelper('ct1', 'ct1')).to.be.true;
+      expect(callHelper('ct2', 'ct1')).to.be.false;
+    });
+
+    fancy.stdout({ print: process.env.PRINT === 'true' || false }).it('returns false when reference_to is empty array', () => {
+      expect(callHelper('ct1', [])).to.be.false;
+    });
+
+    fancy.stdout({ print: process.env.PRINT === 'true' || false }).it('returns true when refCtUid is undefined', () => {
+      expect(callHelper(undefined, ['ct1'])).to.be.true;
+    });
+
+    fancy.stdout({ print: process.env.PRINT === 'true' || false }).it('returns true when refCtUid is in skipRefs', () => {
+      expect(callHelper('sys_assets', ['ct1'])).to.be.true;
+    });
   });
 });

--- a/packages/contentstack-import/package.json
+++ b/packages/contentstack-import/package.json
@@ -5,7 +5,7 @@
   "author": "Contentstack",
   "bugs": "https://github.com/contentstack/cli/issues",
   "dependencies": {
-    "@contentstack/cli-audit": "~2.0.0-beta.4",
+    "@contentstack/cli-audit": "~2.0.0-beta.5",
     "@contentstack/cli-command": "~2.0.0-beta",
     "@contentstack/cli-utilities": "~2.0.0-beta",
     "@contentstack/cli-variants": "~2.0.0-beta.5",

--- a/packages/contentstack/package.json
+++ b/packages/contentstack/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contentstack/cli",
   "description": "Command-line tool (CLI) to interact with Contentstack",
-  "version": "2.0.0-beta.12",
+  "version": "2.0.0-beta.13",
   "author": "Contentstack",
   "bin": {
     "csdx": "./bin/run.js"
@@ -22,7 +22,7 @@
     "prepack": "pnpm compile && oclif manifest && oclif readme"
   },
   "dependencies": {
-    "@contentstack/cli-audit": "~2.0.0-beta.4",
+    "@contentstack/cli-audit": "~2.0.0-beta.5",
     "@contentstack/cli-cm-export": "~2.0.0-beta.9",
     "@contentstack/cli-cm-import": "~2.0.0-beta.9",
     "@contentstack/cli-auth": "~2.0.0-beta.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ importers:
 
   packages/contentstack:
     specifiers:
-      '@contentstack/cli-audit': ~2.0.0-beta.4
+      '@contentstack/cli-audit': ~2.0.0-beta.5
       '@contentstack/cli-auth': ~2.0.0-beta.5
       '@contentstack/cli-bulk-operations': ^1.0.0-beta
       '@contentstack/cli-cm-bootstrap': ~2.0.0-beta.9
@@ -89,9 +89,9 @@ importers:
       '@contentstack/cli-migration': link:../contentstack-migration
       '@contentstack/cli-utilities': link:../contentstack-utilities
       '@contentstack/cli-variants': link:../contentstack-variants
-      '@contentstack/management': 1.27.5_debug@4.4.3
-      '@contentstack/utils': 1.7.0
-      '@oclif/core': 4.8.0
+      '@contentstack/management': 1.27.6_debug@4.4.3
+      '@contentstack/utils': 1.7.1
+      '@oclif/core': 4.8.1
       '@oclif/plugin-help': 6.2.37
       '@oclif/plugin-not-found': 3.2.74_@types+node@14.18.63
       '@oclif/plugin-plugins': 5.4.56
@@ -108,7 +108,7 @@ importers:
       uuid: 9.0.1
       winston: 3.19.0
     devDependencies:
-      '@oclif/test': 4.1.16_@oclif+core@4.8.0
+      '@oclif/test': 4.1.16_@oclif+core@4.8.1
       '@types/chai': 4.3.20
       '@types/inquirer': 9.0.9
       '@types/mkdirp': 1.0.2
@@ -118,13 +118,13 @@ importers:
       '@types/sinon': 10.0.20
       chai: 4.5.0
       eslint: 8.57.1
-      eslint-config-oclif: 6.0.140_avq3eyf5kaj6ssrwo7fvkrwnji
+      eslint-config-oclif: 6.0.144_avq3eyf5kaj6ssrwo7fvkrwnji
       eslint-config-oclif-typescript: 3.1.14_avq3eyf5kaj6ssrwo7fvkrwnji
       globby: 10.0.2
       mocha: 10.8.2
       nock: 13.5.6
       nyc: 15.1.0
-      oclif: 4.22.79_@types+node@14.18.63
+      oclif: 4.22.81_@types+node@14.18.63
       rimraf: 5.0.10
       shelljs: 0.10.0
       sinon: 21.0.1
@@ -165,7 +165,7 @@ importers:
     dependencies:
       '@contentstack/cli-command': link:../contentstack-command
       '@contentstack/cli-utilities': link:../contentstack-utilities
-      '@oclif/core': 4.8.0
+      '@oclif/core': 4.8.1
       '@oclif/plugin-help': 6.2.37
       chalk: 4.1.2
       fast-csv: 4.3.6
@@ -174,7 +174,7 @@ importers:
       uuid: 9.0.1
       winston: 3.19.0
     devDependencies:
-      '@oclif/test': 4.1.16_@oclif+core@4.8.0
+      '@oclif/test': 4.1.16_@oclif+core@4.8.1
       '@types/chai': 4.3.20
       '@types/fs-extra': 11.0.4
       '@types/mocha': 10.0.10
@@ -182,11 +182,11 @@ importers:
       '@types/uuid': 9.0.8
       chai: 4.5.0
       eslint: 8.57.1
-      eslint-config-oclif: 6.0.140_k2rwabtyo525wwqr6566umnmhy
+      eslint-config-oclif: 6.0.144_k2rwabtyo525wwqr6566umnmhy
       eslint-config-oclif-typescript: 3.1.14_k2rwabtyo525wwqr6566umnmhy
       mocha: 10.8.2
       nyc: 15.1.0
-      oclif: 4.22.79_@types+node@20.19.33
+      oclif: 4.22.81_@types+node@20.19.33
       shx: 0.4.0
       sinon: 21.0.1
       ts-node: 10.9.2_kqhm6myfefuzfehvzgjpmkqpaa
@@ -220,12 +220,12 @@ importers:
     dependencies:
       '@contentstack/cli-command': link:../contentstack-command
       '@contentstack/cli-utilities': link:../contentstack-utilities
-      '@oclif/core': 4.8.0
+      '@oclif/core': 4.8.1
       '@oclif/plugin-help': 6.2.37
       otplib: 12.0.1
     devDependencies:
       '@fancy-test/nock': 0.1.1
-      '@oclif/test': 4.1.16_@oclif+core@4.8.0
+      '@oclif/test': 4.1.16_@oclif+core@4.8.1
       '@types/chai': 4.3.20
       '@types/mkdirp': 1.0.2
       '@types/mocha': 8.2.3
@@ -238,7 +238,7 @@ importers:
       eslint-config-oclif-typescript: 3.1.14_avq3eyf5kaj6ssrwo7fvkrwnji
       mocha: 10.8.2
       nyc: 15.1.0
-      oclif: 4.22.79_@types+node@14.18.63
+      oclif: 4.22.81_@types+node@14.18.63
       sinon: 21.0.1
       ts-node: 10.9.2_ogreqof3k35xezedraj6pnd45y
       typescript: 4.9.5
@@ -274,24 +274,24 @@ importers:
       '@contentstack/cli-command': link:../contentstack-command
       '@contentstack/cli-config': link:../contentstack-config
       '@contentstack/cli-utilities': link:../contentstack-utilities
-      '@oclif/core': 4.8.0
+      '@oclif/core': 4.8.1
       '@oclif/plugin-help': 6.2.37
       inquirer: 8.2.7_@types+node@14.18.63
       mkdirp: 1.0.4
       tar: 7.5.9
     devDependencies:
-      '@oclif/test': 4.1.16_@oclif+core@4.8.0
+      '@oclif/test': 4.1.16_@oclif+core@4.8.1
       '@types/inquirer': 9.0.9
       '@types/mkdirp': 1.0.2
       '@types/node': 14.18.63
       '@types/tar': 6.1.13
       chai: 4.5.0
       eslint: 8.57.1
-      eslint-config-oclif: 6.0.140_avq3eyf5kaj6ssrwo7fvkrwnji
+      eslint-config-oclif: 6.0.144_avq3eyf5kaj6ssrwo7fvkrwnji
       eslint-config-oclif-typescript: 3.1.14_avq3eyf5kaj6ssrwo7fvkrwnji
       mocha: 10.8.2
       nyc: 15.1.0
-      oclif: 4.22.79_@types+node@14.18.63
+      oclif: 4.22.81_@types+node@14.18.63
       tmp: 0.2.5
       ts-node: 8.10.2_typescript@4.9.5
       typescript: 4.9.5
@@ -321,7 +321,7 @@ importers:
     dependencies:
       '@contentstack/cli-command': link:../contentstack-command
       '@contentstack/cli-utilities': link:../contentstack-utilities
-      '@oclif/core': 4.8.0
+      '@oclif/core': 4.8.1
       '@oclif/plugin-help': 6.2.37
       chalk: 4.1.2
       just-diff: 6.0.2
@@ -333,10 +333,10 @@ importers:
       dotenv: 16.6.1
       dotenv-expand: 9.0.0
       eslint: 8.57.1
-      eslint-config-oclif: 6.0.140_avq3eyf5kaj6ssrwo7fvkrwnji
+      eslint-config-oclif: 6.0.144_avq3eyf5kaj6ssrwo7fvkrwnji
       mocha: 10.8.2
       nyc: 15.1.0
-      oclif: 4.22.79
+      oclif: 4.22.81
       sinon: 21.0.1
       ts-node: 10.9.2_typescript@4.9.5
       typescript: 4.9.5
@@ -378,7 +378,7 @@ importers:
       '@contentstack/cli-cm-import': link:../contentstack-import
       '@contentstack/cli-command': link:../contentstack-command
       '@contentstack/cli-utilities': link:../contentstack-utilities
-      '@oclif/core': 4.8.0
+      '@oclif/core': 4.8.1
       '@oclif/plugin-help': 6.2.37
       chalk: 4.1.2
       inquirer: 8.2.7_@types+node@14.18.63
@@ -388,7 +388,7 @@ importers:
       prompt: 1.3.0
       rimraf: 6.1.3
     devDependencies:
-      '@oclif/test': 4.1.16_@oclif+core@4.8.0
+      '@oclif/test': 4.1.16_@oclif+core@4.8.1
       '@types/chai': 4.3.20
       '@types/mocha': 10.0.10
       '@types/node': 14.18.63
@@ -396,10 +396,10 @@ importers:
       '@typescript-eslint/eslint-plugin': 5.62.0_avq3eyf5kaj6ssrwo7fvkrwnji
       chai: 4.5.0
       eslint: 8.57.1
-      eslint-config-oclif: 6.0.140_avq3eyf5kaj6ssrwo7fvkrwnji
+      eslint-config-oclif: 6.0.144_avq3eyf5kaj6ssrwo7fvkrwnji
       mocha: 10.8.2
       nyc: 15.1.0
-      oclif: 4.22.79_@types+node@14.18.63
+      oclif: 4.22.81_@types+node@14.18.63
       sinon: 21.0.1
       ts-node: 10.9.2_ogreqof3k35xezedraj6pnd45y
       typescript: 4.9.5
@@ -423,16 +423,16 @@ importers:
       typescript: ^4.9.5
     dependencies:
       '@contentstack/cli-utilities': link:../contentstack-utilities
-      '@oclif/core': 4.8.0
+      '@oclif/core': 4.8.1
       '@oclif/plugin-help': 6.2.37
       contentstack: 3.26.4
     devDependencies:
-      '@oclif/test': 4.1.16_@oclif+core@4.8.0
+      '@oclif/test': 4.1.16_@oclif+core@4.8.1
       '@types/mkdirp': 1.0.2
       '@types/mocha': 8.2.3
       '@types/node': 14.18.63
       eslint: 8.57.1
-      eslint-config-oclif: 6.0.140_avq3eyf5kaj6ssrwo7fvkrwnji
+      eslint-config-oclif: 6.0.144_avq3eyf5kaj6ssrwo7fvkrwnji
       eslint-config-oclif-typescript: 3.1.14_avq3eyf5kaj6ssrwo7fvkrwnji
       mocha: 10.8.2
       nyc: 15.1.0
@@ -465,23 +465,23 @@ importers:
     dependencies:
       '@contentstack/cli-command': link:../contentstack-command
       '@contentstack/cli-utilities': link:../contentstack-utilities
-      '@contentstack/utils': 1.7.0
-      '@oclif/core': 4.8.0
+      '@contentstack/utils': 1.7.1
+      '@oclif/core': 4.8.1
       '@oclif/plugin-help': 6.2.37
       lodash: 4.17.23
     devDependencies:
-      '@oclif/test': 4.1.16_@oclif+core@4.8.0
+      '@oclif/test': 4.1.16_@oclif+core@4.8.1
       '@types/chai': 4.3.20
       '@types/mocha': 8.2.3
       '@types/node': 14.18.63
       '@types/sinon': 21.0.0
       chai: 4.5.0
       eslint: 8.57.1
-      eslint-config-oclif: 6.0.140_avq3eyf5kaj6ssrwo7fvkrwnji
+      eslint-config-oclif: 6.0.144_avq3eyf5kaj6ssrwo7fvkrwnji
       eslint-config-oclif-typescript: 3.1.14_avq3eyf5kaj6ssrwo7fvkrwnji
       mocha: 10.8.2
       nyc: 15.1.0
-      oclif: 4.22.79_@types+node@14.18.63
+      oclif: 4.22.81_@types+node@14.18.63
       sinon: 21.0.1
       ts-node: 10.9.2_ogreqof3k35xezedraj6pnd45y
       typescript: 4.9.5
@@ -499,8 +499,8 @@ importers:
       tslib: ^2.8.1
       typescript: ^4.9.5
     dependencies:
-      '@oclif/core': 4.8.0
-      '@oclif/test': 4.1.16_@oclif+core@4.8.0
+      '@oclif/core': 4.8.1
+      '@oclif/test': 4.1.16_@oclif+core@4.8.1
       fancy-test: 2.0.42
       lodash: 4.17.23
     devDependencies:
@@ -554,7 +554,7 @@ importers:
       '@contentstack/cli-command': link:../contentstack-command
       '@contentstack/cli-utilities': link:../contentstack-utilities
       '@contentstack/cli-variants': link:../contentstack-variants
-      '@oclif/core': 4.8.0
+      '@oclif/core': 4.8.1
       async: 3.2.6
       big-json: 3.2.0
       bluebird: 3.7.2
@@ -570,7 +570,7 @@ importers:
       '@contentstack/cli-config': link:../contentstack-config
       '@contentstack/cli-dev-dependencies': link:../contentstack-dev-dependencies
       '@oclif/plugin-help': 6.2.37
-      '@oclif/test': 4.1.16_@oclif+core@4.8.0
+      '@oclif/test': 4.1.16_@oclif+core@4.8.1
       '@types/big-json': 3.2.5
       '@types/chai': 4.3.20
       '@types/mkdirp': 1.0.2
@@ -581,10 +581,10 @@ importers:
       dotenv: 16.6.1
       dotenv-expand: 9.0.0
       eslint: 8.57.1
-      eslint-config-oclif: 6.0.140_avq3eyf5kaj6ssrwo7fvkrwnji
+      eslint-config-oclif: 6.0.144_avq3eyf5kaj6ssrwo7fvkrwnji
       mocha: 10.8.2
       nyc: 15.1.0
-      oclif: 4.22.79
+      oclif: 4.22.81
       sinon: 17.0.2
       source-map-support: 0.5.21
       ts-node: 10.9.2_typescript@4.9.5
@@ -618,32 +618,32 @@ importers:
     dependencies:
       '@contentstack/cli-command': link:../contentstack-command
       '@contentstack/cli-utilities': link:../contentstack-utilities
-      '@oclif/core': 4.8.0
+      '@oclif/core': 4.8.1
       '@oclif/plugin-help': 6.2.37
       fast-csv: 4.3.6
       inquirer: 8.2.7_@types+node@20.19.33
       inquirer-checkbox-plus-prompt: 1.4.2_inquirer@8.2.7
     devDependencies:
-      '@oclif/test': 4.1.16_@oclif+core@4.8.0
+      '@oclif/test': 4.1.16_@oclif+core@4.8.1
       '@types/chai': 4.3.20
       '@types/inquirer': 9.0.9
       '@types/mocha': 10.0.10
       '@types/node': 20.19.33
       chai: 4.5.0
       eslint: 8.57.1
-      eslint-config-oclif: 6.0.140_k2rwabtyo525wwqr6566umnmhy
+      eslint-config-oclif: 6.0.144_k2rwabtyo525wwqr6566umnmhy
       eslint-config-oclif-typescript: 3.1.14_k2rwabtyo525wwqr6566umnmhy
       mocha: 10.8.2
       nock: 13.5.6
       nyc: 15.1.0
-      oclif: 4.22.79_@types+node@20.19.33
+      oclif: 4.22.81_@types+node@20.19.33
       sinon: 21.0.1
       ts-node: 10.9.2_kqhm6myfefuzfehvzgjpmkqpaa
       typescript: 5.9.3
 
   packages/contentstack-import:
     specifiers:
-      '@contentstack/cli-audit': ~2.0.0-beta.4
+      '@contentstack/cli-audit': ~2.0.0-beta.5
       '@contentstack/cli-command': ~2.0.0-beta
       '@contentstack/cli-utilities': ~2.0.0-beta
       '@contentstack/cli-variants': ~2.0.0-beta.5
@@ -684,7 +684,7 @@ importers:
       '@contentstack/cli-command': link:../contentstack-command
       '@contentstack/cli-utilities': link:../contentstack-utilities
       '@contentstack/cli-variants': link:../contentstack-variants
-      '@oclif/core': 4.8.0
+      '@oclif/core': 4.8.1
       big-json: 3.2.0
       bluebird: 3.7.2
       chalk: 4.1.2
@@ -698,7 +698,7 @@ importers:
       uuid: 9.0.1
       winston: 3.19.0
     devDependencies:
-      '@oclif/test': 4.1.16_@oclif+core@4.8.0
+      '@oclif/test': 4.1.16_@oclif+core@4.8.1
       '@types/big-json': 3.2.5
       '@types/bluebird': 3.5.42
       '@types/fs-extra': 11.0.4
@@ -710,10 +710,10 @@ importers:
       '@types/uuid': 9.0.8
       '@typescript-eslint/eslint-plugin': 5.62.0_avq3eyf5kaj6ssrwo7fvkrwnji
       eslint: 8.57.1
-      eslint-config-oclif: 6.0.140_avq3eyf5kaj6ssrwo7fvkrwnji
+      eslint-config-oclif: 6.0.144_avq3eyf5kaj6ssrwo7fvkrwnji
       mocha: 10.8.2
       nyc: 15.1.0
-      oclif: 4.22.79_@types+node@14.18.63
+      oclif: 4.22.81_@types+node@14.18.63
       rewire: 9.0.1
       ts-node: 10.9.2_ogreqof3k35xezedraj6pnd45y
       typescript: 4.9.5
@@ -756,7 +756,7 @@ importers:
     dependencies:
       '@contentstack/cli-command': link:../contentstack-command
       '@contentstack/cli-utilities': link:../contentstack-utilities
-      '@oclif/core': 4.8.0
+      '@oclif/core': 4.8.1
       big-json: 3.2.0
       chalk: 4.1.2
       fs-extra: 11.3.3
@@ -779,10 +779,10 @@ importers:
       '@typescript-eslint/eslint-plugin': 5.62.0_avq3eyf5kaj6ssrwo7fvkrwnji
       chai: 4.5.0
       eslint: 8.57.1
-      eslint-config-oclif: 6.0.140_avq3eyf5kaj6ssrwo7fvkrwnji
+      eslint-config-oclif: 6.0.144_avq3eyf5kaj6ssrwo7fvkrwnji
       mocha: 10.8.2
       nyc: 15.1.0
-      oclif: 4.22.79_@types+node@14.18.63
+      oclif: 4.22.81_@types+node@14.18.63
       rewire: 9.0.1
       sinon: 21.0.1
       ts-node: 10.9.2_ogreqof3k35xezedraj6pnd45y
@@ -820,7 +820,7 @@ importers:
     dependencies:
       '@contentstack/cli-command': link:../contentstack-command
       '@contentstack/cli-utilities': link:../contentstack-utilities
-      '@oclif/core': 4.8.0
+      '@oclif/core': 4.8.1
       '@oclif/plugin-help': 6.2.37
       async: 3.2.6
       callsites: 3.1.0
@@ -830,17 +830,17 @@ importers:
       listr: 0.14.3
       winston: 3.19.0
     devDependencies:
-      '@oclif/test': 4.1.16_@oclif+core@4.8.0
+      '@oclif/test': 4.1.16_@oclif+core@4.8.1
       '@types/mocha': 8.2.3
       '@types/node': 14.18.63
       chai: 4.5.0
       eslint: 8.57.1
-      eslint-config-oclif: 6.0.140_avq3eyf5kaj6ssrwo7fvkrwnji
+      eslint-config-oclif: 6.0.144_avq3eyf5kaj6ssrwo7fvkrwnji
       jsdoc-to-markdown: 8.0.3
       mocha: 10.8.2
       nock: 13.5.6
       nyc: 15.1.0
-      oclif: 4.22.79_@types+node@14.18.63
+      oclif: 4.22.81_@types+node@14.18.63
       sinon: 21.0.1
       source-map-support: 0.5.21
       ts-node: 10.9.2_ogreqof3k35xezedraj6pnd45y
@@ -887,10 +887,10 @@ importers:
       '@types/tmp': 0.2.6
       axios: 1.13.5
       eslint: 8.57.1
-      eslint-config-oclif: 6.0.140_avq3eyf5kaj6ssrwo7fvkrwnji
+      eslint-config-oclif: 6.0.144_avq3eyf5kaj6ssrwo7fvkrwnji
       eslint-config-oclif-typescript: 3.1.14_avq3eyf5kaj6ssrwo7fvkrwnji
       jest: 29.7.0_gmerzvnqkqd6hvbwzqmybfpwqi
-      oclif: 4.22.79_@types+node@14.18.63
+      oclif: 4.22.81_@types+node@14.18.63
       ts-jest: 29.4.6_67xnt3v64q2pgz6kguni4h37hu
       ts-node: 8.10.2_typescript@4.9.5
       typescript: 4.9.5
@@ -944,9 +944,9 @@ importers:
       winston: ^3.17.0
       xdg-basedir: ^4.0.0
     dependencies:
-      '@contentstack/management': 1.27.5
+      '@contentstack/management': 1.27.6
       '@contentstack/marketplace-sdk': 1.5.0
-      '@oclif/core': 4.8.0
+      '@oclif/core': 4.8.1
       axios: 1.13.5
       chalk: 4.1.2
       cli-cursor: 3.1.0
@@ -983,7 +983,7 @@ importers:
       '@types/traverse': 0.6.37
       chai: 4.5.0
       eslint: 8.57.1
-      eslint-config-oclif: 6.0.140_avq3eyf5kaj6ssrwo7fvkrwnji
+      eslint-config-oclif: 6.0.144_avq3eyf5kaj6ssrwo7fvkrwnji
       eslint-config-oclif-typescript: 3.1.14_avq3eyf5kaj6ssrwo7fvkrwnji
       fancy-test: 2.0.42
       mocha: 10.8.2
@@ -1009,14 +1009,14 @@ importers:
       winston: ^3.17.0
     dependencies:
       '@contentstack/cli-utilities': link:../contentstack-utilities
-      '@oclif/core': 4.8.0
+      '@oclif/core': 4.8.1
       '@oclif/plugin-help': 6.2.37
       lodash: 4.17.23
       mkdirp: 1.0.4
       winston: 3.19.0
     devDependencies:
       '@contentstack/cli-dev-dependencies': link:../contentstack-dev-dependencies
-      '@oclif/test': 4.1.16_@oclif+core@4.8.0
+      '@oclif/test': 4.1.16_@oclif+core@4.8.1
       '@types/node': 20.19.33
       mocha: 10.8.2
       nyc: 15.1.0
@@ -1124,8 +1124,8 @@ packages:
       tslib: 2.8.1
     dev: true
 
-  /@aws-sdk/client-cloudfront/3.993.0:
-    resolution: {integrity: sha512-8jCdRFDWJSyeAtAMuynUPy+3Bz9aRaunxhUluxCK9aLCadj9J19mvxsMHvdumObeYam4NYVi2GYVs8GFZ0ET1g==}
+  /@aws-sdk/client-cloudfront/3.995.0:
+    resolution: {integrity: sha512-hTyUaVs0hKPSlQyreyxmj6g9sPRs9XWNzDCozYfU5rbAcqS1E0AVTFAjbgNvKIOEbY5iL4UuiIFdFG7m5z9SAQ==}
     engines: {node: '>=20.0.0'}
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
@@ -1138,34 +1138,34 @@ packages:
       '@aws-sdk/middleware-user-agent': 3.972.11
       '@aws-sdk/region-config-resolver': 3.972.3
       '@aws-sdk/types': 3.973.1
-      '@aws-sdk/util-endpoints': 3.993.0
+      '@aws-sdk/util-endpoints': 3.995.0
       '@aws-sdk/util-user-agent-browser': 3.972.3
-      '@aws-sdk/util-user-agent-node': 3.972.9
+      '@aws-sdk/util-user-agent-node': 3.972.10
       '@smithy/config-resolver': 4.4.6
-      '@smithy/core': 3.23.2
+      '@smithy/core': 3.23.3
       '@smithy/fetch-http-handler': 5.3.9
       '@smithy/hash-node': 4.2.8
       '@smithy/invalid-dependency': 4.2.8
       '@smithy/middleware-content-length': 4.2.8
-      '@smithy/middleware-endpoint': 4.4.16
-      '@smithy/middleware-retry': 4.4.33
+      '@smithy/middleware-endpoint': 4.4.17
+      '@smithy/middleware-retry': 4.4.34
       '@smithy/middleware-serde': 4.2.9
       '@smithy/middleware-stack': 4.2.8
       '@smithy/node-config-provider': 4.3.8
       '@smithy/node-http-handler': 4.4.10
       '@smithy/protocol-http': 5.3.8
-      '@smithy/smithy-client': 4.11.5
+      '@smithy/smithy-client': 4.11.6
       '@smithy/types': 4.12.0
       '@smithy/url-parser': 4.2.8
       '@smithy/util-base64': 4.3.0
       '@smithy/util-body-length-browser': 4.2.0
       '@smithy/util-body-length-node': 4.2.1
-      '@smithy/util-defaults-mode-browser': 4.3.32
-      '@smithy/util-defaults-mode-node': 4.2.35
+      '@smithy/util-defaults-mode-browser': 4.3.33
+      '@smithy/util-defaults-mode-node': 4.2.36
       '@smithy/util-endpoints': 3.2.8
       '@smithy/util-middleware': 4.2.8
       '@smithy/util-retry': 4.2.8
-      '@smithy/util-stream': 4.5.12
+      '@smithy/util-stream': 4.5.13
       '@smithy/util-utf8': 4.2.0
       '@smithy/util-waiter': 4.2.8
       tslib: 2.8.1
@@ -1173,8 +1173,8 @@ packages:
       - aws-crt
     dev: true
 
-  /@aws-sdk/client-s3/3.993.0:
-    resolution: {integrity: sha512-0slCxdbo9O3rfzqD7/PsBOrZ6vcwFzPAvGeUu5NZApI5WyjEfMLLi2T9QW8R9N9TQeUfiUQiHkg/NV0LPS61/g==}
+  /@aws-sdk/client-s3/3.995.0:
+    resolution: {integrity: sha512-r+t8qrQ0m9zoovYOH+wilp/glFRB/E+blsDyWzq2C+9qmyhCAQwaxjLaHM8T/uluAmhtZQIYqOH9ILRnvWtRNw==}
     engines: {node: '>=20.0.0'}
     dependencies:
       '@aws-crypto/sha1-browser': 5.2.0
@@ -1193,13 +1193,13 @@ packages:
       '@aws-sdk/middleware-ssec': 3.972.3
       '@aws-sdk/middleware-user-agent': 3.972.11
       '@aws-sdk/region-config-resolver': 3.972.3
-      '@aws-sdk/signature-v4-multi-region': 3.993.0
+      '@aws-sdk/signature-v4-multi-region': 3.995.0
       '@aws-sdk/types': 3.973.1
-      '@aws-sdk/util-endpoints': 3.993.0
+      '@aws-sdk/util-endpoints': 3.995.0
       '@aws-sdk/util-user-agent-browser': 3.972.3
-      '@aws-sdk/util-user-agent-node': 3.972.9
+      '@aws-sdk/util-user-agent-node': 3.972.10
       '@smithy/config-resolver': 4.4.6
-      '@smithy/core': 3.23.2
+      '@smithy/core': 3.23.3
       '@smithy/eventstream-serde-browser': 4.2.8
       '@smithy/eventstream-serde-config-resolver': 4.3.8
       '@smithy/eventstream-serde-node': 4.2.8
@@ -1210,25 +1210,25 @@ packages:
       '@smithy/invalid-dependency': 4.2.8
       '@smithy/md5-js': 4.2.8
       '@smithy/middleware-content-length': 4.2.8
-      '@smithy/middleware-endpoint': 4.4.16
-      '@smithy/middleware-retry': 4.4.33
+      '@smithy/middleware-endpoint': 4.4.17
+      '@smithy/middleware-retry': 4.4.34
       '@smithy/middleware-serde': 4.2.9
       '@smithy/middleware-stack': 4.2.8
       '@smithy/node-config-provider': 4.3.8
       '@smithy/node-http-handler': 4.4.10
       '@smithy/protocol-http': 5.3.8
-      '@smithy/smithy-client': 4.11.5
+      '@smithy/smithy-client': 4.11.6
       '@smithy/types': 4.12.0
       '@smithy/url-parser': 4.2.8
       '@smithy/util-base64': 4.3.0
       '@smithy/util-body-length-browser': 4.2.0
       '@smithy/util-body-length-node': 4.2.1
-      '@smithy/util-defaults-mode-browser': 4.3.32
-      '@smithy/util-defaults-mode-node': 4.2.35
+      '@smithy/util-defaults-mode-browser': 4.3.33
+      '@smithy/util-defaults-mode-node': 4.2.36
       '@smithy/util-endpoints': 3.2.8
       '@smithy/util-middleware': 4.2.8
       '@smithy/util-retry': 4.2.8
-      '@smithy/util-stream': 4.5.12
+      '@smithy/util-stream': 4.5.13
       '@smithy/util-utf8': 4.2.0
       '@smithy/util-waiter': 4.2.8
       tslib: 2.8.1
@@ -1251,28 +1251,28 @@ packages:
       '@aws-sdk/types': 3.973.1
       '@aws-sdk/util-endpoints': 3.993.0
       '@aws-sdk/util-user-agent-browser': 3.972.3
-      '@aws-sdk/util-user-agent-node': 3.972.9
+      '@aws-sdk/util-user-agent-node': 3.972.10
       '@smithy/config-resolver': 4.4.6
-      '@smithy/core': 3.23.2
+      '@smithy/core': 3.23.3
       '@smithy/fetch-http-handler': 5.3.9
       '@smithy/hash-node': 4.2.8
       '@smithy/invalid-dependency': 4.2.8
       '@smithy/middleware-content-length': 4.2.8
-      '@smithy/middleware-endpoint': 4.4.16
-      '@smithy/middleware-retry': 4.4.33
+      '@smithy/middleware-endpoint': 4.4.17
+      '@smithy/middleware-retry': 4.4.34
       '@smithy/middleware-serde': 4.2.9
       '@smithy/middleware-stack': 4.2.8
       '@smithy/node-config-provider': 4.3.8
       '@smithy/node-http-handler': 4.4.10
       '@smithy/protocol-http': 5.3.8
-      '@smithy/smithy-client': 4.11.5
+      '@smithy/smithy-client': 4.11.6
       '@smithy/types': 4.12.0
       '@smithy/url-parser': 4.2.8
       '@smithy/util-base64': 4.3.0
       '@smithy/util-body-length-browser': 4.2.0
       '@smithy/util-body-length-node': 4.2.1
-      '@smithy/util-defaults-mode-browser': 4.3.32
-      '@smithy/util-defaults-mode-node': 4.2.35
+      '@smithy/util-defaults-mode-browser': 4.3.33
+      '@smithy/util-defaults-mode-node': 4.2.36
       '@smithy/util-endpoints': 3.2.8
       '@smithy/util-middleware': 4.2.8
       '@smithy/util-retry': 4.2.8
@@ -1288,12 +1288,12 @@ packages:
     dependencies:
       '@aws-sdk/types': 3.973.1
       '@aws-sdk/xml-builder': 3.972.5
-      '@smithy/core': 3.23.2
+      '@smithy/core': 3.23.3
       '@smithy/node-config-provider': 4.3.8
       '@smithy/property-provider': 4.2.8
       '@smithy/protocol-http': 5.3.8
       '@smithy/signature-v4': 5.3.8
-      '@smithy/smithy-client': 4.11.5
+      '@smithy/smithy-client': 4.11.6
       '@smithy/types': 4.12.0
       '@smithy/util-base64': 4.3.0
       '@smithy/util-middleware': 4.2.8
@@ -1330,9 +1330,9 @@ packages:
       '@smithy/node-http-handler': 4.4.10
       '@smithy/property-provider': 4.2.8
       '@smithy/protocol-http': 5.3.8
-      '@smithy/smithy-client': 4.11.5
+      '@smithy/smithy-client': 4.11.6
       '@smithy/types': 4.12.0
-      '@smithy/util-stream': 4.5.12
+      '@smithy/util-stream': 4.5.13
       tslib: 2.8.1
     dev: true
 
@@ -1475,7 +1475,7 @@ packages:
       '@smithy/protocol-http': 5.3.8
       '@smithy/types': 4.12.0
       '@smithy/util-middleware': 4.2.8
-      '@smithy/util-stream': 4.5.12
+      '@smithy/util-stream': 4.5.13
       '@smithy/util-utf8': 4.2.0
       tslib: 2.8.1
     dev: true
@@ -1526,15 +1526,15 @@ packages:
       '@aws-sdk/core': 3.973.11
       '@aws-sdk/types': 3.973.1
       '@aws-sdk/util-arn-parser': 3.972.2
-      '@smithy/core': 3.23.2
+      '@smithy/core': 3.23.3
       '@smithy/node-config-provider': 4.3.8
       '@smithy/protocol-http': 5.3.8
       '@smithy/signature-v4': 5.3.8
-      '@smithy/smithy-client': 4.11.5
+      '@smithy/smithy-client': 4.11.6
       '@smithy/types': 4.12.0
       '@smithy/util-config-provider': 4.2.0
       '@smithy/util-middleware': 4.2.8
-      '@smithy/util-stream': 4.5.12
+      '@smithy/util-stream': 4.5.13
       '@smithy/util-utf8': 4.2.0
       tslib: 2.8.1
     dev: true
@@ -1555,7 +1555,7 @@ packages:
       '@aws-sdk/core': 3.973.11
       '@aws-sdk/types': 3.973.1
       '@aws-sdk/util-endpoints': 3.993.0
-      '@smithy/core': 3.23.2
+      '@smithy/core': 3.23.3
       '@smithy/protocol-http': 5.3.8
       '@smithy/types': 4.12.0
       tslib: 2.8.1
@@ -1576,28 +1576,28 @@ packages:
       '@aws-sdk/types': 3.973.1
       '@aws-sdk/util-endpoints': 3.993.0
       '@aws-sdk/util-user-agent-browser': 3.972.3
-      '@aws-sdk/util-user-agent-node': 3.972.9
+      '@aws-sdk/util-user-agent-node': 3.972.10
       '@smithy/config-resolver': 4.4.6
-      '@smithy/core': 3.23.2
+      '@smithy/core': 3.23.3
       '@smithy/fetch-http-handler': 5.3.9
       '@smithy/hash-node': 4.2.8
       '@smithy/invalid-dependency': 4.2.8
       '@smithy/middleware-content-length': 4.2.8
-      '@smithy/middleware-endpoint': 4.4.16
-      '@smithy/middleware-retry': 4.4.33
+      '@smithy/middleware-endpoint': 4.4.17
+      '@smithy/middleware-retry': 4.4.34
       '@smithy/middleware-serde': 4.2.9
       '@smithy/middleware-stack': 4.2.8
       '@smithy/node-config-provider': 4.3.8
       '@smithy/node-http-handler': 4.4.10
       '@smithy/protocol-http': 5.3.8
-      '@smithy/smithy-client': 4.11.5
+      '@smithy/smithy-client': 4.11.6
       '@smithy/types': 4.12.0
       '@smithy/url-parser': 4.2.8
       '@smithy/util-base64': 4.3.0
       '@smithy/util-body-length-browser': 4.2.0
       '@smithy/util-body-length-node': 4.2.1
-      '@smithy/util-defaults-mode-browser': 4.3.32
-      '@smithy/util-defaults-mode-node': 4.2.35
+      '@smithy/util-defaults-mode-browser': 4.3.33
+      '@smithy/util-defaults-mode-node': 4.2.36
       '@smithy/util-endpoints': 3.2.8
       '@smithy/util-middleware': 4.2.8
       '@smithy/util-retry': 4.2.8
@@ -1618,8 +1618,8 @@ packages:
       tslib: 2.8.1
     dev: true
 
-  /@aws-sdk/signature-v4-multi-region/3.993.0:
-    resolution: {integrity: sha512-6l20k27TJdqTozJOm+s20/1XDey3aj+yaeIdbtqXuYNhQiWHajvYThcI1sHx2I1W4NelZTOmYEF+dj1mya01eg==}
+  /@aws-sdk/signature-v4-multi-region/3.995.0:
+    resolution: {integrity: sha512-9Qx5JcAucnxnomREPb2D6L8K8GLG0rknt3+VK/BU3qTUynAcV4W21DQ04Z2RKDw+DYpW88lsZpXbVetWST2WUg==}
     engines: {node: '>=20.0.0'}
     dependencies:
       '@aws-sdk/middleware-sdk-s3': 3.972.11
@@ -1671,6 +1671,17 @@ packages:
       tslib: 2.8.1
     dev: true
 
+  /@aws-sdk/util-endpoints/3.995.0:
+    resolution: {integrity: sha512-aym/pjB8SLbo9w2nmkrDdAAVKVlf7CM71B9mKhjDbJTzwpSFBPHqJIMdDyj0mLumKC0aIVDr1H6U+59m9GvMFw==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      '@smithy/util-endpoints': 3.2.8
+      tslib: 2.8.1
+    dev: true
+
   /@aws-sdk/util-locate-window/3.965.4:
     resolution: {integrity: sha512-H1onv5SkgPBK2P6JR2MjGgbOnttoNzSPIRoeZTNPZYyaplwGg50zS3amXvXqF0/qfXpWEC9rLWU564QTB9bSog==}
     engines: {node: '>=20.0.0'}
@@ -1687,8 +1698,8 @@ packages:
       tslib: 2.8.1
     dev: true
 
-  /@aws-sdk/util-user-agent-node/3.972.9:
-    resolution: {integrity: sha512-JNswdsLdQemxqaSIBL2HRhsHPUBBziAgoi5RQv6/9avmE5g5RSdt1hWr3mHJ7OxqRYf+KeB11ExWbiqfrnoeaA==}
+  /@aws-sdk/util-user-agent-node/3.972.10:
+    resolution: {integrity: sha512-LVXzICPlsheET+sE6tkcS47Q5HkSTrANIlqL1iFxGAY/wRQ236DX/PCAK56qMh9QJoXAfXfoRW0B0Og4R+X7Nw==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       aws-crt: '>=1.0.0'
@@ -2082,7 +2093,7 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@contentstack/cli-utilities': 1.17.4_lxq42tdpoxpye5tb7w3htdbbdq
-      '@oclif/core': 4.8.0
+      '@oclif/core': 4.8.1
       '@oclif/plugin-help': 6.2.37
       contentstack: 3.26.4
     transitivePeerDependencies:
@@ -2098,12 +2109,12 @@ packages:
       '@apollo/client': 3.14.0_graphql@16.12.0
       '@contentstack/cli-command': 1.7.2_lxq42tdpoxpye5tb7w3htdbbdq
       '@contentstack/cli-utilities': 1.17.4_lxq42tdpoxpye5tb7w3htdbbdq
-      '@oclif/core': 4.8.0
+      '@oclif/core': 4.8.1
       '@oclif/plugin-help': 6.2.37
-      '@rollup/plugin-commonjs': 28.0.9_rollup@4.57.1
-      '@rollup/plugin-json': 6.1.0_rollup@4.57.1
-      '@rollup/plugin-node-resolve': 16.0.3_rollup@4.57.1
-      '@rollup/plugin-typescript': 12.3.0_mmrlxa3go2doaxiivy5r4eo3gi
+      '@rollup/plugin-commonjs': 28.0.9_rollup@4.59.0
+      '@rollup/plugin-json': 6.1.0_rollup@4.59.0
+      '@rollup/plugin-node-resolve': 16.0.3_rollup@4.59.0
+      '@rollup/plugin-typescript': 12.3.0_w4dj76agps3wlyy4rfyqfgfdtm
       '@types/express': 4.17.25
       '@types/express-serve-static-core': 4.19.8
       adm-zip: 0.5.16
@@ -2116,7 +2127,7 @@ packages:
       ini: 3.0.1
       lodash: 4.17.23
       open: 8.4.2
-      rollup: 4.57.1
+      rollup: 4.59.0
       winston: 3.19.0
     transitivePeerDependencies:
       - '@types/node'
@@ -2135,9 +2146,9 @@ packages:
   /@contentstack/cli-utilities/1.17.4_lxq42tdpoxpye5tb7w3htdbbdq:
     resolution: {integrity: sha512-45Ujy0lNtQiU0FhZrtfGEfte4kjy3tlOnlVz6REH+cW/y1Dgg1nMh+YVgygbOh+6b8PkvTYVlEvb15UxRarNiA==}
     dependencies:
-      '@contentstack/management': 1.27.5_debug@4.4.3
+      '@contentstack/management': 1.27.6_debug@4.4.3
       '@contentstack/marketplace-sdk': 1.5.0_debug@4.4.3
-      '@oclif/core': 4.8.0
+      '@oclif/core': 4.8.1
       axios: 1.13.5_debug@4.4.3
       chalk: 4.1.2
       cli-cursor: 3.1.0
@@ -2185,18 +2196,18 @@ packages:
     resolution: {integrity: sha512-tDqv1SKl831PfEK1qdTFvS+sPChPF6/84pLOBM6K9hXrxecm7jW4sJJx4B7cvtzEMErHLsZocdUuGCzPrQXXGA==}
     dependencies:
       '@contentstack/core': 1.3.10_debug@4.4.3
-      '@contentstack/utils': 1.7.0
+      '@contentstack/utils': 1.7.1
       axios: 1.13.5_debug@4.4.3
       humps: 2.0.1
     transitivePeerDependencies:
       - debug
     dev: false
 
-  /@contentstack/management/1.27.5:
-    resolution: {integrity: sha512-eiv3NeGHGtjRhbOKotbfvHOL+RQv24aaZVb/gxxkyFVE0wyQmagtUzz4nRURDy0qnYttdkGxx65r4hzNZbxq8Q==}
+  /@contentstack/management/1.27.6:
+    resolution: {integrity: sha512-92h8YzKZ2EDzMogf0fmBHapCjVpzHkDBIj0Eb/MhPFIhlybDlAZhcM/di6zwgicEJj5UjTJ+ETXXQMEJZouDew==}
     engines: {node: '>=8.0.0'}
     dependencies:
-      '@contentstack/utils': 1.7.0
+      '@contentstack/utils': 1.7.1
       assert: 2.1.0
       axios: 1.13.5
       buffer: 6.0.3
@@ -2204,17 +2215,17 @@ packages:
       husky: 9.1.7
       lodash: 4.17.23
       otplib: 12.0.1
-      qs: 6.14.1
+      qs: 6.15.0
       stream-browserify: 3.0.0
     transitivePeerDependencies:
       - debug
     dev: false
 
-  /@contentstack/management/1.27.5_debug@4.4.3:
-    resolution: {integrity: sha512-eiv3NeGHGtjRhbOKotbfvHOL+RQv24aaZVb/gxxkyFVE0wyQmagtUzz4nRURDy0qnYttdkGxx65r4hzNZbxq8Q==}
+  /@contentstack/management/1.27.6_debug@4.4.3:
+    resolution: {integrity: sha512-92h8YzKZ2EDzMogf0fmBHapCjVpzHkDBIj0Eb/MhPFIhlybDlAZhcM/di6zwgicEJj5UjTJ+ETXXQMEJZouDew==}
     engines: {node: '>=8.0.0'}
     dependencies:
-      '@contentstack/utils': 1.7.0
+      '@contentstack/utils': 1.7.1
       assert: 2.1.0
       axios: 1.13.5_debug@4.4.3
       buffer: 6.0.3
@@ -2222,7 +2233,7 @@ packages:
       husky: 9.1.7
       lodash: 4.17.23
       otplib: 12.0.1
-      qs: 6.14.1
+      qs: 6.15.0
       stream-browserify: 3.0.0
     transitivePeerDependencies:
       - debug
@@ -2231,7 +2242,7 @@ packages:
   /@contentstack/marketplace-sdk/1.5.0:
     resolution: {integrity: sha512-n2USMwswXBDtmVOg0t5FUks8X0d49u0UDFSrwxti09X/SONeP0P8wSqIDCjoB2gGRQc6fg/Fg2YPRvejUWeR4A==}
     dependencies:
-      '@contentstack/utils': 1.7.0
+      '@contentstack/utils': 1.7.1
       axios: 1.13.5
     transitivePeerDependencies:
       - debug
@@ -2240,14 +2251,14 @@ packages:
   /@contentstack/marketplace-sdk/1.5.0_debug@4.4.3:
     resolution: {integrity: sha512-n2USMwswXBDtmVOg0t5FUks8X0d49u0UDFSrwxti09X/SONeP0P8wSqIDCjoB2gGRQc6fg/Fg2YPRvejUWeR4A==}
     dependencies:
-      '@contentstack/utils': 1.7.0
+      '@contentstack/utils': 1.7.1
       axios: 1.13.5_debug@4.4.3
     transitivePeerDependencies:
       - debug
     dev: false
 
-  /@contentstack/utils/1.7.0:
-    resolution: {integrity: sha512-wNWNt+wkoGJzCr5ZhAMKWJ5ND5xbD7N3t++Y6s1O+FB+AFzJszqCT740j6VqwjhQzw5sGfHoGjHIvlQA9dCcBw==}
+  /@contentstack/utils/1.7.1:
+    resolution: {integrity: sha512-b/0t1malpJeFCNd9+1uN3BuO8mRn2b5+aNtrYEZ6YlSNjYNRu9IjqSxZ5Clhs5267950UV1ayhgFE8z3qre2eQ==}
     dev: false
 
   /@cspotcode/source-map-support/0.8.1:
@@ -2545,13 +2556,13 @@ packages:
       eslint-visitor-keys: 3.4.3
     dev: true
 
-  /@eslint-community/eslint-utils/4.9.1_eslint@9.39.2:
+  /@eslint-community/eslint-utils/4.9.1_eslint@9.39.3:
     resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
     dependencies:
-      eslint: 9.39.2
+      eslint: 9.39.3
       eslint-visitor-keys: 3.4.3
     dev: true
 
@@ -2579,7 +2590,7 @@ packages:
     dependencies:
       '@eslint/object-schema': 2.1.7
       debug: 4.4.3
-      minimatch: 3.1.2
+      minimatch: 3.1.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -2633,14 +2644,14 @@ packages:
     resolution: {integrity: sha512-J6KFFz5QCYUJq3pf0mjEcCJVERbzv71PUIDczuh9JkwGEzced6CO5ADLHB1rbf/+oPBtoPfMYNOpGDzCANlbXw==}
     engines: {node: ^10.12.0 || >=12.0.0}
     dependencies:
-      ajv: 6.12.6
+      ajv: 6.14.0
       debug: 4.4.3
       espree: 7.3.1
       globals: 13.24.0
       ignore: 4.0.6
       import-fresh: 3.3.1
       js-yaml: 3.14.2
-      minimatch: 3.1.2
+      minimatch: 3.1.3
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
@@ -2650,14 +2661,14 @@ packages:
     resolution: {integrity: sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
-      ajv: 6.12.6
+      ajv: 6.14.0
       debug: 4.4.3
       espree: 9.6.1
       globals: 13.24.0
       ignore: 5.3.2
       import-fresh: 3.3.1
       js-yaml: 4.1.1
-      minimatch: 3.1.2
+      minimatch: 3.1.3
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
@@ -2667,14 +2678,14 @@ packages:
     resolution: {integrity: sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     dependencies:
-      ajv: 6.12.6
+      ajv: 6.14.0
       debug: 4.4.3
       espree: 10.4.0
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
       js-yaml: 4.1.1
-      minimatch: 3.1.2
+      minimatch: 3.1.3
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
@@ -2685,8 +2696,8 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /@eslint/js/9.39.2:
-    resolution: {integrity: sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==}
+  /@eslint/js/9.39.3:
+    resolution: {integrity: sha512-1B1VkCq6FuUNlQvlBYb+1jDu/gV297TIs/OeiaSR9l1H27SVW55ONE1e1Vp16NqP683+xEGzxYtv4XCiDPaQiw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     dev: true
 
@@ -2777,7 +2788,7 @@ packages:
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
       debug: 4.4.3
-      minimatch: 3.1.2
+      minimatch: 3.1.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -2789,7 +2800,7 @@ packages:
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
       debug: 4.4.3
-      minimatch: 3.1.2
+      minimatch: 3.1.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -3812,8 +3823,8 @@ packages:
       '@jridgewell/sourcemap-codec': 1.5.5
     dev: true
 
-  /@jsdoc/salty/0.2.9:
-    resolution: {integrity: sha512-yYxMVH7Dqw6nO0d5NIV8OQWnitU8k6vXH8NtgqAfIa/IUqRMxRv/NUJJ08VEKbAakwxlgBl5PJdrU0dMPStsnw==}
+  /@jsdoc/salty/0.2.10:
+    resolution: {integrity: sha512-VFHSsQAQp8y1NJvAJBpLs9I2shHE6hz9TwukocDObuUgGVAq62yZGbTgJg04Z3Fj0XSMWe0sJqGg5dhKGTV92A==}
     engines: {node: '>=v12.0.0'}
     dependencies:
       lodash: 4.17.23
@@ -3855,8 +3866,8 @@ packages:
     engines: {node: '>=12.4.0'}
     dev: true
 
-  /@oclif/core/4.8.0:
-    resolution: {integrity: sha512-jteNUQKgJHLHFbbz806aGZqf+RJJ7t4gwF4MYa8fCwCxQ8/klJNWc0MvaJiBebk7Mc+J39mdlsB4XraaCKznFw==}
+  /@oclif/core/4.8.1:
+    resolution: {integrity: sha512-07mq0vKCWNsB85ZHeBMlTAiO0KLFqHyAeRK3bD2K8CI1tX3tiwkWw1lZQZkiw8MUBrhxdROhMkYMY4Q0l7JHqA==}
     engines: {node: '>=18.0.0'}
     dependencies:
       ansi-escapes: 4.3.2
@@ -3869,7 +3880,7 @@ packages:
       indent-string: 4.0.0
       is-wsl: 2.2.0
       lilconfig: 3.1.3
-      minimatch: 9.0.5
+      minimatch: 10.2.2
       semver: 7.7.4
       string-width: 4.2.3
       supports-color: 8.1.1
@@ -3882,14 +3893,14 @@ packages:
     resolution: {integrity: sha512-5N/X/FzlJaYfpaHwDC0YHzOzKDWa41s9t+4FpCDu4f9OMReds4JeNBaaWk9rlIzdKjh2M6AC5Q18ORfECRkHGA==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      '@oclif/core': 4.8.0
+      '@oclif/core': 4.8.1
 
   /@oclif/plugin-not-found/3.2.74:
     resolution: {integrity: sha512-6RD/EuIUGxAYR45nMQg+nw+PqwCXUxkR6Eyn+1fvbVjtb9d+60OPwB77LCRUI4zKNI+n0LOFaMniEdSpb+A7kQ==}
     engines: {node: '>=18.0.0'}
     dependencies:
       '@inquirer/prompts': 7.10.1
-      '@oclif/core': 4.8.0
+      '@oclif/core': 4.8.1
       ansis: 3.17.0
       fast-levenshtein: 3.0.0
     transitivePeerDependencies:
@@ -3901,7 +3912,7 @@ packages:
     engines: {node: '>=18.0.0'}
     dependencies:
       '@inquirer/prompts': 7.10.1_@types+node@14.18.63
-      '@oclif/core': 4.8.0
+      '@oclif/core': 4.8.1
       ansis: 3.17.0
       fast-levenshtein: 3.0.0
     transitivePeerDependencies:
@@ -3912,7 +3923,7 @@ packages:
     engines: {node: '>=18.0.0'}
     dependencies:
       '@inquirer/prompts': 7.10.1_@types+node@20.19.33
-      '@oclif/core': 4.8.0
+      '@oclif/core': 4.8.1
       ansis: 3.17.0
       fast-levenshtein: 3.0.0
     transitivePeerDependencies:
@@ -3923,7 +3934,7 @@ packages:
     resolution: {integrity: sha512-mZjRudlmVSr6Stz0CVFuaIZOjwZ5DqjWepQCR/yK9nbs8YunGautpuxBx/CcqaEH29xiQfsuNOIUWa1w/+3VSA==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      '@oclif/core': 4.8.0
+      '@oclif/core': 4.8.1
       ansis: 3.17.0
       debug: 4.4.3
       npm: 10.9.4
@@ -3942,7 +3953,7 @@ packages:
     resolution: {integrity: sha512-VIEBoaoMOCjl3y+w/kdfZMODi0mVMnDuM0vkBf3nqeidhRXVXq87hBqYDdRwN1XoD+eDfE8tBbOP7qtSOONztQ==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      '@oclif/core': 4.8.0
+      '@oclif/core': 4.8.1
       ansis: 3.17.0
       debug: 4.4.3
       http-call: 5.3.0
@@ -3952,13 +3963,13 @@ packages:
       - supports-color
     dev: true
 
-  /@oclif/test/4.1.16_@oclif+core@4.8.0:
+  /@oclif/test/4.1.16_@oclif+core@4.8.1:
     resolution: {integrity: sha512-LPrF++WGGBE0pe3GUkzEteI5WrwTT7usGpIMSxkyJhYnFXKkwASyTcCmOhNH4QC65kqsLt1oBA88BMkCJqPtxg==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       '@oclif/core': '>= 3.0.0'
     dependencies:
-      '@oclif/core': 4.8.0
+      '@oclif/core': 4.8.1
       ansis: 3.17.0
       debug: 4.4.3
     transitivePeerDependencies:
@@ -4028,7 +4039,7 @@ packages:
       config-chain: 1.1.13
     dev: true
 
-  /@rollup/plugin-commonjs/28.0.9_rollup@4.57.1:
+  /@rollup/plugin-commonjs/28.0.9_rollup@4.59.0:
     resolution: {integrity: sha512-PIR4/OHZ79romx0BVVll/PkwWpJ7e5lsqFa3gFfcrFPWwLXLV39JVUzQV9RKjWerE7B845Hqjj9VYlQeieZ2dA==}
     engines: {node: '>=16.0.0 || 14 >= 14.17'}
     peerDependencies:
@@ -4037,17 +4048,17 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.3.0_rollup@4.57.1
+      '@rollup/pluginutils': 5.3.0_rollup@4.59.0
       commondir: 1.0.1
       estree-walker: 2.0.2
       fdir: 6.5.0_picomatch@4.0.3
       is-reference: 1.2.1
       magic-string: 0.30.21
       picomatch: 4.0.3
-      rollup: 4.57.1
+      rollup: 4.59.0
     dev: false
 
-  /@rollup/plugin-json/6.1.0_rollup@4.57.1:
+  /@rollup/plugin-json/6.1.0_rollup@4.59.0:
     resolution: {integrity: sha512-EGI2te5ENk1coGeADSIwZ7G2Q8CJS2sF120T7jLw4xFw9n7wIOXHo+kIYRAoVpJAN+kmqZSoO3Fp4JtoNF4ReA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -4056,11 +4067,11 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.3.0_rollup@4.57.1
-      rollup: 4.57.1
+      '@rollup/pluginutils': 5.3.0_rollup@4.59.0
+      rollup: 4.59.0
     dev: false
 
-  /@rollup/plugin-node-resolve/16.0.3_rollup@4.57.1:
+  /@rollup/plugin-node-resolve/16.0.3_rollup@4.59.0:
     resolution: {integrity: sha512-lUYM3UBGuM93CnMPG1YocWu7X802BrNF3jW2zny5gQyLQgRFJhV1Sq0Zi74+dh/6NBx1DxFC4b4GXg9wUCG5Qg==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -4069,15 +4080,15 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.3.0_rollup@4.57.1
+      '@rollup/pluginutils': 5.3.0_rollup@4.59.0
       '@types/resolve': 1.20.2
       deepmerge: 4.3.1
       is-module: 1.0.0
       resolve: 1.22.11
-      rollup: 4.57.1
+      rollup: 4.59.0
     dev: false
 
-  /@rollup/plugin-typescript/12.3.0_mmrlxa3go2doaxiivy5r4eo3gi:
+  /@rollup/plugin-typescript/12.3.0_w4dj76agps3wlyy4rfyqfgfdtm:
     resolution: {integrity: sha512-7DP0/p7y3t67+NabT9f8oTBFE6gGkto4SA6Np2oudYmZE/m1dt8RB0SjL1msMxFpLo631qjRCcBlAbq1ml/Big==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -4090,14 +4101,14 @@ packages:
       tslib:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.3.0_rollup@4.57.1
+      '@rollup/pluginutils': 5.3.0_rollup@4.59.0
       resolve: 1.22.11
-      rollup: 4.57.1
+      rollup: 4.59.0
       tslib: 2.8.1
       typescript: 4.9.5
     dev: false
 
-  /@rollup/pluginutils/5.3.0_rollup@4.57.1:
+  /@rollup/pluginutils/5.3.0_rollup@4.59.0:
     resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -4109,203 +4120,203 @@ packages:
       '@types/estree': 1.0.8
       estree-walker: 2.0.2
       picomatch: 4.0.3
-      rollup: 4.57.1
+      rollup: 4.59.0
     dev: false
 
-  /@rollup/rollup-android-arm-eabi/4.57.1:
-    resolution: {integrity: sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==}
+  /@rollup/rollup-android-arm-eabi/4.59.0:
+    resolution: {integrity: sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==}
     cpu: [arm]
     os: [android]
     requiresBuild: true
     dev: false
     optional: true
 
-  /@rollup/rollup-android-arm64/4.57.1:
-    resolution: {integrity: sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==}
+  /@rollup/rollup-android-arm64/4.59.0:
+    resolution: {integrity: sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==}
     cpu: [arm64]
     os: [android]
     requiresBuild: true
     dev: false
     optional: true
 
-  /@rollup/rollup-darwin-arm64/4.57.1:
-    resolution: {integrity: sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==}
+  /@rollup/rollup-darwin-arm64/4.59.0:
+    resolution: {integrity: sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
     dev: false
     optional: true
 
-  /@rollup/rollup-darwin-x64/4.57.1:
-    resolution: {integrity: sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==}
+  /@rollup/rollup-darwin-x64/4.59.0:
+    resolution: {integrity: sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
     dev: false
     optional: true
 
-  /@rollup/rollup-freebsd-arm64/4.57.1:
-    resolution: {integrity: sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==}
+  /@rollup/rollup-freebsd-arm64/4.59.0:
+    resolution: {integrity: sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==}
     cpu: [arm64]
     os: [freebsd]
     requiresBuild: true
     dev: false
     optional: true
 
-  /@rollup/rollup-freebsd-x64/4.57.1:
-    resolution: {integrity: sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==}
+  /@rollup/rollup-freebsd-x64/4.59.0:
+    resolution: {integrity: sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==}
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
     dev: false
     optional: true
 
-  /@rollup/rollup-linux-arm-gnueabihf/4.57.1:
-    resolution: {integrity: sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==}
+  /@rollup/rollup-linux-arm-gnueabihf/4.59.0:
+    resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
     cpu: [arm]
     os: [linux]
     requiresBuild: true
     dev: false
     optional: true
 
-  /@rollup/rollup-linux-arm-musleabihf/4.57.1:
-    resolution: {integrity: sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==}
+  /@rollup/rollup-linux-arm-musleabihf/4.59.0:
+    resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
     cpu: [arm]
     os: [linux]
     requiresBuild: true
     dev: false
     optional: true
 
-  /@rollup/rollup-linux-arm64-gnu/4.57.1:
-    resolution: {integrity: sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==}
+  /@rollup/rollup-linux-arm64-gnu/4.59.0:
+    resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     dev: false
     optional: true
 
-  /@rollup/rollup-linux-arm64-musl/4.57.1:
-    resolution: {integrity: sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==}
+  /@rollup/rollup-linux-arm64-musl/4.59.0:
+    resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     dev: false
     optional: true
 
-  /@rollup/rollup-linux-loong64-gnu/4.57.1:
-    resolution: {integrity: sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==}
+  /@rollup/rollup-linux-loong64-gnu/4.59.0:
+    resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
     cpu: [loong64]
     os: [linux]
     requiresBuild: true
     dev: false
     optional: true
 
-  /@rollup/rollup-linux-loong64-musl/4.57.1:
-    resolution: {integrity: sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==}
+  /@rollup/rollup-linux-loong64-musl/4.59.0:
+    resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
     cpu: [loong64]
     os: [linux]
     requiresBuild: true
     dev: false
     optional: true
 
-  /@rollup/rollup-linux-ppc64-gnu/4.57.1:
-    resolution: {integrity: sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==}
+  /@rollup/rollup-linux-ppc64-gnu/4.59.0:
+    resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
     dev: false
     optional: true
 
-  /@rollup/rollup-linux-ppc64-musl/4.57.1:
-    resolution: {integrity: sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==}
+  /@rollup/rollup-linux-ppc64-musl/4.59.0:
+    resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
     dev: false
     optional: true
 
-  /@rollup/rollup-linux-riscv64-gnu/4.57.1:
-    resolution: {integrity: sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==}
+  /@rollup/rollup-linux-riscv64-gnu/4.59.0:
+    resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
     dev: false
     optional: true
 
-  /@rollup/rollup-linux-riscv64-musl/4.57.1:
-    resolution: {integrity: sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==}
+  /@rollup/rollup-linux-riscv64-musl/4.59.0:
+    resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
     dev: false
     optional: true
 
-  /@rollup/rollup-linux-s390x-gnu/4.57.1:
-    resolution: {integrity: sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==}
+  /@rollup/rollup-linux-s390x-gnu/4.59.0:
+    resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
     dev: false
     optional: true
 
-  /@rollup/rollup-linux-x64-gnu/4.57.1:
-    resolution: {integrity: sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==}
+  /@rollup/rollup-linux-x64-gnu/4.59.0:
+    resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     dev: false
     optional: true
 
-  /@rollup/rollup-linux-x64-musl/4.57.1:
-    resolution: {integrity: sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==}
+  /@rollup/rollup-linux-x64-musl/4.59.0:
+    resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     dev: false
     optional: true
 
-  /@rollup/rollup-openbsd-x64/4.57.1:
-    resolution: {integrity: sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==}
+  /@rollup/rollup-openbsd-x64/4.59.0:
+    resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
     cpu: [x64]
     os: [openbsd]
     requiresBuild: true
     dev: false
     optional: true
 
-  /@rollup/rollup-openharmony-arm64/4.57.1:
-    resolution: {integrity: sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==}
+  /@rollup/rollup-openharmony-arm64/4.59.0:
+    resolution: {integrity: sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==}
     cpu: [arm64]
     os: [openharmony]
     requiresBuild: true
     dev: false
     optional: true
 
-  /@rollup/rollup-win32-arm64-msvc/4.57.1:
-    resolution: {integrity: sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==}
+  /@rollup/rollup-win32-arm64-msvc/4.59.0:
+    resolution: {integrity: sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==}
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
     dev: false
     optional: true
 
-  /@rollup/rollup-win32-ia32-msvc/4.57.1:
-    resolution: {integrity: sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==}
+  /@rollup/rollup-win32-ia32-msvc/4.59.0:
+    resolution: {integrity: sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==}
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
     dev: false
     optional: true
 
-  /@rollup/rollup-win32-x64-gnu/4.57.1:
-    resolution: {integrity: sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==}
+  /@rollup/rollup-win32-x64-gnu/4.59.0:
+    resolution: {integrity: sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
     dev: false
     optional: true
 
-  /@rollup/rollup-win32-x64-msvc/4.57.1:
-    resolution: {integrity: sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==}
+  /@rollup/rollup-win32-x64-msvc/4.59.0:
+    resolution: {integrity: sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
@@ -4413,8 +4424,8 @@ packages:
       tslib: 2.8.1
     dev: true
 
-  /@smithy/core/3.23.2:
-    resolution: {integrity: sha512-HaaH4VbGie4t0+9nY3tNBRSxVTr96wzIqexUa6C2qx3MPePAuz7lIxPxYtt1Wc//SPfJLNoZJzfdt0B6ksj2jA==}
+  /@smithy/core/3.23.3:
+    resolution: {integrity: sha512-5IETfbqrTuGs0fC22ZnTW6df+PHlrWpSbAbySzTozsUROWPiOXDIWt1Y4dCDzhJUQ6H3ig/dFOZaEeLsTjNGRQ==}
     engines: {node: '>=18.0.0'}
     dependencies:
       '@smithy/middleware-serde': 4.2.9
@@ -4423,7 +4434,7 @@ packages:
       '@smithy/util-base64': 4.3.0
       '@smithy/util-body-length-browser': 4.2.0
       '@smithy/util-middleware': 4.2.8
-      '@smithy/util-stream': 4.5.12
+      '@smithy/util-stream': 4.5.13
       '@smithy/util-utf8': 4.2.0
       '@smithy/uuid': 1.1.0
       tslib: 2.8.1
@@ -4565,11 +4576,11 @@ packages:
       tslib: 2.8.1
     dev: true
 
-  /@smithy/middleware-endpoint/4.4.16:
-    resolution: {integrity: sha512-L5GICFCSsNhbJ5JSKeWFGFy16Q2OhoBizb3X2DrxaJwXSEujVvjG9Jt386dpQn2t7jINglQl0b4K/Su69BdbMA==}
+  /@smithy/middleware-endpoint/4.4.17:
+    resolution: {integrity: sha512-QP8wuZ7iSNEQ4/HyihTHlDUlQ3eBrCo+HoMm8l2gPcNrR4TA1RCC10jR7IyCnn3ASTrUwEnRaQ062vFC2/eYJw==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      '@smithy/core': 3.23.2
+      '@smithy/core': 3.23.3
       '@smithy/middleware-serde': 4.2.9
       '@smithy/node-config-provider': 4.3.8
       '@smithy/shared-ini-file-loader': 4.4.3
@@ -4579,14 +4590,14 @@ packages:
       tslib: 2.8.1
     dev: true
 
-  /@smithy/middleware-retry/4.4.33:
-    resolution: {integrity: sha512-jLqZOdJhtIL4lnA9hXnAG6GgnJlo1sD3FqsTxm9wSfjviqgWesY/TMBVnT84yr4O0Vfe0jWoXlfFbzsBVph3WA==}
+  /@smithy/middleware-retry/4.4.34:
+    resolution: {integrity: sha512-ROmCX/ev7ryOzgsQ6dnJ46gbVSrvR2HX7ioxkfXlrgfKEMMOUCWgl/OMOi7PZn95CXTxMMNJTbP3nkvWGFTz+w==}
     engines: {node: '>=18.0.0'}
     dependencies:
       '@smithy/node-config-provider': 4.3.8
       '@smithy/protocol-http': 5.3.8
       '@smithy/service-error-classification': 4.2.8
-      '@smithy/smithy-client': 4.11.5
+      '@smithy/smithy-client': 4.11.6
       '@smithy/types': 4.12.0
       '@smithy/util-middleware': 4.2.8
       '@smithy/util-retry': 4.2.8
@@ -4694,16 +4705,16 @@ packages:
       tslib: 2.8.1
     dev: true
 
-  /@smithy/smithy-client/4.11.5:
-    resolution: {integrity: sha512-xixwBRqoeP2IUgcAl3U9dvJXc+qJum4lzo3maaJxifsZxKUYLfVfCXvhT4/jD01sRrHg5zjd1cw2Zmjr4/SuKQ==}
+  /@smithy/smithy-client/4.11.6:
+    resolution: {integrity: sha512-g9FNlCTfQzkSpHW3ILOm+TWZfXuOj2UcrNWNBHLnY3Ch+67mLVmiu3fGWPWbs1XiRK174q5tGphnPCTHvImQUA==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      '@smithy/core': 3.23.2
-      '@smithy/middleware-endpoint': 4.4.16
+      '@smithy/core': 3.23.3
+      '@smithy/middleware-endpoint': 4.4.17
       '@smithy/middleware-stack': 4.2.8
       '@smithy/protocol-http': 5.3.8
       '@smithy/types': 4.12.0
-      '@smithy/util-stream': 4.5.12
+      '@smithy/util-stream': 4.5.13
       tslib: 2.8.1
     dev: true
 
@@ -4769,25 +4780,25 @@ packages:
       tslib: 2.8.1
     dev: true
 
-  /@smithy/util-defaults-mode-browser/4.3.32:
-    resolution: {integrity: sha512-092sjYfFMQ/iaPH798LY/OJFBcYu0sSK34Oy9vdixhsU36zlZu8OcYjF3TD4e2ARupyK7xaxPXl+T0VIJTEkkg==}
+  /@smithy/util-defaults-mode-browser/4.3.33:
+    resolution: {integrity: sha512-VutP/lyBWaTNUzNjI+NC3Kwts4Grhb8CTUyGZNQadf5lujqNy2IIM739D31qplSdbxqYBLOPvMXwy4CIKOArrg==}
     engines: {node: '>=18.0.0'}
     dependencies:
       '@smithy/property-provider': 4.2.8
-      '@smithy/smithy-client': 4.11.5
+      '@smithy/smithy-client': 4.11.6
       '@smithy/types': 4.12.0
       tslib: 2.8.1
     dev: true
 
-  /@smithy/util-defaults-mode-node/4.2.35:
-    resolution: {integrity: sha512-miz/ggz87M8VuM29y7jJZMYkn7+IErM5p5UgKIf8OtqVs/h2bXr1Bt3uTsREsI/4nK8a0PQERbAPsVPVNIsG7Q==}
+  /@smithy/util-defaults-mode-node/4.2.36:
+    resolution: {integrity: sha512-x73FjvOgG8XBtxu4auMnMDhLi6bUVBLHgNAv8xU0noDGks0KF59JNSzgVQ0oOSuf/D6pVJ5tMEkajwz6IavBUg==}
     engines: {node: '>=18.0.0'}
     dependencies:
       '@smithy/config-resolver': 4.4.6
       '@smithy/credential-provider-imds': 4.2.8
       '@smithy/node-config-provider': 4.3.8
       '@smithy/property-provider': 4.2.8
-      '@smithy/smithy-client': 4.11.5
+      '@smithy/smithy-client': 4.11.6
       '@smithy/types': 4.12.0
       tslib: 2.8.1
     dev: true
@@ -4825,8 +4836,8 @@ packages:
       tslib: 2.8.1
     dev: true
 
-  /@smithy/util-stream/4.5.12:
-    resolution: {integrity: sha512-D8tgkrmhAX/UNeCZbqbEO3uqyghUnEmmoO9YEvRuwxjlkKKUE7FOgCJnqpTlQPe9MApdWPky58mNQQHbnCzoNg==}
+  /@smithy/util-stream/4.5.13:
+    resolution: {integrity: sha512-ZJQh++mmjO7JiWAW4SdWFrsde1VE038g4uGtkTlvCGcpytMLsxIAg9o9blorLYaQG47EfY9QjLP38od88NLL8w==}
     engines: {node: '>=18.0.0'}
     dependencies:
       '@smithy/fetch-http-handler': 5.3.9
@@ -4919,11 +4930,11 @@ packages:
       - typescript
     dev: true
 
-  /@stylistic/eslint-plugin/5.8.0_eslint@8.57.1:
-    resolution: {integrity: sha512-WNPVF/FfBAjyi3OA7gok8swRiImNLKI4dmV3iK/GC/0xSJR7eCzBFsw9hLZVgb1+MYNLy7aDsjohxN1hA/FIfQ==}
+  /@stylistic/eslint-plugin/5.9.0_eslint@8.57.1:
+    resolution: {integrity: sha512-FqqSkvDMYJReydrMhlugc71M76yLLQWNfmGq+SIlLa7N3kHp8Qq8i2PyWrVNAfjOyOIY+xv9XaaYwvVW7vroMA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      eslint: '>=9.0.0'
+      eslint: ^9.0.0 || ^10.0.0
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1_eslint@8.57.1
       '@typescript-eslint/types': 8.56.0
@@ -5121,8 +5132,8 @@ packages:
     resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
     dev: true
 
-  /@types/lodash/4.17.23:
-    resolution: {integrity: sha512-RDvF6wTulMPjrNdCoYRC8gNR880JNGT8uB+REUpC2Ns4pRqQJhGz90wh7rgdXDPpCczF3VGktDuFGVnz8zP7HA==}
+  /@types/lodash/4.17.24:
+    resolution: {integrity: sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==}
 
   /@types/markdown-it/14.1.2:
     resolution: {integrity: sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==}
@@ -5143,7 +5154,7 @@ packages:
     resolution: {integrity: sha512-zmPitbQ8+6zNutpwgcQuLcsEpn/Cj54Kbn7L5pX0Os5kdWplB7xPgEh/g+SWOB/qmows2gpuCaPyduq8ZZRnxA==}
     deprecated: This is a stub types definition. minimatch provides its own type definitions, so you do not need this installed.
     dependencies:
-      minimatch: 10.2.1
+      minimatch: 10.2.2
     dev: true
 
   /@types/mkdirp/1.0.2:
@@ -5786,7 +5797,7 @@ packages:
       debug: 4.4.3
       globby: 11.1.0
       is-glob: 4.0.3
-      minimatch: 9.0.5
+      minimatch: 9.0.6
       semver: 7.7.4
       ts-api-utils: 1.4.3_typescript@4.9.5
       typescript: 4.9.5
@@ -5808,7 +5819,7 @@ packages:
       debug: 4.4.3
       globby: 11.1.0
       is-glob: 4.0.3
-      minimatch: 9.0.5
+      minimatch: 9.0.6
       semver: 7.7.4
       ts-api-utils: 1.4.3_typescript@5.9.3
       typescript: 5.9.3
@@ -5827,7 +5838,7 @@ packages:
       '@typescript-eslint/types': 8.56.0
       '@typescript-eslint/visitor-keys': 8.56.0
       debug: 4.4.3
-      minimatch: 9.0.5
+      minimatch: 9.0.6
       semver: 7.7.4
       tinyglobby: 0.2.15
       ts-api-utils: 2.4.0_typescript@4.9.5
@@ -5847,7 +5858,7 @@ packages:
       '@typescript-eslint/types': 8.56.0
       '@typescript-eslint/visitor-keys': 8.56.0
       debug: 4.4.3
-      minimatch: 9.0.5
+      minimatch: 9.0.6
       semver: 7.7.4
       tinyglobby: 0.2.15
       ts-api-utils: 2.4.0_typescript@5.9.3
@@ -6009,7 +6020,7 @@ packages:
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     dependencies:
       '@typescript-eslint/types': 8.56.0
-      eslint-visitor-keys: 5.0.0
+      eslint-visitor-keys: 5.0.1
     dev: true
 
   /@ungap/structured-clone/1.3.0:
@@ -6222,19 +6233,19 @@ packages:
       acorn: 7.4.1
     dev: true
 
-  /acorn-jsx/5.3.2_acorn@8.15.0:
+  /acorn-jsx/5.3.2_acorn@8.16.0:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      acorn: 8.15.0
+      acorn: 8.16.0
     dev: true
 
-  /acorn-walk/8.3.4:
-    resolution: {integrity: sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==}
+  /acorn-walk/8.3.5:
+    resolution: {integrity: sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==}
     engines: {node: '>=0.4.0'}
     dependencies:
-      acorn: 8.15.0
+      acorn: 8.16.0
     dev: true
 
   /acorn/7.4.1:
@@ -6243,8 +6254,8 @@ packages:
     hasBin: true
     dev: true
 
-  /acorn/8.15.0:
-    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
+  /acorn/8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
     dev: true
@@ -6271,8 +6282,8 @@ packages:
       ajv: 8.18.0
     dev: false
 
-  /ajv/6.12.6:
-    resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
+  /ajv/6.14.0:
+    resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
     dependencies:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
@@ -6695,17 +6706,19 @@ packages:
 
   /balanced-match/1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+    dev: true
 
-  /balanced-match/4.0.3:
-    resolution: {integrity: sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g==}
-    engines: {node: 20 || >=22}
+  /balanced-match/4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
 
   /base64-js/1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
     dev: false
 
-  /baseline-browser-mapping/2.9.19:
-    resolution: {integrity: sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==}
+  /baseline-browser-mapping/2.10.0:
+    resolution: {integrity: sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==}
+    engines: {node: '>=6.0.0'}
     hasBin: true
     dev: true
 
@@ -6771,12 +6784,13 @@ packages:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
     dependencies:
       balanced-match: 1.0.2
+    dev: true
 
-  /brace-expansion/5.0.2:
-    resolution: {integrity: sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==}
-    engines: {node: 20 || >=22}
+  /brace-expansion/5.0.3:
+    resolution: {integrity: sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==}
+    engines: {node: 18 || 20 || >=22}
     dependencies:
-      balanced-match: 4.0.3
+      balanced-match: 4.0.4
 
   /braces/3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -6800,9 +6814,9 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
     dependencies:
-      baseline-browser-mapping: 2.9.19
-      caniuse-lite: 1.0.30001770
-      electron-to-chromium: 1.5.286
+      baseline-browser-mapping: 2.10.0
+      caniuse-lite: 1.0.30001774
+      electron-to-chromium: 1.5.302
       node-releases: 2.0.27
       update-browserslist-db: 1.2.3_browserslist@4.28.1
     dev: true
@@ -6933,8 +6947,8 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /caniuse-lite/1.0.30001770:
-    resolution: {integrity: sha512-x/2CLQ1jHENRbHg5PSId2sXq1CIO1CISvwWAj027ltMVG2UNgW+w9oH2+HzgEIRFembL8bUlXtfbBHR1fCg2xw==}
+  /caniuse-lite/1.0.30001774:
+    resolution: {integrity: sha512-DDdwPGz99nmIEv216hKSgLD+D4ikHQHjBC/seF98N9CPqRX4M5mSxT9eTV6oyisnJcuzxtZy4n17yKKQYmYQOA==}
     dev: true
 
   /capital-case/1.0.4:
@@ -7370,7 +7384,7 @@ packages:
     resolution: {integrity: sha512-NUe1Yz+NwmNJHTbSMr0tJ4YrerhHSaHPgptXFGxhTQkHG1d/2JDmjGeKocpA5ffO/x9JhgJmzrki+V4BsyQN4A==}
     engines: {node: '>= 10.14.2'}
     dependencies:
-      '@contentstack/utils': 1.7.0
+      '@contentstack/utils': 1.7.1
       es6-promise: 4.2.8
       husky: 9.1.7
       localStorage: 1.0.4
@@ -7789,8 +7803,8 @@ packages:
     dependencies:
       jake: 10.9.4
 
-  /electron-to-chromium/1.5.286:
-    resolution: {integrity: sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==}
+  /electron-to-chromium/1.5.302:
+    resolution: {integrity: sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==}
     dev: true
 
   /elegant-spinner/1.0.1:
@@ -8092,13 +8106,13 @@ packages:
       - eslint
     dev: true
 
-  /eslint-config-oclif/6.0.140_avq3eyf5kaj6ssrwo7fvkrwnji:
-    resolution: {integrity: sha512-e+tZJ+PM+keWV/yZoaURDH8i2jIpvQD28She9Sz4x6+zHUQjRw13AR78NDeI+HdfixDuTrlPI2eTxYWxmpg7FQ==}
+  /eslint-config-oclif/6.0.144_avq3eyf5kaj6ssrwo7fvkrwnji:
+    resolution: {integrity: sha512-87Zn12V0wnkxPSsm9TdIyZ4v5uNceqjMilyyR8Snk/oxCtOaawy/6mU1DwzS1zv4tnspZgeLJn+Y1ZI8Mf7BQw==}
     engines: {node: '>=18.18.0'}
     dependencies:
       '@eslint/compat': 1.4.1_eslint@8.57.1
       '@eslint/eslintrc': 3.3.3
-      '@eslint/js': 9.39.2
+      '@eslint/js': 9.39.3
       '@stylistic/eslint-plugin': 3.1.0_avq3eyf5kaj6ssrwo7fvkrwnji
       '@typescript-eslint/eslint-plugin': 8.56.0_jerijdkviegrghngx23wa33wga
       '@typescript-eslint/parser': 8.56.0_avq3eyf5kaj6ssrwo7fvkrwnji
@@ -8121,13 +8135,13 @@ packages:
       - typescript
     dev: true
 
-  /eslint-config-oclif/6.0.140_k2rwabtyo525wwqr6566umnmhy:
-    resolution: {integrity: sha512-e+tZJ+PM+keWV/yZoaURDH8i2jIpvQD28She9Sz4x6+zHUQjRw13AR78NDeI+HdfixDuTrlPI2eTxYWxmpg7FQ==}
+  /eslint-config-oclif/6.0.144_k2rwabtyo525wwqr6566umnmhy:
+    resolution: {integrity: sha512-87Zn12V0wnkxPSsm9TdIyZ4v5uNceqjMilyyR8Snk/oxCtOaawy/6mU1DwzS1zv4tnspZgeLJn+Y1ZI8Mf7BQw==}
     engines: {node: '>=18.18.0'}
     dependencies:
       '@eslint/compat': 1.4.1_eslint@8.57.1
       '@eslint/eslintrc': 3.3.3
-      '@eslint/js': 9.39.2
+      '@eslint/js': 9.39.3
       '@stylistic/eslint-plugin': 3.1.0_k2rwabtyo525wwqr6566umnmhy
       '@typescript-eslint/eslint-plugin': 8.56.0_7s7xby5jeagacgd2hmnr4oz5f4
       '@typescript-eslint/parser': 8.56.0_k2rwabtyo525wwqr6566umnmhy
@@ -8178,7 +8192,7 @@ packages:
     dependencies:
       '@eslint/css': 0.10.0
       '@eslint/json': 0.13.2
-      '@stylistic/eslint-plugin': 5.8.0_eslint@8.57.1
+      '@stylistic/eslint-plugin': 5.9.0_eslint@8.57.1
       confusing-browser-globals: 1.0.11
       eslint: 8.57.1
       globals: 16.5.0
@@ -8327,7 +8341,7 @@ packages:
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
-      minimatch: 3.1.2
+      minimatch: 3.1.3
       object.fromentries: 2.0.8
       object.groupby: 1.0.3
       object.values: 1.2.1
@@ -8364,7 +8378,7 @@ packages:
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
-      minimatch: 3.1.2
+      minimatch: 3.1.3
       object.fromentries: 2.0.8
       object.groupby: 1.0.3
       object.values: 1.2.1
@@ -8422,7 +8436,7 @@ packages:
       eslint-utils: 3.0.0_eslint@8.57.1
       ignore: 5.3.2
       is-core-module: 2.16.1
-      minimatch: 3.1.2
+      minimatch: 3.1.3
       resolve: 1.22.11
       semver: 7.7.4
     dev: true
@@ -8487,7 +8501,7 @@ packages:
     dependencies:
       '@typescript-eslint/utils': 7.18.0_avq3eyf5kaj6ssrwo7fvkrwnji
       eslint: 8.57.1
-      minimatch: 9.0.5
+      minimatch: 9.0.6
       natural-compare-lite: 1.4.0
     transitivePeerDependencies:
       - supports-color
@@ -8514,7 +8528,7 @@ packages:
     dependencies:
       '@typescript-eslint/utils': 7.18.0_k2rwabtyo525wwqr6566umnmhy
       eslint: 8.57.1
-      minimatch: 9.0.5
+      minimatch: 9.0.6
       natural-compare-lite: 1.4.0
     transitivePeerDependencies:
       - supports-color
@@ -8661,8 +8675,8 @@ packages:
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     dev: true
 
-  /eslint-visitor-keys/5.0.0:
-    resolution: {integrity: sha512-A0XeIi7CXU7nPlfHS9loMYEKxUaONu/hTEzHTGba9Huu94Cq1hPivf+DE5erJozZOky0LfvXAyrV/tcswpLI0Q==}
+  /eslint-visitor-keys/5.0.1:
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
     dev: true
 
@@ -8675,7 +8689,7 @@ packages:
       '@babel/code-frame': 7.12.11
       '@eslint/eslintrc': 0.4.3
       '@humanwhocodes/config-array': 0.5.0
-      ajv: 6.12.6
+      ajv: 6.14.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
       debug: 4.4.3
@@ -8701,7 +8715,7 @@ packages:
       json-stable-stringify-without-jsonify: 1.0.1
       levn: 0.4.1
       lodash.merge: 4.6.2
-      minimatch: 3.1.2
+      minimatch: 3.1.3
       natural-compare: 1.4.0
       optionator: 0.9.4
       progress: 2.0.3
@@ -8730,7 +8744,7 @@ packages:
       '@humanwhocodes/module-importer': 1.0.1
       '@nodelib/fs.walk': 1.2.8
       '@ungap/structured-clone': 1.3.0
-      ajv: 6.12.6
+      ajv: 6.14.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
       debug: 4.4.3
@@ -8755,7 +8769,7 @@ packages:
       json-stable-stringify-without-jsonify: 1.0.1
       levn: 0.4.1
       lodash.merge: 4.6.2
-      minimatch: 3.1.2
+      minimatch: 3.1.3
       natural-compare: 1.4.0
       optionator: 0.9.4
       strip-ansi: 6.0.1
@@ -8764,8 +8778,8 @@ packages:
       - supports-color
     dev: true
 
-  /eslint/9.39.2:
-    resolution: {integrity: sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==}
+  /eslint/9.39.3:
+    resolution: {integrity: sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     hasBin: true
     peerDependencies:
@@ -8774,19 +8788,19 @@ packages:
       jiti:
         optional: true
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1_eslint@9.39.2
+      '@eslint-community/eslint-utils': 4.9.1_eslint@9.39.3
       '@eslint-community/regexpp': 4.12.2
       '@eslint/config-array': 0.21.1
       '@eslint/config-helpers': 0.4.2
       '@eslint/core': 0.17.0
       '@eslint/eslintrc': 3.3.3
-      '@eslint/js': 9.39.2
+      '@eslint/js': 9.39.3
       '@eslint/plugin-kit': 0.4.1
       '@humanfs/node': 0.16.7
       '@humanwhocodes/module-importer': 1.0.1
       '@humanwhocodes/retry': 0.4.3
       '@types/estree': 1.0.8
-      ajv: 6.12.6
+      ajv: 6.14.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
       debug: 4.4.3
@@ -8805,7 +8819,7 @@ packages:
       is-glob: 4.0.3
       json-stable-stringify-without-jsonify: 1.0.1
       lodash.merge: 4.6.2
-      minimatch: 3.1.2
+      minimatch: 3.1.3
       natural-compare: 1.4.0
       optionator: 0.9.4
     transitivePeerDependencies:
@@ -8816,8 +8830,8 @@ packages:
     resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     dependencies:
-      acorn: 8.15.0
-      acorn-jsx: 5.3.2_acorn@8.15.0
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2_acorn@8.16.0
       eslint-visitor-keys: 4.2.1
     dev: true
 
@@ -8834,8 +8848,8 @@ packages:
     resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
-      acorn: 8.15.0
-      acorn-jsx: 5.3.2_acorn@8.15.0
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2_acorn@8.16.0
       eslint-visitor-keys: 3.4.3
     dev: true
 
@@ -8985,7 +8999,7 @@ packages:
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     dependencies:
       '@types/chai': 4.3.20
-      '@types/lodash': 4.17.23
+      '@types/lodash': 4.17.24
       '@types/node': 20.19.33
       '@types/sinon': 10.0.20
       lodash: 4.17.23
@@ -9121,10 +9135,11 @@ packages:
       glob: 7.2.3
     dev: true
 
-  /filelist/1.0.4:
-    resolution: {integrity: sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==}
+  /filelist/1.0.5:
+    resolution: {integrity: sha512-ct/ckWBV/9Dg3MlvCXsLcSUyoWwv9mCKqlhLNB2DAuXR/NZolSXlQqP5dyy6guWlPXBhodZyZ5lGPQcbQDxrEQ==}
+    engines: {node: 20 || >=22}
     dependencies:
-      minimatch: 5.1.6
+      minimatch: 10.2.2
 
   /fill-range/7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
@@ -9490,19 +9505,19 @@ packages:
     dependencies:
       foreground-child: 3.3.1
       jackspeak: 3.4.3
-      minimatch: 9.0.5
+      minimatch: 9.0.6
       minipass: 7.1.3
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
     dev: true
 
-  /glob/13.0.5:
-    resolution: {integrity: sha512-BzXxZg24Ibra1pbQ/zE7Kys4Ua1ks7Bn6pKLkVPZ9FZe4JQS6/Q7ef3LG1H+k7lUf5l4T3PLSyYyYJVYUvfgTw==}
-    engines: {node: 20 || >=22}
+  /glob/13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
     dependencies:
-      minimatch: 10.2.1
+      minimatch: 10.2.2
       minipass: 7.1.3
-      path-scurry: 2.0.1
+      path-scurry: 2.0.2
     dev: false
 
   /glob/7.2.3:
@@ -9512,7 +9527,7 @@ packages:
       fs.realpath: 1.0.0
       inflight: 1.0.6
       inherits: 2.0.4
-      minimatch: 3.1.2
+      minimatch: 3.1.3
       once: 1.4.0
       path-is-absolute: 1.0.1
     dev: true
@@ -9525,7 +9540,7 @@ packages:
       fs.realpath: 1.0.0
       inflight: 1.0.6
       inherits: 2.0.4
-      minimatch: 5.1.6
+      minimatch: 5.1.7
       once: 1.4.0
     dev: true
 
@@ -10443,7 +10458,7 @@ packages:
     hasBin: true
     dependencies:
       async: 3.2.6
-      filelist: 1.0.4
+      filelist: 1.0.5
       picocolors: 1.1.1
 
   /jest-changed-files/29.7.0:
@@ -10989,7 +11004,7 @@ packages:
     hasBin: true
     dependencies:
       '@babel/parser': 7.29.0
-      '@jsdoc/salty': 0.2.9
+      '@jsdoc/salty': 0.2.10
       '@types/markdown-it': 14.1.2
       bluebird: 3.7.2
       catharsis: 0.9.0
@@ -11002,7 +11017,7 @@ packages:
       mkdirp: 1.0.4
       requizzle: 0.2.4
       strip-json-comments: 3.1.1
-      underscore: 1.13.7
+      underscore: 1.13.8
     dev: true
 
   /jsesc/0.5.0:
@@ -11519,23 +11534,24 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
-  /minimatch/10.2.1:
-    resolution: {integrity: sha512-MClCe8IL5nRRmawL6ib/eT4oLyeKMGCghibcDWK+J0hh0Q8kqSdia6BvbRMVk6mPa6WqUa5uR2oxt6C5jd533A==}
-    engines: {node: 20 || >=22}
+  /minimatch/10.2.2:
+    resolution: {integrity: sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==}
+    engines: {node: 18 || 20 || >=22}
     dependencies:
-      brace-expansion: 5.0.2
+      brace-expansion: 5.0.3
 
-  /minimatch/3.1.2:
-    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
+  /minimatch/3.1.3:
+    resolution: {integrity: sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==}
     dependencies:
       brace-expansion: 1.1.12
     dev: true
 
-  /minimatch/5.1.6:
-    resolution: {integrity: sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==}
+  /minimatch/5.1.7:
+    resolution: {integrity: sha512-FjiwU9HaHW6YB3H4a1sFudnv93lvydNjz2lmyUXR6IwKhGI+bgL3SOZrBGn6kvvX2pJvhEkGSGjyTHN47O4rqA==}
     engines: {node: '>=10'}
     dependencies:
       brace-expansion: 2.0.2
+    dev: true
 
   /minimatch/9.0.3:
     resolution: {integrity: sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==}
@@ -11544,11 +11560,12 @@ packages:
       brace-expansion: 2.0.2
     dev: true
 
-  /minimatch/9.0.5:
-    resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
+  /minimatch/9.0.6:
+    resolution: {integrity: sha512-kQAVowdR33euIqeA0+VZTDqU+qo1IeVY+hrKYtZMio3Pg0P0vuh/kwRylLUddJhB6pf3q/botcOvRtx4IN1wqQ==}
     engines: {node: '>=16 || 14 >=14.17'}
     dependencies:
-      brace-expansion: 2.0.2
+      brace-expansion: 5.0.3
+    dev: true
 
   /minimist/1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
@@ -11600,7 +11617,7 @@ packages:
       he: 1.2.0
       js-yaml: 4.1.1
       log-symbols: 4.1.0
-      minimatch: 5.1.6
+      minimatch: 5.1.7
       ms: 2.1.3
       serialize-javascript: 6.0.2
       strip-json-comments: 3.1.1
@@ -11978,17 +11995,17 @@ packages:
       es-object-atoms: 1.1.1
     dev: true
 
-  /oclif/4.22.79:
-    resolution: {integrity: sha512-yMhiVsMdOOhqNc62ZOehPGNoLIWYc6MUHtb9AVlCgML45Jrfr3NlXi5LiOEOm0Xe37FVNZYiJJJM8O31cYLhdQ==}
+  /oclif/4.22.81:
+    resolution: {integrity: sha512-MO2bupt/3wWYqt05F8ZLwMYKN58YqDfRVdJxAvCdg/wZJg6/sDXVKoMSTSzwqsnIaJGjru2LBNvk8lH+p+1uMQ==}
     engines: {node: '>=18.0.0'}
     hasBin: true
     dependencies:
-      '@aws-sdk/client-cloudfront': 3.993.0
-      '@aws-sdk/client-s3': 3.993.0
+      '@aws-sdk/client-cloudfront': 3.995.0
+      '@aws-sdk/client-s3': 3.995.0
       '@inquirer/confirm': 3.2.0
       '@inquirer/input': 2.3.0
       '@inquirer/select': 2.5.0
-      '@oclif/core': 4.8.0
+      '@oclif/core': 4.8.1
       '@oclif/plugin-help': 6.2.37
       '@oclif/plugin-not-found': 3.2.74
       '@oclif/plugin-warn-if-update-available': 3.1.55
@@ -12013,17 +12030,17 @@ packages:
       - supports-color
     dev: true
 
-  /oclif/4.22.79_@types+node@14.18.63:
-    resolution: {integrity: sha512-yMhiVsMdOOhqNc62ZOehPGNoLIWYc6MUHtb9AVlCgML45Jrfr3NlXi5LiOEOm0Xe37FVNZYiJJJM8O31cYLhdQ==}
+  /oclif/4.22.81_@types+node@14.18.63:
+    resolution: {integrity: sha512-MO2bupt/3wWYqt05F8ZLwMYKN58YqDfRVdJxAvCdg/wZJg6/sDXVKoMSTSzwqsnIaJGjru2LBNvk8lH+p+1uMQ==}
     engines: {node: '>=18.0.0'}
     hasBin: true
     dependencies:
-      '@aws-sdk/client-cloudfront': 3.993.0
-      '@aws-sdk/client-s3': 3.993.0
+      '@aws-sdk/client-cloudfront': 3.995.0
+      '@aws-sdk/client-s3': 3.995.0
       '@inquirer/confirm': 3.2.0
       '@inquirer/input': 2.3.0
       '@inquirer/select': 2.5.0
-      '@oclif/core': 4.8.0
+      '@oclif/core': 4.8.1
       '@oclif/plugin-help': 6.2.37
       '@oclif/plugin-not-found': 3.2.74_@types+node@14.18.63
       '@oclif/plugin-warn-if-update-available': 3.1.55
@@ -12048,17 +12065,17 @@ packages:
       - supports-color
     dev: true
 
-  /oclif/4.22.79_@types+node@20.19.33:
-    resolution: {integrity: sha512-yMhiVsMdOOhqNc62ZOehPGNoLIWYc6MUHtb9AVlCgML45Jrfr3NlXi5LiOEOm0Xe37FVNZYiJJJM8O31cYLhdQ==}
+  /oclif/4.22.81_@types+node@20.19.33:
+    resolution: {integrity: sha512-MO2bupt/3wWYqt05F8ZLwMYKN58YqDfRVdJxAvCdg/wZJg6/sDXVKoMSTSzwqsnIaJGjru2LBNvk8lH+p+1uMQ==}
     engines: {node: '>=18.0.0'}
     hasBin: true
     dependencies:
-      '@aws-sdk/client-cloudfront': 3.993.0
-      '@aws-sdk/client-s3': 3.993.0
+      '@aws-sdk/client-cloudfront': 3.995.0
+      '@aws-sdk/client-s3': 3.995.0
       '@inquirer/confirm': 3.2.0
       '@inquirer/input': 2.3.0
       '@inquirer/select': 2.5.0
-      '@oclif/core': 4.8.0
+      '@oclif/core': 4.8.1
       '@oclif/plugin-help': 6.2.37
       '@oclif/plugin-not-found': 3.2.74_@types+node@20.19.33
       '@oclif/plugin-warn-if-update-available': 3.1.55
@@ -12384,9 +12401,9 @@ packages:
       minipass: 7.1.3
     dev: true
 
-  /path-scurry/2.0.1:
-    resolution: {integrity: sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==}
-    engines: {node: 20 || >=22}
+  /path-scurry/2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
     dependencies:
       lru-cache: 11.2.6
       minipass: 7.1.3
@@ -12587,6 +12604,13 @@ packages:
 
   /qs/6.14.2:
     resolution: {integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==}
+    engines: {node: '>=0.6'}
+    dependencies:
+      side-channel: 1.1.0
+    dev: false
+
+  /qs/6.15.0:
+    resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
     engines: {node: '>=0.6'}
     dependencies:
       side-channel: 1.1.0
@@ -12939,7 +12963,7 @@ packages:
   /rewire/9.0.1:
     resolution: {integrity: sha512-dnbLeTwHpXvWJjswC6CshXUUnnpE5AVhlayVRvDJhJx5ejbO4nbj1IXqN2urErgB7TpHUAMpf6iPDhQIxeSQOQ==}
     dependencies:
-      eslint: 9.39.2
+      eslint: 9.39.3
       pirates: 4.0.7
     transitivePeerDependencies:
       - jiti
@@ -12966,42 +12990,42 @@ packages:
     engines: {node: 20 || >=22}
     hasBin: true
     dependencies:
-      glob: 13.0.5
+      glob: 13.0.6
       package-json-from-dist: 1.0.1
     dev: false
 
-  /rollup/4.57.1:
-    resolution: {integrity: sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==}
+  /rollup/4.59.0:
+    resolution: {integrity: sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
     dependencies:
       '@types/estree': 1.0.8
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.57.1
-      '@rollup/rollup-android-arm64': 4.57.1
-      '@rollup/rollup-darwin-arm64': 4.57.1
-      '@rollup/rollup-darwin-x64': 4.57.1
-      '@rollup/rollup-freebsd-arm64': 4.57.1
-      '@rollup/rollup-freebsd-x64': 4.57.1
-      '@rollup/rollup-linux-arm-gnueabihf': 4.57.1
-      '@rollup/rollup-linux-arm-musleabihf': 4.57.1
-      '@rollup/rollup-linux-arm64-gnu': 4.57.1
-      '@rollup/rollup-linux-arm64-musl': 4.57.1
-      '@rollup/rollup-linux-loong64-gnu': 4.57.1
-      '@rollup/rollup-linux-loong64-musl': 4.57.1
-      '@rollup/rollup-linux-ppc64-gnu': 4.57.1
-      '@rollup/rollup-linux-ppc64-musl': 4.57.1
-      '@rollup/rollup-linux-riscv64-gnu': 4.57.1
-      '@rollup/rollup-linux-riscv64-musl': 4.57.1
-      '@rollup/rollup-linux-s390x-gnu': 4.57.1
-      '@rollup/rollup-linux-x64-gnu': 4.57.1
-      '@rollup/rollup-linux-x64-musl': 4.57.1
-      '@rollup/rollup-openbsd-x64': 4.57.1
-      '@rollup/rollup-openharmony-arm64': 4.57.1
-      '@rollup/rollup-win32-arm64-msvc': 4.57.1
-      '@rollup/rollup-win32-ia32-msvc': 4.57.1
-      '@rollup/rollup-win32-x64-gnu': 4.57.1
-      '@rollup/rollup-win32-x64-msvc': 4.57.1
+      '@rollup/rollup-android-arm-eabi': 4.59.0
+      '@rollup/rollup-android-arm64': 4.59.0
+      '@rollup/rollup-darwin-arm64': 4.59.0
+      '@rollup/rollup-darwin-x64': 4.59.0
+      '@rollup/rollup-freebsd-arm64': 4.59.0
+      '@rollup/rollup-freebsd-x64': 4.59.0
+      '@rollup/rollup-linux-arm-gnueabihf': 4.59.0
+      '@rollup/rollup-linux-arm-musleabihf': 4.59.0
+      '@rollup/rollup-linux-arm64-gnu': 4.59.0
+      '@rollup/rollup-linux-arm64-musl': 4.59.0
+      '@rollup/rollup-linux-loong64-gnu': 4.59.0
+      '@rollup/rollup-linux-loong64-musl': 4.59.0
+      '@rollup/rollup-linux-ppc64-gnu': 4.59.0
+      '@rollup/rollup-linux-ppc64-musl': 4.59.0
+      '@rollup/rollup-linux-riscv64-gnu': 4.59.0
+      '@rollup/rollup-linux-riscv64-musl': 4.59.0
+      '@rollup/rollup-linux-s390x-gnu': 4.59.0
+      '@rollup/rollup-linux-x64-gnu': 4.59.0
+      '@rollup/rollup-linux-x64-musl': 4.59.0
+      '@rollup/rollup-openbsd-x64': 4.59.0
+      '@rollup/rollup-openharmony-arm64': 4.59.0
+      '@rollup/rollup-win32-arm64-msvc': 4.59.0
+      '@rollup/rollup-win32-ia32-msvc': 4.59.0
+      '@rollup/rollup-win32-x64-gnu': 4.59.0
+      '@rollup/rollup-win32-x64-msvc': 4.59.0
       fsevents: 2.3.3
     dev: false
 
@@ -13414,7 +13438,7 @@ packages:
     resolution: {integrity: sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==}
     dependencies:
       spdx-expression-parse: 3.0.1
-      spdx-license-ids: 3.0.22
+      spdx-license-ids: 3.0.23
     dev: true
 
   /spdx-exceptions/2.5.0:
@@ -13425,18 +13449,18 @@ packages:
     resolution: {integrity: sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==}
     dependencies:
       spdx-exceptions: 2.5.0
-      spdx-license-ids: 3.0.22
+      spdx-license-ids: 3.0.23
     dev: true
 
   /spdx-expression-parse/4.0.0:
     resolution: {integrity: sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==}
     dependencies:
       spdx-exceptions: 2.5.0
-      spdx-license-ids: 3.0.22
+      spdx-license-ids: 3.0.23
     dev: true
 
-  /spdx-license-ids/3.0.22:
-    resolution: {integrity: sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ==}
+  /spdx-license-ids/3.0.23:
+    resolution: {integrity: sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==}
     dev: true
 
   /speedometer/1.0.0:
@@ -13753,7 +13777,7 @@ packages:
     dependencies:
       '@istanbuljs/schema': 0.1.3
       glob: 7.2.3
-      minimatch: 3.1.2
+      minimatch: 3.1.3
     dev: true
 
   /test-value/2.1.0:
@@ -13980,8 +14004,8 @@ packages:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
       '@types/node': 20.19.33
-      acorn: 8.15.0
-      acorn-walk: 8.3.4
+      acorn: 8.16.0
+      acorn-walk: 8.3.5
       arg: 4.1.3
       create-require: 1.1.1
       diff: 4.0.4
@@ -14011,8 +14035,8 @@ packages:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
       '@types/node': 14.18.63
-      acorn: 8.15.0
-      acorn-walk: 8.3.4
+      acorn: 8.16.0
+      acorn-walk: 8.3.5
       arg: 4.1.3
       create-require: 1.1.1
       diff: 4.0.4
@@ -14041,8 +14065,8 @@ packages:
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      acorn: 8.15.0
-      acorn-walk: 8.3.4
+      acorn: 8.16.0
+      acorn-walk: 8.3.5
       arg: 4.1.3
       create-require: 1.1.1
       diff: 4.0.4
@@ -14317,8 +14341,8 @@ packages:
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
 
-  /underscore/1.13.7:
-    resolution: {integrity: sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==}
+  /underscore/1.13.8:
+    resolution: {integrity: sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==}
     dev: true
 
   /undici-types/6.21.0:


### PR DESCRIPTION
# feat(audit): Validate reference content types against schema in entries audit

## Problem
The entries audit only verified that referenced entry UIDs exist in the export. It did **not** validate that the referenced entry's content type matched the schema's `reference_to`. This allowed invalid references to pass audit, e.g.:

- **Reference fields:** A field with `reference_to: ["ct1"]` could reference ct2 entries and pass
- **JSON RTE:** A field with `reference_to: ["ct1", "sys_assets"]` could embed ct2 entries and pass

These invalid references could cause import failures.

## Solution
Add content-type validation so that when a reference exists in `entryMetaData`, the audit also checks that the referenced entry's content type is allowed by `reference_to`. Invalid references are now reported and can be fixed.

## Changes

| Area | Change |
|------|--------|
| **Helper** | Added `isRefContentTypeAllowed(refCtUid, referenceTo, config?)` to centralize the content-type check |
| **Audit – reference fields** | In `validateReferenceValues`, when ref exists, validate content type and report if invalid |
| **Audit – JSON RTE** | In `jsonRefCheck`, when ref exists, validate content type and report if invalid |
| **Fix – reference fields** | In `fixMissingReferences`, filter out refs with invalid content type and record in missingRefs |
| **Fix – JSON RTE** | In `jsonRefCheck`, return `null` when CT invalid in fix mode so fix path removes the embed |

## Edge Cases Handled

| Case | Handling |
|------|----------|
| `reference_to` undefined/null | Skip check (no restriction) |
| `reference_to` string | Normalize to `[reference_to]` |
| `reference_to` empty array | No refs allowed; invalid if ref present |
| `refCtUid` undefined | Skip check (cannot determine) |
| `refCtUid` in `skipRefs` (e.g. `sys_assets`) | Allow |
| Reference as string `"blt..."` | Use `refExist.ctUid` from metadata |
| Reference as `{ uid, _content_type_uid }` | Prefer `_content_type_uid`, fallback `refExist.ctUid` |
| JSON RTE attrs | Use `content-type-uid` (kebab-case) |

## Testing
- **Unit tests:** 7 for `isRefContentTypeAllowed`, 3 for `validateReferenceValues`, 1 for JSON RTE audit, 1 for `fixMissingReferences`, 1 for `jsonRefCheck` fix mode
- **TDD:** Tests written first, then implementation
- **All 140 unit tests pass**


## Files Changed
- `packages/contentstack-audit/src/modules/entries.ts` – implementation
- `packages/contentstack-audit/test/unit/modules/entries.test.ts` – unit tests
