### PR TITLE
fix(dx-4439): Show human-readable prompts in interactive mode after command correction

### DIFF
--- a/.github/workflows/sca-scan.yml
+++ b/.github/workflows/sca-scan.yml
@@ -16,3 +16,5 @@ jobs:
           json: true
         continue-on-error: true
       - uses: contentstack/sca-policy@main 
+        with:
+          MAX_HIGH_ISSUES: 100

--- a/.talismanrc
+++ b/.talismanrc
@@ -1,8 +1,7 @@
 fileignoreconfig:
-- filename: package-lock.json
-  checksum: 10993a3e930b77c3c6e09afcb50c23e6a8a901302172b699e92b0a4bfec0cffa
 - filename: pnpm-lock.yaml
-  checksum: 3e47ed021491e9f3c21d25e4ea72a1101b51f16ebedd279019df1792b72417a4
-- filename: packages/contentstack-bootstrap/src/bootstrap/utils.ts
+  checksum: f0c20ed844fb34ef09aa879079d0d998171afd819913171dcf777bea13e25076
+- filename: package-lock.json
+  checksum: f5eca8ce4123fe306eabf684981d154cf0e6b9c2480a2f888598a59c1388bac4
   checksum: 6e6fb00bb11b03141e5ad27eeaa4af9718dc30520c3e73970bc208cc0ba2a7d2
 version: '1.0'

--- a/package-lock.json
+++ b/package-lock.json
@@ -26948,7 +26948,7 @@
       "license": "MIT",
       "dependencies": {
         "@contentstack/cli-audit": "~1.18.0",
-        "@contentstack/cli-auth": "~1.7.3",
+        "@contentstack/cli-auth": "~1.7.4",
         "@contentstack/cli-cm-bootstrap": "~1.18.4",
         "@contentstack/cli-cm-branches": "~1.6.3",
         "@contentstack/cli-cm-bulk-publish": "~1.10.7",
@@ -27090,7 +27090,7 @@
     },
     "packages/contentstack-auth": {
       "name": "@contentstack/cli-auth",
-      "version": "1.7.3",
+      "version": "1.7.4",
       "license": "MIT",
       "dependencies": {
         "@contentstack/cli-command": "~1.7.2",
@@ -27909,7 +27909,7 @@
         "winston": "^3.17.0"
       },
       "devDependencies": {
-        "@contentstack/cli-auth": "~1.7.3",
+        "@contentstack/cli-auth": "~1.7.4",
         "@contentstack/cli-config": "~1.19.0",
         "@contentstack/cli-dev-dependencies": "~1.3.1",
         "@oclif/plugin-help": "^6.2.28",

--- a/package-lock.json
+++ b/package-lock.json
@@ -280,9 +280,9 @@
       }
     },
     "node_modules/@aws-sdk/client-cloudfront": {
-      "version": "3.999.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudfront/-/client-cloudfront-3.999.0.tgz",
-      "integrity": "sha512-Ua/rtidq/lSqBV8Fi5pNj3Urxyglt9xWNaxx4vs5SvYB4X8qur+Q3TqiTODpPZHZLSulyOQ7US9qEThimOKpfQ==",
+      "version": "3.1000.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudfront/-/client-cloudfront-3.1000.0.tgz",
+      "integrity": "sha512-+//1gHKzap9g/jLmErpd64pPZIrM2M3jdQfQ8MXL5M0L44MKMdOhKSzN/fy0j6I4C0r4jQNEY3guSYN8dt6Utg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -333,9 +333,9 @@
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.999.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.999.0.tgz",
-      "integrity": "sha512-6ML2ls4nnOxm1kKzy2RgM+i8aS/9wgw6V91iqSibBYU/isYs8BvC2xcv8AsaWG5mOQjytjRzsBO5COxfWVPg3A==",
+      "version": "3.1000.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1000.0.tgz",
+      "integrity": "sha512-7kPy33qNGq3NfwHC0412T6LDK1bp4+eiPzetX0sVd9cpTSXuQDKpoOFnB0Njj6uZjJDcLS3n2OeyarwwgkQ0Ow==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3770,9 +3770,9 @@
       }
     },
     "node_modules/@oclif/core": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-4.8.1.tgz",
-      "integrity": "sha512-07mq0vKCWNsB85ZHeBMlTAiO0KLFqHyAeRK3bD2K8CI1tX3tiwkWw1lZQZkiw8MUBrhxdROhMkYMY4Q0l7JHqA==",
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-4.8.3.tgz",
+      "integrity": "sha512-f7Rc1JBZO0wNMyDmNzP5IFOv5eM97S9pO4JUFdu2OLyk73YeBI9wog1Yyf666NOQvyptkbG1xh8inzMDQLNTyQ==",
       "license": "MIT",
       "dependencies": {
         "ansi-escapes": "^4.3.2",
@@ -3785,7 +3785,7 @@
         "indent-string": "^4.0.0",
         "is-wsl": "^2.2.0",
         "lilconfig": "^3.1.3",
-        "minimatch": "^10.2.1",
+        "minimatch": "^10.2.4",
         "semver": "^7.7.3",
         "string-width": "^4.2.3",
         "supports-color": "^8",
@@ -4142,9 +4142,9 @@
       }
     },
     "node_modules/@oclif/plugin-not-found/node_modules/@types/node": {
-      "version": "25.3.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.2.tgz",
-      "integrity": "sha512-RpV6r/ij22zRRdyBPcxDeKAzH43phWVKEjL2iksqo1Vz3CuBUrgmPpPhALKiRfU7OMCmeeO9vECBMsV0hMTG8Q==",
+      "version": "25.3.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.3.tgz",
+      "integrity": "sha512-DpzbrH7wIcBaJibpKo9nnSQL0MTRdnWttGyE5haGwK86xgMOkFLp7vEyfQPGLOJh5wNYiJ3V9PmUMDhV9u8kkQ==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -4914,6 +4914,7 @@
       "version": "0.7.3",
       "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.3.tgz",
       "integrity": "sha512-DE427ROAphMQzU4ENbliGYrBSYPXF+TtLg9S8vzeA+OF4ZKzoDdzfL8sxuMUGS/lgRhM6j1URSk9ghf7Xo1tyA==",
+      "deprecated": "Deprecated: no longer maintained, as we are not depending on it",
       "dev": true,
       "license": "(Unlicense OR Apache-2.0)"
     },
@@ -7608,9 +7609,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
+      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
@@ -7938,9 +7939,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
-      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -8283,9 +8284,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001774",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001774.tgz",
-      "integrity": "sha512-DDdwPGz99nmIEv216hKSgLD+D4ikHQHjBC/seF98N9CPqRX4M5mSxT9eTV6oyisnJcuzxtZy4n17yKKQYmYQOA==",
+      "version": "1.0.30001776",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001776.tgz",
+      "integrity": "sha512-sg01JDPzZ9jGshqKSckOQthXnYwOEP50jeVFhaSFbZcOy05TiuuaffDOfcwtCisJ9kNQuLBFibYywv2Bgm9osw==",
       "dev": true,
       "funding": [
         {
@@ -9430,9 +9431,9 @@
       }
     },
     "node_modules/dedent": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.1.tgz",
-      "integrity": "sha512-9JmrhGZpOlEgOLdQgSm0zxFaYoQon408V1v49aqTWuXENVlnCuY9JBZcXZiCsZQWDjTm5Qf/nIvAy77mXDAjEg==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
+      "integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -9789,9 +9790,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.302",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.302.tgz",
-      "integrity": "sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==",
+      "version": "1.5.307",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.307.tgz",
+      "integrity": "sha512-5z3uFKBWjiNR44nFcYdkcXjKMbg5KXNdciu7mhTPo9tB7NbqSNP2sSnGR+fqknZSCwKkBN+oxiiajWs4dT6ORg==",
       "dev": true,
       "license": "ISC"
     },
