### PR TITLE
fix: Changed the mapper path from contentDir to backupDir for taxonom…

### DIFF
--- a/packages/contentstack-import/src/import/modules/content-types.ts
+++ b/packages/contentstack-import/src/import/modules/content-types.ts
@@ -136,13 +136,13 @@ export default class ContentTypesImport extends BaseClass {
     this.pendingGFs = [];
     this.pendingExts = [];
     this.taxonomiesPath = path.join(
-      sanitizePath(importConfig.contentDir),
+      sanitizePath(importConfig.backupDir),
       PATH_CONSTANTS.MAPPER,
       PATH_CONSTANTS.MAPPER_MODULES.TAXONOMIES,
       PATH_CONSTANTS.FILES.SUCCESS,
     );
     this.extPendingPath = path.join(
-      sanitizePath(importConfig.contentDir),
+      sanitizePath(importConfig.backupDir),
       PATH_CONSTANTS.MAPPER,
       PATH_CONSTANTS.MAPPER_MODULES.EXTENSIONS,
       PATH_CONSTANTS.FILES.PENDING_EXTENSIONS,


### PR DESCRIPTION
# Fix: Taxonomy fields removed during content-types import (contentDir vs backupDir)

## Problem

During import, taxonomy fields on content types were being removed instead of preserved. That led to:

- Content type schemas losing taxonomy field definitions
- Entry import failing when entries referenced those taxonomy fields

## Root cause

The import flow uses two base paths after backup:

- **`contentDir`** – original export folder (user-provided path)
- **`backupDir`** – copy created by `backupHandler` (e.g. `_backup_123`)

- The **taxonomies** module writes its success file to **`backupDir`/mapper/taxonomies/success.json**.
- The **extensions** module writes pending extensions to **`backupDir`**/mapper/extensions/pending_extensions.js.
- **Content-types** was reading both from **`contentDir`** (mapper/taxonomies/success.json and mapper/extensions/pending_extensions.js).

So content-types never saw the files written in the current run. For taxonomies, `lookUpTaxonomy` got missing/empty data, treated every taxonomy as “not in stack,” and stripped taxonomy fields from schemas.

## Solution

Content-types now reads mapper outputs from the same base as the modules that write them:

1. **Taxonomy success**  
   `taxonomiesPath` is built from **`importConfig.backupDir`** instead of `importConfig.contentDir`, so it points to `backupDir/mapper/taxonomies/success.json`.

2. **Pending extensions**  
   `extPendingPath` is built from **`importConfig.backupDir`** instead of `importConfig.contentDir`, so it points to `backupDir/mapper/extensions/pending_extensions.js`.

Rule used: **mapper and any file written during import → `backupDir`**; **export content (read-only source) → `contentDir`**.

## Changes

- **`packages/contentstack-import/src/import/modules/content-types.ts`**
  - `taxonomiesPath`: `contentDir` → `backupDir`
  - `extPendingPath`: `contentDir` → `backupDir`

## Verification

- Taxonomy fields on content types are preserved during import.
- Entry import succeeds when entries use taxonomy fields.
- Pending extensions are correctly picked up when content-types runs after the extensions module.