@@ -9849,9 +9850,9 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.19.0.tgz",
-      "integrity": "sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.0.tgz",
+      "integrity": "sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10227,14 +10228,14 @@
       }
     },
     "node_modules/eslint-config-oclif": {
-      "version": "6.0.144",
-      "resolved": "https://registry.npmjs.org/eslint-config-oclif/-/eslint-config-oclif-6.0.144.tgz",
-      "integrity": "sha512-87Zn12V0wnkxPSsm9TdIyZ4v5uNceqjMilyyR8Snk/oxCtOaawy/6mU1DwzS1zv4tnspZgeLJn+Y1ZI8Mf7BQw==",
+      "version": "6.0.146",
+      "resolved": "https://registry.npmjs.org/eslint-config-oclif/-/eslint-config-oclif-6.0.146.tgz",
+      "integrity": "sha512-x59Gopo4wQiuuGOUQ2D3HaIpU1LaeksPql3vTGBNnAM0dNmHWqchMvaYczoRVBx0tfGVljWGYqDA0I/355cF4Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint/compat": "^1.4.1",
-        "@eslint/eslintrc": "^3.3.3",
+        "@eslint/eslintrc": "^3.3.4",
         "@eslint/js": "^9.38.0",
         "@stylistic/eslint-plugin": "^3.1.0",
         "@typescript-eslint/eslint-plugin": "^8",
@@ -10249,7 +10250,7 @@
         "eslint-plugin-n": "^17.24.0",
         "eslint-plugin-perfectionist": "^4",
         "eslint-plugin-unicorn": "^56.0.1",
-        "typescript-eslint": "^8.56.0"
+        "typescript-eslint": "^8.56.1"
       },
       "engines": {
         "node": ">=18.18.0"
@@ -12766,9 +12767,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.4.tgz",
+      "integrity": "sha512-3+mMldrTAPdta5kjX2G2J7iX4zxtnwpdA8Tr2ZSjkyPSanvbZAcy6flmtnXbEybHrDcU9641lxrMfFuUxVz9vA==",
       "dev": true,
       "license": "ISC"
     },
@@ -12956,6 +12957,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fs-then-native/-/fs-then-native-2.0.0.tgz",
       "integrity": "sha512-X712jAOaWXkemQCAmWeg5rOT2i+KOpWz1Z/txk/cW0qlOu2oQ9H61vc5w3X/iyuUEfq/OyaFJ78/cZAQD1/bgA==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -14414,9 +14416,9 @@
       }
     },
     "node_modules/inquirer/node_modules/@types/node": {
-      "version": "25.3.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.2.tgz",
-      "integrity": "sha512-RpV6r/ij22zRRdyBPcxDeKAzH43phWVKEjL2iksqo1Vz3CuBUrgmPpPhALKiRfU7OMCmeeO9vECBMsV0hMTG8Q==",
+      "version": "25.3.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.3.tgz",
+      "integrity": "sha512-DpzbrH7wIcBaJibpKo9nnSQL0MTRdnWttGyE5haGwK86xgMOkFLp7vEyfQPGLOJh5wNYiJ3V9PmUMDhV9u8kkQ==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -18038,23 +18040,23 @@
       "license": "MIT"
     },
     "node_modules/nise": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-6.1.1.tgz",
-      "integrity": "sha512-aMSAzLVY7LyeM60gvBS423nBmIPP+Wy7St7hsb+8/fc1HmeoHJfLO8CKse4u3BtOZvQLJghYPI2i/1WZrEj5/g==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-6.1.2.tgz",
+      "integrity": "sha512-zPM6UobDUDnhGcaWYjzig0tZCv4tXfF/1fnV58mfzL7pXSEwDLG0lXreuZ3u19O2ABghlYO8tFL1m1hrKUz/nw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.1",
-        "@sinonjs/fake-timers": "^13.0.1",
+        "@sinonjs/fake-timers": "^15.1.1",
         "@sinonjs/text-encoding": "^0.7.3",
         "just-extend": "^6.2.0",
-        "path-to-regexp": "^8.1.0"
+        "path-to-regexp": "^8.3.0"
       }
     },
     "node_modules/nise/node_modules/@sinonjs/fake-timers": {
-      "version": "13.0.5",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-13.0.5.tgz",
-      "integrity": "sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==",
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.1.1.tgz",
+      "integrity": "sha512-cO5W33JgAPbOh07tvZjUOJ7oWhtaqGHiZw+11DPbyqh2kHTBc3eF/CjJDeQ4205RLQsX6rxCuYOroFQwl7JDRw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -22227,9 +22229,9 @@
       }
     },
     "node_modules/pump": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
-      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -22699,6 +22701,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/test-value/-/test-value-2.1.0.tgz",
       "integrity": "sha512-+1epbAxtKeXttkGFMTX9H42oqzOTufR1ceCF+GYA5aOmvaPq9wd4PUS8329fn2RRLGNeUkgRLnVpycjx8DsO2w==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -24136,9 +24139,9 @@
       }
     },
     "node_modules/sinon/node_modules/@sinonjs/fake-timers": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.1.0.tgz",
-      "integrity": "sha512-cqfapCxwTGsrR80FEgOoPsTonoefMBY7dnUEbQ+GRcved0jvkJLzvX6F4WtN+HBqbPX/SiFsIRUp+IrCW/2I2w==",
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.1.1.tgz",
+      "integrity": "sha512-cO5W33JgAPbOh07tvZjUOJ7oWhtaqGHiZw+11DPbyqh2kHTBc3eF/CjJDeQ4205RLQsX6rxCuYOroFQwl7JDRw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.1"
@@ -24920,9 +24923,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.2.tgz",
-      "integrity": "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.0.tgz",
+      "integrity": "sha512-Y7Bj8XyJxnPAORMZj/xltsfo55uOiyHcU2tnAVzHUnSJR/KsEX+9RoDeXEnsXtl/CX4fAcrt64gZ13aGaWPeBg==",
       "dev": true,
       "funding": [
         {
@@ -25144,6 +25147,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/test-value/-/test-value-3.0.0.tgz",
       "integrity": "sha512-sVACdAWcZkSU9x7AOmJo5TqE+GyNJknHaHsMrR6ZnhjVlVN9Yx6FjHrsKZ3BjIpPCT68zYesPWkakrNupwfOTQ==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -26940,7 +26944,7 @@
     },
     "packages/contentstack": {
       "name": "@contentstack/cli",
-      "version": "1.59.0",
+      "version": "1.59.1",
       "license": "MIT",
       "dependencies": {
         "@contentstack/cli-audit": "~1.18.0",

--- a/packages/contentstack-auth/messages/index.json
+++ b/packages/contentstack-auth/messages/index.json
@@ -18,6 +18,7 @@
   "CLI_AUTH_LOGOUT_DESCRIPTION": "User session logout",
   "CLI_AUTH_LOGOUT_FLAG_FORCE": "Force logging out for skipping the confirmation",
   "CLI_AUTH_LOGOUT_ALREADY": "You're already logged out",
+  "CLI_AUTH_LOGOUT_CANCELLED": "Log out cancelled",
   "CLI_AUTH_LOGOUT_NO_AUTHORIZATIONS": "No authorizations found",
   "CLI_AUTH_LOGOUT_NO_AUTHORIZATIONS_USER": "No authorizations found for current user",
   "CLI_AUTH_WHOAMI_LOGGED_IN_AS": "You are currently logged in with email:",

--- a/packages/contentstack-auth/package.json
+++ b/packages/contentstack-auth/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contentstack/cli-auth",
   "description": "Contentstack CLI plugin for authentication activities",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "author": "Contentstack",
   "bugs": "https://github.com/contentstack/cli/issues",
   "scripts": {

--- a/packages/contentstack-auth/src/commands/auth/logout.ts
+++ b/packages/contentstack-auth/src/commands/auth/logout.ts
@@ -93,7 +93,10 @@ export default class LogoutCommand extends BaseCommand<typeof LogoutCommand> {
           confirm,
           isAuthenticated: oauthHandler.isAuthenticated(),
         });
-        log.success(messageHandler.parse('CLI_AUTH_LOGOUT_ALREADY'), this.contextDetails);
+        const messageKey = confirm === false && oauthHandler.isAuthenticated()
+          ? 'CLI_AUTH_LOGOUT_CANCELLED'
+          : 'CLI_AUTH_LOGOUT_ALREADY';
+        log.success(messageHandler.parse(messageKey), this.contextDetails);
       }
     } catch (error) {
       log.debug('Logout failed.', { ...this.contextDetails, error: error.message });

--- a/packages/contentstack-export/package.json
+++ b/packages/contentstack-export/package.json
@@ -21,7 +21,7 @@
     "winston": "^3.17.0"
   },
   "devDependencies": {
-    "@contentstack/cli-auth": "~1.7.3",
+    "@contentstack/cli-auth": "~1.7.4",
     "@contentstack/cli-config": "~1.19.0",
     "@contentstack/cli-dev-dependencies": "~1.3.1",
     "@oclif/plugin-help": "^6.2.28",

--- a/packages/contentstack/package.json
+++ b/packages/contentstack/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contentstack/cli",
   "description": "Command-line tool (CLI) to interact with Contentstack",
-  "version": "1.59.0",
+  "version": "1.59.1",
   "author": "Contentstack",
   "bin": {
     "csdx": "./bin/run.js"
@@ -156,6 +156,7 @@
     ],
     "hooks": {
       "prerun": [
+        "./lib/hooks/prerun/init-context-for-command",
         "./lib/hooks/prerun/command-deprecation-check",
         "./lib/hooks/prerun/default-rate-limit-check",
         "./lib/hooks/prerun/latest-version-warning"

--- a/packages/contentstack/package.json
+++ b/packages/contentstack/package.json
@@ -25,7 +25,7 @@
     "@contentstack/cli-audit": "~1.18.0",
     "@contentstack/cli-cm-export": "~1.23.2",
     "@contentstack/cli-cm-import": "~1.31.3",
-    "@contentstack/cli-auth": "~1.7.3",
+    "@contentstack/cli-auth": "~1.7.4",
     "@contentstack/cli-cm-bootstrap": "~1.18.4",
     "@contentstack/cli-cm-branches": "~1.6.3",
     "@contentstack/cli-cm-bulk-publish": "~1.10.7",

--- a/packages/contentstack/src/hooks/prerun/init-context-for-command.ts
+++ b/packages/contentstack/src/hooks/prerun/init-context-for-command.ts
@@ -1,0 +1,27 @@
+import {
+  cliux,
+  messageHandler,
+  managementSDKInitiator,
+  marketplaceSDKInitiator,
+} from '@contentstack/cli-utilities';
+import { CsdxContext } from '../../utils';
+
+/**
+ * When an invalid command is corrected (e.g. loginasda → login), init ran with the invalid
+ * command so context.messageFilePath was never set. Re-build context and re-init utilities
+ * for the actual command so i18n prompts show human-readable text.
+ */
+export default async function (opts: {
+  Command?: { id?: string };
+  config?: any;
+}): Promise<void> {
+  const config = opts?.config ?? this.config;
+  const commandId = opts?.Command?.id;
+  if (!config?.context?.messageFilePath && commandId) {
+    config.context = new CsdxContext({ id: commandId }, config);
+    messageHandler.init(config.context);
+    cliux.init(config.context);
+    managementSDKInitiator.init(config.context);
+    marketplaceSDKInitiator.init(config.context);
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,7 +89,7 @@ importers:
       '@contentstack/cli-utilities': link:../contentstack-utilities
       '@contentstack/cli-variants': link:../contentstack-variants
       '@contentstack/management': 1.27.6_debug@4.4.3
-      '@oclif/core': 4.8.1
+      '@oclif/core': 4.8.3
       '@oclif/plugin-help': 6.2.37
       '@oclif/plugin-not-found': 3.2.74_@types+node@14.18.63
       '@oclif/plugin-plugins': 5.4.56
@@ -104,7 +104,7 @@ importers:
       uuid: 9.0.1
       winston: 3.19.0
     devDependencies:
-      '@oclif/test': 4.1.16_@oclif+core@4.8.1
+      '@oclif/test': 4.1.16_@oclif+core@4.8.3
       '@types/chai': 4.3.20
       '@types/inquirer': 9.0.9
       '@types/mkdirp': 1.0.2
@@ -114,7 +114,7 @@ importers:
       '@types/sinon': 21.0.0
       chai: 4.5.0
       eslint: 8.57.1
-      eslint-config-oclif: 6.0.144_avq3eyf5kaj6ssrwo7fvkrwnji
+      eslint-config-oclif: 6.0.146_avq3eyf5kaj6ssrwo7fvkrwnji
       eslint-config-oclif-typescript: 3.1.14_avq3eyf5kaj6ssrwo7fvkrwnji
       globby: 10.0.2
       mocha: 10.8.2
@@ -162,7 +162,7 @@ importers:
     dependencies:
       '@contentstack/cli-command': link:../contentstack-command
       '@contentstack/cli-utilities': link:../contentstack-utilities
-      '@oclif/core': 4.8.1
+      '@oclif/core': 4.8.3
       '@oclif/plugin-help': 6.2.37
       '@oclif/plugin-plugins': 5.4.56
       chalk: 4.1.2
@@ -172,7 +172,7 @@ importers:
       uuid: 9.0.1
       winston: 3.19.0
     devDependencies:
-      '@oclif/test': 4.1.16_@oclif+core@4.8.1
+      '@oclif/test': 4.1.16_@oclif+core@4.8.3
       '@types/chai': 4.3.20
       '@types/fs-extra': 11.0.4
       '@types/mocha': 10.0.10
@@ -180,7 +180,7 @@ importers:
       '@types/uuid': 9.0.8
       chai: 4.5.0
       eslint: 8.57.1
-      eslint-config-oclif: 6.0.144_k2rwabtyo525wwqr6566umnmhy
+      eslint-config-oclif: 6.0.146_k2rwabtyo525wwqr6566umnmhy
       eslint-config-oclif-typescript: 3.1.14_k2rwabtyo525wwqr6566umnmhy
       mocha: 10.8.2
       nyc: 15.1.0
@@ -218,12 +218,12 @@ importers:
     dependencies:
       '@contentstack/cli-command': link:../contentstack-command
       '@contentstack/cli-utilities': link:../contentstack-utilities
-      '@oclif/core': 4.8.1
+      '@oclif/core': 4.8.3
       '@oclif/plugin-help': 6.2.37
       otplib: 12.0.1
     devDependencies:
       '@fancy-test/nock': 0.1.1
-      '@oclif/test': 4.1.16_@oclif+core@4.8.1
+      '@oclif/test': 4.1.16_@oclif+core@4.8.3
       '@types/chai': 4.3.20
       '@types/mkdirp': 1.0.2
       '@types/mocha': 8.2.3
@@ -272,20 +272,20 @@ importers:
       '@contentstack/cli-command': link:../contentstack-command
       '@contentstack/cli-config': link:../contentstack-config
       '@contentstack/cli-utilities': link:../contentstack-utilities
-      '@oclif/core': 4.8.1
+      '@oclif/core': 4.8.3
       '@oclif/plugin-help': 6.2.37
       inquirer: 8.2.7_@types+node@14.18.63
       mkdirp: 1.0.4
       tar: 7.5.9
     devDependencies:
-      '@oclif/test': 4.1.16_@oclif+core@4.8.1
+      '@oclif/test': 4.1.16_@oclif+core@4.8.3
       '@types/inquirer': 9.0.9
       '@types/mkdirp': 1.0.2
       '@types/node': 14.18.63
       '@types/tar': 6.1.13
       chai: 4.5.0
       eslint: 8.57.1
-      eslint-config-oclif: 6.0.144_avq3eyf5kaj6ssrwo7fvkrwnji
+      eslint-config-oclif: 6.0.146_avq3eyf5kaj6ssrwo7fvkrwnji
       eslint-config-oclif-typescript: 3.1.14_avq3eyf5kaj6ssrwo7fvkrwnji
       mocha: 10.8.2
       nyc: 15.1.0
@@ -319,7 +319,7 @@ importers:
     dependencies:
       '@contentstack/cli-command': link:../contentstack-command
       '@contentstack/cli-utilities': link:../contentstack-utilities
-      '@oclif/core': 4.8.1
+      '@oclif/core': 4.8.3
       '@oclif/plugin-help': 6.2.37
       chalk: 4.1.2
       just-diff: 6.0.2
@@ -331,7 +331,7 @@ importers:
       dotenv: 16.6.1
       dotenv-expand: 9.0.0
       eslint: 8.57.1
-      eslint-config-oclif: 6.0.144_avq3eyf5kaj6ssrwo7fvkrwnji
+      eslint-config-oclif: 6.0.146_avq3eyf5kaj6ssrwo7fvkrwnji
       mocha: 10.8.2
       nyc: 15.1.0
       oclif: 4.22.81
@@ -362,7 +362,7 @@ importers:
       '@contentstack/cli-command': link:../contentstack-command
       '@contentstack/cli-config': link:../contentstack-config
       '@contentstack/cli-utilities': link:../contentstack-utilities
-      '@oclif/core': 4.8.1
+      '@oclif/core': 4.8.3
       '@oclif/plugin-help': 6.2.37
       chalk: 4.1.2
       dotenv: 16.6.1
@@ -370,10 +370,10 @@ importers:
       lodash: 4.17.23
       winston: 3.19.0
     devDependencies:
-      '@oclif/test': 4.1.16_@oclif+core@4.8.1
+      '@oclif/test': 4.1.16_@oclif+core@4.8.3
       chai: 4.5.0
       eslint: 8.57.1
-      eslint-config-oclif: 6.0.144_eslint@8.57.1
+      eslint-config-oclif: 6.0.146_eslint@8.57.1
       mocha: 10.8.2
       nyc: 15.1.0
       oclif: 4.22.81
@@ -415,7 +415,7 @@ importers:
       '@contentstack/cli-cm-import': link:../contentstack-import
       '@contentstack/cli-command': link:../contentstack-command
       '@contentstack/cli-utilities': link:../contentstack-utilities
-      '@oclif/core': 4.8.1
+      '@oclif/core': 4.8.3
       '@oclif/plugin-help': 6.2.37
       chalk: 4.1.2
       inquirer: 8.2.7_@types+node@14.18.63
@@ -425,7 +425,7 @@ importers:
       prompt: 1.3.0
       rimraf: 6.1.3
     devDependencies:
-      '@oclif/test': 4.1.16_@oclif+core@4.8.1
+      '@oclif/test': 4.1.16_@oclif+core@4.8.3
       '@types/chai': 4.3.20
       '@types/mocha': 10.0.10
       '@types/node': 14.18.63
@@ -433,7 +433,7 @@ importers:
       '@typescript-eslint/eslint-plugin': 5.62.0_avq3eyf5kaj6ssrwo7fvkrwnji
       chai: 4.5.0
       eslint: 8.57.1
-      eslint-config-oclif: 6.0.144_avq3eyf5kaj6ssrwo7fvkrwnji
+      eslint-config-oclif: 6.0.146_avq3eyf5kaj6ssrwo7fvkrwnji
       mocha: 10.8.2
       nyc: 15.1.0
       oclif: 4.22.81_@types+node@14.18.63
@@ -460,16 +460,16 @@ importers:
       typescript: ^4.9.5
     dependencies:
       '@contentstack/cli-utilities': link:../contentstack-utilities
-      '@oclif/core': 4.8.1
+      '@oclif/core': 4.8.3
       '@oclif/plugin-help': 6.2.37
       contentstack: 3.26.4
     devDependencies:
-      '@oclif/test': 4.1.16_@oclif+core@4.8.1
+      '@oclif/test': 4.1.16_@oclif+core@4.8.3
       '@types/mkdirp': 1.0.2
       '@types/mocha': 8.2.3
       '@types/node': 14.18.63
       eslint: 8.57.1
-      eslint-config-oclif: 6.0.144_avq3eyf5kaj6ssrwo7fvkrwnji
+      eslint-config-oclif: 6.0.146_avq3eyf5kaj6ssrwo7fvkrwnji
       eslint-config-oclif-typescript: 3.1.14_avq3eyf5kaj6ssrwo7fvkrwnji
       mocha: 10.8.2
       nyc: 15.1.0
@@ -503,18 +503,18 @@ importers:
       '@contentstack/cli-command': link:../contentstack-command
       '@contentstack/cli-utilities': link:../contentstack-utilities
       '@contentstack/utils': 1.7.1
-      '@oclif/core': 4.8.1
+      '@oclif/core': 4.8.3
       '@oclif/plugin-help': 6.2.37
       lodash: 4.17.23
     devDependencies:
-      '@oclif/test': 4.1.16_@oclif+core@4.8.1
+      '@oclif/test': 4.1.16_@oclif+core@4.8.3
       '@types/chai': 4.3.20
       '@types/mocha': 8.2.3
       '@types/node': 14.18.63
       '@types/sinon': 21.0.0
       chai: 4.5.0
       eslint: 8.57.1
-      eslint-config-oclif: 6.0.144_avq3eyf5kaj6ssrwo7fvkrwnji
+      eslint-config-oclif: 6.0.146_avq3eyf5kaj6ssrwo7fvkrwnji
       eslint-config-oclif-typescript: 3.1.14_avq3eyf5kaj6ssrwo7fvkrwnji
       mocha: 10.8.2
       nyc: 15.1.0
@@ -536,8 +536,8 @@ importers:
       tslib: ^2.8.1
       typescript: ^4.9.5
     dependencies:
-      '@oclif/core': 4.8.1
-      '@oclif/test': 4.1.16_@oclif+core@4.8.1
+      '@oclif/core': 4.8.3
+      '@oclif/test': 4.1.16_@oclif+core@4.8.3
       fancy-test: 2.0.42
       lodash: 4.17.23
     devDependencies:
@@ -591,7 +591,7 @@ importers:
       '@contentstack/cli-command': link:../contentstack-command
       '@contentstack/cli-utilities': link:../contentstack-utilities
       '@contentstack/cli-variants': link:../contentstack-variants
-      '@oclif/core': 4.8.1
+      '@oclif/core': 4.8.3
       async: 3.2.6
       big-json: 3.2.0
       bluebird: 3.7.2
@@ -607,7 +607,7 @@ importers:
       '@contentstack/cli-config': link:../contentstack-config
       '@contentstack/cli-dev-dependencies': link:../contentstack-dev-dependencies
       '@oclif/plugin-help': 6.2.37
-      '@oclif/test': 4.1.16_@oclif+core@4.8.1
+      '@oclif/test': 4.1.16_@oclif+core@4.8.3
       '@types/big-json': 3.2.5
       '@types/chai': 4.3.20
       '@types/mkdirp': 1.0.2
@@ -618,7 +618,7 @@ importers:
       dotenv: 16.6.1
       dotenv-expand: 9.0.0
       eslint: 8.57.1
-      eslint-config-oclif: 6.0.144_avq3eyf5kaj6ssrwo7fvkrwnji
+      eslint-config-oclif: 6.0.146_avq3eyf5kaj6ssrwo7fvkrwnji
       mocha: 10.8.2
       nyc: 15.1.0
       oclif: 4.22.81
@@ -657,14 +657,14 @@ importers:
     dependencies:
       '@contentstack/cli-command': link:../contentstack-command
       '@contentstack/cli-utilities': link:../contentstack-utilities
-      '@oclif/core': 4.8.1
+      '@oclif/core': 4.8.3
       '@oclif/plugin-help': 6.2.37
       fast-csv: 4.3.6
       inquirer: 8.2.7_@types+node@20.19.35
       inquirer-checkbox-plus-prompt: 1.4.2_inquirer@8.2.7
       mkdirp: 3.0.1
     devDependencies:
-      '@oclif/test': 4.1.16_@oclif+core@4.8.1
+      '@oclif/test': 4.1.16_@oclif+core@4.8.3
       '@types/chai': 4.3.20
       '@types/inquirer': 9.0.9
       '@types/mkdirp': 1.0.2
@@ -672,7 +672,7 @@ importers:
       '@types/node': 20.19.35
       chai: 4.5.0
       eslint: 8.57.1
-      eslint-config-oclif: 6.0.144_k2rwabtyo525wwqr6566umnmhy
+      eslint-config-oclif: 6.0.146_k2rwabtyo525wwqr6566umnmhy
       eslint-config-oclif-typescript: 3.1.14_k2rwabtyo525wwqr6566umnmhy
       mocha: 10.8.2
       nock: 13.5.6
@@ -725,7 +725,7 @@ importers:
       '@contentstack/cli-command': link:../contentstack-command
       '@contentstack/cli-utilities': link:../contentstack-utilities
       '@contentstack/cli-variants': link:../contentstack-variants
-      '@oclif/core': 4.8.1
+      '@oclif/core': 4.8.3
       big-json: 3.2.0
       bluebird: 3.7.2
       chalk: 4.1.2
@@ -739,7 +739,7 @@ importers:
       uuid: 9.0.1
       winston: 3.19.0
     devDependencies:
-      '@oclif/test': 4.1.16_@oclif+core@4.8.1
+      '@oclif/test': 4.1.16_@oclif+core@4.8.3
       '@types/big-json': 3.2.5
       '@types/bluebird': 3.5.42
       '@types/fs-extra': 11.0.4
@@ -751,7 +751,7 @@ importers:
       '@types/uuid': 9.0.8
       '@typescript-eslint/eslint-plugin': 5.62.0_avq3eyf5kaj6ssrwo7fvkrwnji
       eslint: 8.57.1
-      eslint-config-oclif: 6.0.144_avq3eyf5kaj6ssrwo7fvkrwnji
+      eslint-config-oclif: 6.0.146_avq3eyf5kaj6ssrwo7fvkrwnji
       mocha: 10.8.2
       nyc: 15.1.0
       oclif: 4.22.81_@types+node@14.18.63
@@ -795,7 +795,7 @@ importers:
     dependencies:
       '@contentstack/cli-command': link:../contentstack-command
       '@contentstack/cli-utilities': link:../contentstack-utilities
-      '@oclif/core': 4.8.1
+      '@oclif/core': 4.8.3
       big-json: 3.2.0
       chalk: 4.1.2
       fs-extra: 11.3.3
@@ -817,7 +817,7 @@ importers:
       '@typescript-eslint/eslint-plugin': 5.62.0_avq3eyf5kaj6ssrwo7fvkrwnji
       chai: 4.5.0
       eslint: 8.57.1
-      eslint-config-oclif: 6.0.144_avq3eyf5kaj6ssrwo7fvkrwnji
+      eslint-config-oclif: 6.0.146_avq3eyf5kaj6ssrwo7fvkrwnji
       mocha: 10.8.2
       nyc: 15.1.0
       oclif: 4.22.81_@types+node@14.18.63
@@ -852,7 +852,7 @@ importers:
       '@contentstack/cli-command': link:../contentstack-command
       '@contentstack/cli-utilities': link:../contentstack-utilities
       '@contentstack/json-rte-serializer': 2.1.0
-      '@oclif/core': 4.8.1
+      '@oclif/core': 4.8.3
       '@oclif/plugin-help': 6.2.37
       chalk: 4.1.2
       collapse-whitespace: 1.1.7
@@ -863,10 +863,10 @@ importers:
       omit-deep-lodash: 1.1.7
       sinon: 21.0.1
     devDependencies:
-      '@oclif/test': 4.1.16_@oclif+core@4.8.1
+      '@oclif/test': 4.1.16_@oclif+core@4.8.3
       chai: 4.5.0
       eslint: 8.57.1
-      eslint-config-oclif: 6.0.144_eslint@8.57.1
+      eslint-config-oclif: 6.0.146_eslint@8.57.1
       mocha: 10.8.2
       nyc: 15.1.0
       oclif: 4.22.81
@@ -902,7 +902,7 @@ importers:
     dependencies:
       '@contentstack/cli-command': link:../contentstack-command
       '@contentstack/cli-utilities': link:../contentstack-utilities
-      '@oclif/core': 4.8.1
+      '@oclif/core': 4.8.3
       '@oclif/plugin-help': 6.2.37
       async: 3.2.6
       callsites: 3.1.0
@@ -912,12 +912,12 @@ importers:
       listr: 0.14.3
       winston: 3.19.0
     devDependencies:
-      '@oclif/test': 4.1.16_@oclif+core@4.8.1
+      '@oclif/test': 4.1.16_@oclif+core@4.8.3
       '@types/mocha': 8.2.3
       '@types/node': 14.18.63
       chai: 4.5.0
       eslint: 8.57.1
-      eslint-config-oclif: 6.0.144_avq3eyf5kaj6ssrwo7fvkrwnji
+      eslint-config-oclif: 6.0.146_avq3eyf5kaj6ssrwo7fvkrwnji
       jsdoc-to-markdown: 8.0.3
       mocha: 10.8.2
       nock: 13.5.6
@@ -967,9 +967,9 @@ importers:
       '@types/node': 14.18.63
       '@types/tar': 6.1.13
       '@types/tmp': 0.2.6
-      axios: 1.13.5
+      axios: 1.13.6
       eslint: 8.57.1
-      eslint-config-oclif: 6.0.144_avq3eyf5kaj6ssrwo7fvkrwnji
+      eslint-config-oclif: 6.0.146_avq3eyf5kaj6ssrwo7fvkrwnji
       eslint-config-oclif-typescript: 3.1.14_avq3eyf5kaj6ssrwo7fvkrwnji
       jest: 29.7.0_gmerzvnqkqd6hvbwzqmybfpwqi
       oclif: 4.22.81_@types+node@14.18.63
@@ -1028,8 +1028,8 @@ importers:
     dependencies:
       '@contentstack/management': 1.27.6
       '@contentstack/marketplace-sdk': 1.5.0
-      '@oclif/core': 4.8.1
-      axios: 1.13.5
+      '@oclif/core': 4.8.3
+      axios: 1.13.6
       chalk: 4.1.2
       cli-cursor: 3.1.0
       cli-progress: 3.12.0
@@ -1065,7 +1065,7 @@ importers:
       '@types/traverse': 0.6.37
       chai: 4.5.0
       eslint: 8.57.1
-      eslint-config-oclif: 6.0.144_avq3eyf5kaj6ssrwo7fvkrwnji
+      eslint-config-oclif: 6.0.146_avq3eyf5kaj6ssrwo7fvkrwnji
       eslint-config-oclif-typescript: 3.1.14_avq3eyf5kaj6ssrwo7fvkrwnji
       fancy-test: 2.0.42
       mocha: 10.8.2
@@ -1091,14 +1091,14 @@ importers:
       winston: ^3.17.0
     dependencies:
       '@contentstack/cli-utilities': link:../contentstack-utilities
-      '@oclif/core': 4.8.1
+      '@oclif/core': 4.8.3
       '@oclif/plugin-help': 6.2.37
       lodash: 4.17.23
       mkdirp: 1.0.4
       winston: 3.19.0
     devDependencies:
       '@contentstack/cli-dev-dependencies': link:../contentstack-dev-dependencies
-      '@oclif/test': 4.1.16_@oclif+core@4.8.1
+      '@oclif/test': 4.1.16_@oclif+core@4.8.3
       '@types/node': 20.19.35
       mocha: 10.8.2
       nyc: 15.1.0
@@ -1206,8 +1206,8 @@ packages:
       tslib: 2.8.1
     dev: true
 
-  /@aws-sdk/client-cloudfront/3.999.0:
-    resolution: {integrity: sha512-Ua/rtidq/lSqBV8Fi5pNj3Urxyglt9xWNaxx4vs5SvYB4X8qur+Q3TqiTODpPZHZLSulyOQ7US9qEThimOKpfQ==}
+  /@aws-sdk/client-cloudfront/3.1000.0:
+    resolution: {integrity: sha512-+//1gHKzap9g/jLmErpd64pPZIrM2M3jdQfQ8MXL5M0L44MKMdOhKSzN/fy0j6I4C0r4jQNEY3guSYN8dt6Utg==}
     engines: {node: '>=20.0.0'}
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
@@ -1255,8 +1255,8 @@ packages:
       - aws-crt
     dev: true
 
-  /@aws-sdk/client-s3/3.999.0:
-    resolution: {integrity: sha512-6ML2ls4nnOxm1kKzy2RgM+i8aS/9wgw6V91iqSibBYU/isYs8BvC2xcv8AsaWG5mOQjytjRzsBO5COxfWVPg3A==}
+  /@aws-sdk/client-s3/3.1000.0:
+    resolution: {integrity: sha512-7kPy33qNGq3NfwHC0412T6LDK1bp4+eiPzetX0sVd9cpTSXuQDKpoOFnB0Njj6uZjJDcLS3n2OeyarwwgkQ0Ow==}
     engines: {node: '>=20.0.0'}
     dependencies:
       '@aws-crypto/sha1-browser': 5.2.0
@@ -2103,7 +2103,7 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@contentstack/cli-utilities': 1.17.4_lxq42tdpoxpye5tb7w3htdbbdq
-      '@oclif/core': 4.8.1
+      '@oclif/core': 4.8.3
       '@oclif/plugin-help': 6.2.37
       contentstack: 3.26.4
     transitivePeerDependencies:
@@ -2119,7 +2119,7 @@ packages:
       '@apollo/client': 3.14.0_graphql@16.13.0
       '@contentstack/cli-command': 1.7.2_lxq42tdpoxpye5tb7w3htdbbdq
       '@contentstack/cli-utilities': 1.17.4_lxq42tdpoxpye5tb7w3htdbbdq
-      '@oclif/core': 4.8.1
+      '@oclif/core': 4.8.3
       '@oclif/plugin-help': 6.2.37
       '@rollup/plugin-commonjs': 28.0.9_rollup@4.59.0
       '@rollup/plugin-json': 6.1.0_rollup@4.59.0
@@ -2158,8 +2158,8 @@ packages:
     dependencies:
       '@contentstack/management': 1.27.6_debug@4.4.3
       '@contentstack/marketplace-sdk': 1.5.0_debug@4.4.3
-      '@oclif/core': 4.8.1
-      axios: 1.13.5_debug@4.4.3
+      '@oclif/core': 4.8.3
+      axios: 1.13.6_debug@4.4.3
       chalk: 4.1.2
       cli-cursor: 3.1.0
       cli-progress: 3.12.0
@@ -2213,7 +2213,7 @@ packages:
     dependencies:
       '@contentstack/utils': 1.7.1
       assert: 2.1.0
-      axios: 1.13.5
+      axios: 1.13.6
       buffer: 6.0.3
       form-data: 4.0.5
       husky: 9.1.7
@@ -2231,7 +2231,7 @@ packages:
     dependencies:
       '@contentstack/utils': 1.7.1
       assert: 2.1.0
-      axios: 1.13.5_debug@4.4.3
+      axios: 1.13.6_debug@4.4.3
       buffer: 6.0.3
       form-data: 4.0.5
       husky: 9.1.7
@@ -2247,7 +2247,7 @@ packages:
     resolution: {integrity: sha512-n2USMwswXBDtmVOg0t5FUks8X0d49u0UDFSrwxti09X/SONeP0P8wSqIDCjoB2gGRQc6fg/Fg2YPRvejUWeR4A==}
     dependencies:
       '@contentstack/utils': 1.7.1
-      axios: 1.13.5
+      axios: 1.13.6
     transitivePeerDependencies:
       - debug
     dev: false
@@ -2256,7 +2256,7 @@ packages:
     resolution: {integrity: sha512-n2USMwswXBDtmVOg0t5FUks8X0d49u0UDFSrwxti09X/SONeP0P8wSqIDCjoB2gGRQc6fg/Fg2YPRvejUWeR4A==}
     dependencies:
       '@contentstack/utils': 1.7.1
-      axios: 1.13.5_debug@4.4.3
+      axios: 1.13.6_debug@4.4.3
     transitivePeerDependencies:
       - debug
     dev: false
@@ -3869,8 +3869,8 @@ packages:
     engines: {node: '>=12.4.0'}
     dev: true
 
-  /@oclif/core/4.8.1:
-    resolution: {integrity: sha512-07mq0vKCWNsB85ZHeBMlTAiO0KLFqHyAeRK3bD2K8CI1tX3tiwkWw1lZQZkiw8MUBrhxdROhMkYMY4Q0l7JHqA==}
+  /@oclif/core/4.8.3:
+    resolution: {integrity: sha512-f7Rc1JBZO0wNMyDmNzP5IFOv5eM97S9pO4JUFdu2OLyk73YeBI9wog1Yyf666NOQvyptkbG1xh8inzMDQLNTyQ==}
     engines: {node: '>=18.0.0'}
     dependencies:
       ansi-escapes: 4.3.2
@@ -3896,14 +3896,14 @@ packages:
     resolution: {integrity: sha512-5N/X/FzlJaYfpaHwDC0YHzOzKDWa41s9t+4FpCDu4f9OMReds4JeNBaaWk9rlIzdKjh2M6AC5Q18ORfECRkHGA==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      '@oclif/core': 4.8.1
+      '@oclif/core': 4.8.3
 
   /@oclif/plugin-not-found/3.2.74:
     resolution: {integrity: sha512-6RD/EuIUGxAYR45nMQg+nw+PqwCXUxkR6Eyn+1fvbVjtb9d+60OPwB77LCRUI4zKNI+n0LOFaMniEdSpb+A7kQ==}
     engines: {node: '>=18.0.0'}
     dependencies:
       '@inquirer/prompts': 7.10.1
-      '@oclif/core': 4.8.1
+      '@oclif/core': 4.8.3
       ansis: 3.17.0
       fast-levenshtein: 3.0.0
     transitivePeerDependencies:
@@ -3915,7 +3915,7 @@ packages:
     engines: {node: '>=18.0.0'}
     dependencies:
       '@inquirer/prompts': 7.10.1_@types+node@14.18.63
-      '@oclif/core': 4.8.1
+      '@oclif/core': 4.8.3
       ansis: 3.17.0
       fast-levenshtein: 3.0.0
     transitivePeerDependencies:
@@ -3926,7 +3926,7 @@ packages:
     engines: {node: '>=18.0.0'}
     dependencies:
       '@inquirer/prompts': 7.10.1_@types+node@20.19.35
-      '@oclif/core': 4.8.1
+      '@oclif/core': 4.8.3
       ansis: 3.17.0
       fast-levenshtein: 3.0.0
     transitivePeerDependencies:
@@ -3937,7 +3937,7 @@ packages:
     resolution: {integrity: sha512-mZjRudlmVSr6Stz0CVFuaIZOjwZ5DqjWepQCR/yK9nbs8YunGautpuxBx/CcqaEH29xiQfsuNOIUWa1w/+3VSA==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      '@oclif/core': 4.8.1
+      '@oclif/core': 4.8.3
       ansis: 3.17.0
       debug: 4.4.3
       npm: 10.9.4
@@ -3956,7 +3956,7 @@ packages:
     resolution: {integrity: sha512-VIEBoaoMOCjl3y+w/kdfZMODi0mVMnDuM0vkBf3nqeidhRXVXq87hBqYDdRwN1XoD+eDfE8tBbOP7qtSOONztQ==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      '@oclif/core': 4.8.1
+      '@oclif/core': 4.8.3
       ansis: 3.17.0
       debug: 4.4.3
       http-call: 5.3.0
@@ -3966,13 +3966,13 @@ packages:
       - supports-color
     dev: true
 
-  /@oclif/test/4.1.16_@oclif+core@4.8.1:
+  /@oclif/test/4.1.16_@oclif+core@4.8.3:
     resolution: {integrity: sha512-LPrF++WGGBE0pe3GUkzEteI5WrwTT7usGpIMSxkyJhYnFXKkwASyTcCmOhNH4QC65kqsLt1oBA88BMkCJqPtxg==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       '@oclif/core': '>= 3.0.0'
     dependencies:
-      '@oclif/core': 4.8.1
+      '@oclif/core': 4.8.3
       ansis: 3.17.0
       debug: 4.4.3
     transitivePeerDependencies:
@@ -4380,8 +4380,8 @@ packages:
       '@sinonjs/commons': 3.0.1
     dev: true
 
-  /@sinonjs/fake-timers/15.1.0:
-    resolution: {integrity: sha512-cqfapCxwTGsrR80FEgOoPsTonoefMBY7dnUEbQ+GRcved0jvkJLzvX6F4WtN+HBqbPX/SiFsIRUp+IrCW/2I2w==}
+  /@sinonjs/fake-timers/15.1.1:
+    resolution: {integrity: sha512-cO5W33JgAPbOh07tvZjUOJ7oWhtaqGHiZw+11DPbyqh2kHTBc3eF/CjJDeQ4205RLQsX6rxCuYOroFQwl7JDRw==}
     dependencies:
       '@sinonjs/commons': 3.0.1
 
@@ -4393,6 +4393,7 @@ packages:
 
   /@sinonjs/text-encoding/0.7.3:
     resolution: {integrity: sha512-DE427ROAphMQzU4ENbliGYrBSYPXF+TtLg9S8vzeA+OF4ZKzoDdzfL8sxuMUGS/lgRhM6j1URSk9ghf7Xo1tyA==}
+    deprecated: 'Deprecated: no longer maintained, as we are not depending on it'
     dev: true
 
   /@smithy/abort-controller/4.2.10:
@@ -6764,8 +6765,8 @@ packages:
     dependencies:
       possible-typed-array-names: 1.1.0
 
-  /axios/1.13.5:
-    resolution: {integrity: sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==}
+  /axios/1.13.6:
+    resolution: {integrity: sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==}
     dependencies:
       follow-redirects: 1.15.11
       form-data: 4.0.5
@@ -6773,8 +6774,8 @@ packages:
     transitivePeerDependencies:
       - debug
 
-  /axios/1.13.5_debug@4.4.3:
-    resolution: {integrity: sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==}
+  /axios/1.13.6_debug@4.4.3:
+    resolution: {integrity: sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==}
     dependencies:
       follow-redirects: 1.15.11_debug@4.4.3
       form-data: 4.0.5
@@ -6942,8 +6943,8 @@ packages:
     dependencies:
       balanced-match: 1.0.2
 
-  /brace-expansion/5.0.3:
-    resolution: {integrity: sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==}
+  /brace-expansion/5.0.4:
+    resolution: {integrity: sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==}
     engines: {node: 18 || 20 || >=22}
     dependencies:
       balanced-match: 4.0.4
@@ -6971,8 +6972,8 @@ packages:
     hasBin: true
     dependencies:
       baseline-browser-mapping: 2.10.0
-      caniuse-lite: 1.0.30001774
-      electron-to-chromium: 1.5.302
+      caniuse-lite: 1.0.30001776
+      electron-to-chromium: 1.5.307
       node-releases: 2.0.27
       update-browserslist-db: 1.2.3_browserslist@4.28.1
     dev: true
@@ -7103,8 +7104,8 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /caniuse-lite/1.0.30001774:
-    resolution: {integrity: sha512-DDdwPGz99nmIEv216hKSgLD+D4ikHQHjBC/seF98N9CPqRX4M5mSxT9eTV6oyisnJcuzxtZy4n17yKKQYmYQOA==}
+  /caniuse-lite/1.0.30001776:
+    resolution: {integrity: sha512-sg01JDPzZ9jGshqKSckOQthXnYwOEP50jeVFhaSFbZcOy05TiuuaffDOfcwtCisJ9kNQuLBFibYywv2Bgm9osw==}
     dev: true
 
   /capital-case/1.0.4:
@@ -7775,8 +7776,8 @@ packages:
       mimic-response: 3.1.0
     dev: true
 
-  /dedent/1.7.1:
-    resolution: {integrity: sha512-9JmrhGZpOlEgOLdQgSm0zxFaYoQon408V1v49aqTWuXENVlnCuY9JBZcXZiCsZQWDjTm5Qf/nIvAy77mXDAjEg==}
+  /dedent/1.7.2:
+    resolution: {integrity: sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==}
     peerDependencies:
       babel-plugin-macros: ^3.1.0
     peerDependenciesMeta:
@@ -7994,8 +7995,8 @@ packages:
     dependencies:
       jake: 10.9.4
 
-  /electron-to-chromium/1.5.302:
-    resolution: {integrity: sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==}
+  /electron-to-chromium/1.5.307:
+    resolution: {integrity: sha512-5z3uFKBWjiNR44nFcYdkcXjKMbg5KXNdciu7mhTPo9tB7NbqSNP2sSnGR+fqknZSCwKkBN+oxiiajWs4dT6ORg==}
     dev: true
 
   /elegant-spinner/1.0.1:
@@ -8030,8 +8031,8 @@ packages:
       once: 1.4.0
     dev: true
 
-  /enhanced-resolve/5.19.0:
-    resolution: {integrity: sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg==}
+  /enhanced-resolve/5.20.0:
+    resolution: {integrity: sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ==}
     engines: {node: '>=10.13.0'}
     dependencies:
       graceful-fs: 4.2.11
@@ -8310,8 +8311,8 @@ packages:
       - eslint
     dev: true
 
-  /eslint-config-oclif/6.0.144_avq3eyf5kaj6ssrwo7fvkrwnji:
-    resolution: {integrity: sha512-87Zn12V0wnkxPSsm9TdIyZ4v5uNceqjMilyyR8Snk/oxCtOaawy/6mU1DwzS1zv4tnspZgeLJn+Y1ZI8Mf7BQw==}
+  /eslint-config-oclif/6.0.146_avq3eyf5kaj6ssrwo7fvkrwnji:
+    resolution: {integrity: sha512-x59Gopo4wQiuuGOUQ2D3HaIpU1LaeksPql3vTGBNnAM0dNmHWqchMvaYczoRVBx0tfGVljWGYqDA0I/355cF4Q==}
     engines: {node: '>=18.18.0'}
     dependencies:
       '@eslint/compat': 1.4.1_eslint@8.57.1
@@ -8339,8 +8340,8 @@ packages:
       - typescript
     dev: true
 
-  /eslint-config-oclif/6.0.144_eslint@8.57.1:
-    resolution: {integrity: sha512-87Zn12V0wnkxPSsm9TdIyZ4v5uNceqjMilyyR8Snk/oxCtOaawy/6mU1DwzS1zv4tnspZgeLJn+Y1ZI8Mf7BQw==}
+  /eslint-config-oclif/6.0.146_eslint@8.57.1:
+    resolution: {integrity: sha512-x59Gopo4wQiuuGOUQ2D3HaIpU1LaeksPql3vTGBNnAM0dNmHWqchMvaYczoRVBx0tfGVljWGYqDA0I/355cF4Q==}
     engines: {node: '>=18.18.0'}
     dependencies:
       '@eslint/compat': 1.4.1_eslint@8.57.1
@@ -8368,8 +8369,8 @@ packages:
       - typescript
     dev: true
 
-  /eslint-config-oclif/6.0.144_k2rwabtyo525wwqr6566umnmhy:
-    resolution: {integrity: sha512-87Zn12V0wnkxPSsm9TdIyZ4v5uNceqjMilyyR8Snk/oxCtOaawy/6mU1DwzS1zv4tnspZgeLJn+Y1ZI8Mf7BQw==}
+  /eslint-config-oclif/6.0.146_k2rwabtyo525wwqr6566umnmhy:
+    resolution: {integrity: sha512-x59Gopo4wQiuuGOUQ2D3HaIpU1LaeksPql3vTGBNnAM0dNmHWqchMvaYczoRVBx0tfGVljWGYqDA0I/355cF4Q==}
     engines: {node: '>=18.18.0'}
     dependencies:
       '@eslint/compat': 1.4.1_eslint@8.57.1
@@ -8681,7 +8682,7 @@ packages:
       eslint: '>=8.23.0'
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1_eslint@8.57.1
-      enhanced-resolve: 5.19.0
+      enhanced-resolve: 5.20.0
       eslint: 8.57.1
       eslint-plugin-es-x: 7.8.0_eslint@8.57.1
       get-tsconfig: 4.13.6
@@ -8701,7 +8702,7 @@ packages:
       eslint: '>=8.23.0'
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1_eslint@8.57.1
-      enhanced-resolve: 5.19.0
+      enhanced-resolve: 5.20.0
       eslint: 8.57.1
       eslint-plugin-es-x: 7.8.0_eslint@8.57.1
       get-tsconfig: 4.13.6
@@ -8721,7 +8722,7 @@ packages:
       eslint: '>=8.23.0'
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1_eslint@8.57.1
-      enhanced-resolve: 5.19.0
+      enhanced-resolve: 5.20.0
       eslint: 8.57.1
       eslint-plugin-es-x: 7.8.0_eslint@8.57.1
       get-tsconfig: 4.13.6
@@ -9317,7 +9318,7 @@ packages:
     resolution: {integrity: sha512-QNI3sAvSvaOiaMl8FYU4trnEzCwiRr8XMWgAHzlrWpTSj+QaCSvOf1h82OEP1s4hiAXhnbXSyFWCf4ldZzZRVA==}
     hasBin: true
     dependencies:
-      strnum: 2.1.2
+      strnum: 2.2.0
     dev: true
 
   /fastest-levenshtein/1.0.16:
@@ -9486,7 +9487,7 @@ packages:
     resolution: {integrity: sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==}
     engines: {node: ^10.12.0 || >=12.0.0}
     dependencies:
-      flatted: 3.3.3
+      flatted: 3.3.4
       keyv: 4.5.4
       rimraf: 3.0.2
     dev: true
@@ -9495,7 +9496,7 @@ packages:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
     dependencies:
-      flatted: 3.3.3
+      flatted: 3.3.4
       keyv: 4.5.4
     dev: true
 
@@ -9504,8 +9505,8 @@ packages:
     hasBin: true
     dev: true
 
-  /flatted/3.3.3:
-    resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
+  /flatted/3.3.4:
+    resolution: {integrity: sha512-3+mMldrTAPdta5kjX2G2J7iX4zxtnwpdA8Tr2ZSjkyPSanvbZAcy6flmtnXbEybHrDcU9641lxrMfFuUxVz9vA==}
     dev: true
 
   /fn.name/1.1.0:
@@ -9623,6 +9624,7 @@ packages:
   /fs-then-native/2.0.0:
     resolution: {integrity: sha512-X712jAOaWXkemQCAmWeg5rOT2i+KOpWz1Z/txk/cW0qlOu2oQ9H61vc5w3X/iyuUEfq/OyaFJ78/cZAQD1/bgA==}
     engines: {node: '>=4.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     dev: true
 
   /fs.realpath/1.0.0:
@@ -9714,7 +9716,7 @@ packages:
     resolution: {integrity: sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==}
     engines: {node: '>=6'}
     dependencies:
-      pump: 3.0.3
+      pump: 3.0.4
     dev: true
 
   /get-stream/6.0.1:
@@ -10788,7 +10790,7 @@ packages:
       '@types/node': 20.19.35
       chalk: 4.1.2
       co: 4.6.0
-      dedent: 1.7.1
+      dedent: 1.7.2
       is-generator-fn: 2.1.0
       jest-each: 29.7.0
       jest-matcher-utils: 29.7.0
@@ -11901,7 +11903,7 @@ packages:
     resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
     engines: {node: 18 || 20 || >=22}
     dependencies:
-      brace-expansion: 5.0.3
+      brace-expansion: 5.0.4
 
   /minimatch/3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
@@ -12065,11 +12067,11 @@ packages:
       path-to-regexp: 6.3.0
     dev: true
 
-  /nise/6.1.1:
-    resolution: {integrity: sha512-aMSAzLVY7LyeM60gvBS423nBmIPP+Wy7St7hsb+8/fc1HmeoHJfLO8CKse4u3BtOZvQLJghYPI2i/1WZrEj5/g==}
+  /nise/6.1.2:
+    resolution: {integrity: sha512-zPM6UobDUDnhGcaWYjzig0tZCv4tXfF/1fnV58mfzL7pXSEwDLG0lXreuZ3u19O2ABghlYO8tFL1m1hrKUz/nw==}
     dependencies:
       '@sinonjs/commons': 3.0.1
-      '@sinonjs/fake-timers': 13.0.5
+      '@sinonjs/fake-timers': 15.1.1
       '@sinonjs/text-encoding': 0.7.3
       just-extend: 6.2.0
       path-to-regexp: 8.3.0
@@ -12382,12 +12384,12 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
     dependencies:
-      '@aws-sdk/client-cloudfront': 3.999.0
-      '@aws-sdk/client-s3': 3.999.0
+      '@aws-sdk/client-cloudfront': 3.1000.0
+      '@aws-sdk/client-s3': 3.1000.0
       '@inquirer/confirm': 3.2.0
       '@inquirer/input': 2.3.0
       '@inquirer/select': 2.5.0
-      '@oclif/core': 4.8.1
+      '@oclif/core': 4.8.3
       '@oclif/plugin-help': 6.2.37
       '@oclif/plugin-not-found': 3.2.74
       '@oclif/plugin-warn-if-update-available': 3.1.55
@@ -12417,12 +12419,12 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
     dependencies:
-      '@aws-sdk/client-cloudfront': 3.999.0
-      '@aws-sdk/client-s3': 3.999.0
+      '@aws-sdk/client-cloudfront': 3.1000.0
+      '@aws-sdk/client-s3': 3.1000.0
       '@inquirer/confirm': 3.2.0
       '@inquirer/input': 2.3.0
       '@inquirer/select': 2.5.0
-      '@oclif/core': 4.8.1
+      '@oclif/core': 4.8.3
       '@oclif/plugin-help': 6.2.37
       '@oclif/plugin-not-found': 3.2.74_@types+node@14.18.63
       '@oclif/plugin-warn-if-update-available': 3.1.55
@@ -12452,12 +12454,12 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
     dependencies:
-      '@aws-sdk/client-cloudfront': 3.999.0
-      '@aws-sdk/client-s3': 3.999.0
+      '@aws-sdk/client-cloudfront': 3.1000.0
+      '@aws-sdk/client-s3': 3.1000.0
       '@inquirer/confirm': 3.2.0
       '@inquirer/input': 2.3.0
       '@inquirer/select': 2.5.0
-      '@oclif/core': 4.8.1
+      '@oclif/core': 4.8.3
       '@oclif/plugin-help': 6.2.37
       '@oclif/plugin-not-found': 3.2.74_@types+node@20.19.35
       '@oclif/plugin-warn-if-update-available': 3.1.55
@@ -12957,8 +12959,8 @@ packages:
       punycode: 2.3.1
     dev: false
 
-  /pump/3.0.3:
-    resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
+  /pump/3.0.4:
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
     dependencies:
       end-of-stream: 1.4.5
       once: 1.4.0
@@ -13703,7 +13705,7 @@ packages:
       '@sinonjs/fake-timers': 13.0.5
       '@sinonjs/samsam': 8.0.3
       diff: 7.0.0
-      nise: 6.1.1
+      nise: 6.1.2
       supports-color: 7.2.0
     dev: true
 
@@ -13711,7 +13713,7 @@ packages:
     resolution: {integrity: sha512-Z0NVCW45W8Mg5oC/27/+fCqIHFnW8kpkFOq0j9XJIev4Ld0mKmERaZv5DMLAb9fGCevjKwaEeIQz5+MBXfZcDw==}
     dependencies:
       '@sinonjs/commons': 3.0.1
-      '@sinonjs/fake-timers': 15.1.0
+      '@sinonjs/fake-timers': 15.1.1
       '@sinonjs/samsam': 8.0.3
       diff: 8.0.3
       supports-color: 7.2.0
@@ -14074,8 +14076,8 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /strnum/2.1.2:
-    resolution: {integrity: sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==}
+  /strnum/2.2.0:
+    resolution: {integrity: sha512-Y7Bj8XyJxnPAORMZj/xltsfo55uOiyHcU2tnAVzHUnSJR/KsEX+9RoDeXEnsXtl/CX4fAcrt64gZ13aGaWPeBg==}
     dev: true
 
   /supports-color/2.0.0:
@@ -14173,6 +14175,7 @@ packages:
   /test-value/2.1.0:
     resolution: {integrity: sha512-+1epbAxtKeXttkGFMTX9H42oqzOTufR1ceCF+GYA5aOmvaPq9wd4PUS8329fn2RRLGNeUkgRLnVpycjx8DsO2w==}
     engines: {node: '>=0.10.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     dependencies:
       array-back: 1.0.4
       typical: 2.6.1
@@ -14181,6 +14184,7 @@ packages:
   /test-value/3.0.0:
     resolution: {integrity: sha512-sVACdAWcZkSU9x7AOmJo5TqE+GyNJknHaHsMrR6ZnhjVlVN9Yx6FjHrsKZ3BjIpPCT68zYesPWkakrNupwfOTQ==}
     engines: {node: '>=4.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     dependencies:
       array-back: 2.0.0
       typical: 2.6.1


### PR DESCRIPTION
## Problem

1. **Interactive prompts after command correction:** When an invalid command is corrected (e.g. `csdx loginasda` → "Did you mean login?" → Yes), the CLI shows i18n keys (e.g. `CLI_AUTH_LOGIN_ENTER_EMAIL_ADDRESS`) instead of user-friendly text (e.g. **"Enter your email address"**).

2. **Logout confirmation message:** When the user answers **No** to "Are you sure you want to log out?", the CLI still shows "SUCCESS: You're already logged out", which is incorrect—the user chose not to log out and remains logged in.

## Solution

### 1. Human-readable prompts after command correction
- **New prerun hook** `init-context-for-command`: When `context.messageFilePath` is missing and the current command id is available (e.g. after correction), re-build `CsdxContext` for that command and re-initialize `messageHandler`, `cliux`, and SDK initiators so the correct plugin message file is loaded.
- Hook is registered as the first prerun hook.

### 2. Correct message when user cancels logout
- Added message key `CLI_AUTH_LOGOUT_CANCELLED`: "Log out cancelled".
- In `auth:logout`, when the user answers **No** to the confirmation and is still authenticated, show **"Log out cancelled"** instead of "You're already logged out". "You're already logged out" is now only shown when the user is actually not authenticated.

## Testing

**Interactive prompts (command correction):**
1. Run `csdx loginasda` (or `node bin/run.js loginasda` from `packages/contentstack`).
2. At "Did you mean login?", answer **Yes**.
3. **Expected:** Prompt shows **"Enter your email address"** (not the key).

**Logout cancel:**
1. Run `csdx auth:login` and log in.
2. Run `csdx auth:logout`, answer **No** to the confirmation.
3. **Expected:** Message shows **"Log out cancelled"** (not "You're already logged out").
4. Run `csdx whoami` to confirm you are still logged in.

