### PR TITLE
docs: comprehensive README audit, package.json standardization, and source fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ CLI supports content management scripts through which you can perform the follow
 ## Installing CLI
 ### Prerequisites
 Contentstack account
-Node.js version 16 or above
+Node.js version 22 or above
 
 ### Installation
 To install CLI on your system, run the below command in your terminal:
@@ -54,7 +54,7 @@ $ csdx --help
 ## Namespaces
 **auth**: To perform [authentication-related](/packages/contentstack-auth) activities
 
-**cm**: To perform content management activities such as [bulk publish](/packages/contentstack-bulk-publish), [import](/packages/contentstack-import), and [export](/packages/contentstack-export), [export-to-csv] (/packages/contentstack-export-to-csv), [seed] (/packages/contentstack-seed)
+**cm**: To perform content management activities such as [bulk operations](/packages/contentstack-bulk-operations), [import](/packages/contentstack-import), and [export](/packages/contentstack-export), [export-to-csv](/packages/contentstack-export-to-csv), [seed](/packages/contentstack-seed)
 
 **help**: To list the helpful commands in CLI
 
@@ -62,8 +62,8 @@ $ csdx --help
 
 ## Documentation
 
-To get a more detailed documentation for every command, visit the [CLI section](https://www.contentstack.com/docs/developers/cli) in our docs.
+To get a more detailed documentation for every command, visit the [CLI section](https://www.contentstack.com/docs/headless-cms/cli) in our docs.
 
 ## Useful Plugins
 
-- [Generate TypeScript typings from a Stack](https://github.com/Contentstack-Solutions/contentstack-cli-tsgen)
+- [Generate TypeScript typings from a Stack](https://github.com/contentstack/cli-plugins/tree/main/packages/contentstack-cli-tsgen)

--- a/packages/contentstack-auth/README.md
+++ b/packages/contentstack-auth/README.md
@@ -1,6 +1,6 @@
 # @contentstack/cli-auth
 
-It is Contentstack’s CLI plugin to perform authentication-related activities. To get started with authentication, refer to the [CLI’s Authentication documentation](https://www.contentstack.com/docs/developers/cli/authentication)
+It is Contentstack’s CLI plugin to perform authentication-related activities. To get started with authentication, refer to the [CLI’s Authentication documentation](https://www.contentstack.com/docs/headless-cms/cli/authentication)
 
 [![License](https://img.shields.io/npm/l/@contentstack/cli)](https://github.com/contentstack/cli/blob/main/LICENSE)
 
@@ -18,7 +18,7 @@ $ npm install -g @contentstack/cli-auth
 $ csdx COMMAND
 running command...
 $ csdx (--version)
-@contentstack/cli-auth/2.0.0-beta.10 darwin-arm64 node-v22.13.1
+@contentstack/cli-auth/2.0.0-beta.15 darwin-arm64 node-v22.21.1
 $ csdx --help [COMMAND]
 USAGE
   $ csdx COMMAND
@@ -33,11 +33,11 @@ USAGE
 * [`csdx auth:logout`](#csdx-authlogout)
 * [`csdx auth:tokens`](#csdx-authtokens)
 * [`csdx auth:tokens:add [-a <value>] [--delivery] [--management] [-e <value>] [-k <value>] [-y] [--token <value>]`](#csdx-authtokensadd--a-value---delivery---management--e-value--k-value--y---token-value)
+* [`csdx auth:tokens:list`](#csdx-authtokenslist)
 * [`csdx auth:tokens:remove`](#csdx-authtokensremove)
 * [`csdx auth:whoami`](#csdx-authwhoami)
 * [`csdx login`](#csdx-login)
 * [`csdx logout`](#csdx-logout)
-* [`csdx tokens`](#csdx-tokens)
 * [`csdx whoami`](#csdx-whoami)
 
 ## `csdx auth:login`
@@ -102,7 +102,7 @@ _See code: [src/commands/auth/logout.ts](https://github.com/contentstack/cli/blo
 
 ## `csdx auth:tokens`
 
-Lists all existing tokens added to the session
+Manage authentication tokens for API access
 
 ```
 USAGE
@@ -120,13 +120,14 @@ TABLE FLAGS
   --sort=<value>     Sort the table by a column. Use "-" for descending.
 
 DESCRIPTION
-  Lists all existing tokens added to the session
-
-ALIASES
-  $ csdx tokens
+  Manage authentication tokens for API access
 
 EXAMPLES
-  $ csdx auth:tokens
+  $ csdx auth:tokens:list
+
+  $ csdx auth:tokens:add --alias mytoken
+
+  $ csdx auth:tokens:remove --alias mytoken
 ```
 
 _See code: [src/commands/auth/tokens/index.ts](https://github.com/contentstack/cli/blob/main/packages/contentstack-auth/src/commands/auth/tokens/index.ts)_
@@ -177,17 +178,44 @@ EXAMPLES
 
 _See code: [src/commands/auth/tokens/add.ts](https://github.com/contentstack/cli/blob/main/packages/contentstack-auth/src/commands/auth/tokens/add.ts)_
 
+## `csdx auth:tokens:list`
+
+Lists all existing tokens added to the session
+
+```
+USAGE
+  $ csdx auth:tokens:list [--columns <value>] [--sort <value>] [--filter <value>] [--csv] [--no-truncate]
+    [--no-header] [--output csv|json|yaml]
+
+TABLE FLAGS
+  --columns=<value>  Specify columns to display, comma-separated.
+  --csv              Output results in CSV format.
+  --filter=<value>   Filter rows by a column value (e.g., name=foo).
+  --no-header        Hide table headers in output.
+  --no-truncate      Prevent truncation of long text in columns.
+  --output=<option>  Specify output format: csv, json, or yaml.
+                     <options: csv|json|yaml>
+  --sort=<value>     Sort the table by a column. Use "-" for descending.
+
+DESCRIPTION
+  Lists all existing tokens added to the session
+
+EXAMPLES
+  $ csdx auth:tokens:list
+```
+
+_See code: [src/commands/auth/tokens/list.ts](https://github.com/contentstack/cli/blob/main/packages/contentstack-auth/src/commands/auth/tokens/list.ts)_
+
 ## `csdx auth:tokens:remove`
 
 Removes selected tokens
 
 ```
 USAGE
-  $ csdx auth:tokens:remove [-a <value>] [-i]
+  $ csdx auth:tokens:remove [-a <value>]
 
 FLAGS
   -a, --alias=<value>  Alias (name) of the token to delete.
-  -i, --ignore         Ignores if the token is not present.
 
 DESCRIPTION
   Removes selected tokens
@@ -202,14 +230,14 @@ _See code: [src/commands/auth/tokens/remove.ts](https://github.com/contentstack/
 
 ## `csdx auth:whoami`
 
-Display current users email address
+Display current user's email address
 
 ```
 USAGE
   $ csdx auth:whoami
 
 DESCRIPTION
-  Display current users email address
+  Display current user's email address
 
 ALIASES
   $ csdx whoami
@@ -276,45 +304,16 @@ EXAMPLES
   $ csdx auth:logout --yes
 ```
 
-## `csdx tokens`
-
-Lists all existing tokens added to the session
-
-```
-USAGE
-  $ csdx tokens [--columns <value>] [--sort <value>] [--filter <value>] [--csv] [--no-truncate]
-    [--no-header] [--output csv|json|yaml]
-
-TABLE FLAGS
-  --columns=<value>  Specify columns to display, comma-separated.
-  --csv              Output results in CSV format.
-  --filter=<value>   Filter rows by a column value (e.g., name=foo).
-  --no-header        Hide table headers in output.
-  --no-truncate      Prevent truncation of long text in columns.
-  --output=<option>  Specify output format: csv, json, or yaml.
-                     <options: csv|json|yaml>
-  --sort=<value>     Sort the table by a column. Use "-" for descending.
-
-DESCRIPTION
-  Lists all existing tokens added to the session
-
-ALIASES
-  $ csdx tokens
-
-EXAMPLES
-  $ csdx auth:tokens
-```
-
 ## `csdx whoami`
 
-Display current users email address
+Display current user's email address
 
 ```
 USAGE
   $ csdx whoami
 
 DESCRIPTION
-  Display current users email address
+  Display current user's email address
 
 ALIASES
   $ csdx whoami

--- a/packages/contentstack-auth/package.json
+++ b/packages/contentstack-auth/package.json
@@ -75,5 +75,9 @@
       "auth:tokens:remove": "RMVTKN"
     }
   },
-  "repository": "contentstack/cli"
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/contentstack/cli.git",
+    "directory": "packages/contentstack-auth"
+  }
 }

--- a/packages/contentstack-auth/src/commands/auth/whoami.ts
+++ b/packages/contentstack-auth/src/commands/auth/whoami.ts
@@ -2,7 +2,7 @@ import { cliux, log, handleAndLogError, messageHandler } from '@contentstack/cli
 import { BaseCommand } from '../../base-command';
 
 export default class WhoamiCommand extends BaseCommand<typeof WhoamiCommand> {
-  static description = 'Display current users email address';
+  static description = "Display current user's email address";
 
   static examples = ['$ csdx auth:whoami'];
 

--- a/packages/contentstack-command/package.json
+++ b/packages/contentstack-command/package.json
@@ -61,5 +61,9 @@
     "bin": "csdx",
     "repositoryPrefix": "<%- repo %>/blob/main/packages/contentstack-command/<%- commandPath %>"
   },
-  "repository": "contentstack/cli"
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/contentstack/cli.git",
+    "directory": "packages/contentstack-command"
+  }
 }

--- a/packages/contentstack-config/README.md
+++ b/packages/contentstack-config/README.md
@@ -1,6 +1,6 @@
 # @contentstack/cli-config
 
-The config namespace contains all the commands that you will need to configure the CLI as per your requirements. Contentstack currently supports four regions: North America, Europe, Azure North America and Azure Europe. [Configure the CLI documentation](https://www.contentstack.com/docs/developers/cli/configure-the-cli)
+The config namespace contains all the commands that you will need to configure the CLI as per your requirements. Contentstack supports multiple regions. [Configure the CLI documentation](https://www.contentstack.com/docs/headless-cms/configure-the-cli)
 
 [![License](https://img.shields.io/npm/l/@contentstack/cli)](https://github.com/contentstack/cli/blob/main/LICENSE)
 
@@ -18,7 +18,7 @@ $ npm install -g @contentstack/cli-config
 $ csdx COMMAND
 running command...
 $ csdx (--version)
-@contentstack/cli-config/2.0.0-beta.7 darwin-arm64 node-v22.13.1
+@contentstack/cli-config/2.0.0-beta.13 darwin-arm64 node-v22.21.1
 $ csdx --help [COMMAND]
 USAGE
   $ csdx COMMAND
@@ -316,8 +316,8 @@ USAGE
   $ csdx config:set:ea-header [--header-alias <value>] [--header <value>]
 
 FLAGS
-  --header=<value>        (optional) Provide the Early Access header alias name.
-  --header-alias=<value>  (optional) Provide the Early Access header value.
+  --header=<value>        (optional) Provide the Early Access header value.
+  --header-alias=<value>  (optional) Provide a name (alias) for this Early Access header.
 
 DESCRIPTION
   Set Early Access header
@@ -340,8 +340,8 @@ USAGE
   $ csdx config:set:early-access-header [--header-alias <value>] [--header <value>]
 
 FLAGS
-  --header=<value>        (optional) Provide the Early Access header alias name.
-  --header-alias=<value>  (optional) Provide the Early Access header value.
+  --header=<value>        (optional) Provide the Early Access header value.
+  --header-alias=<value>  (optional) Provide a name (alias) for this Early Access header.
 
 DESCRIPTION
   Set Early Access header
@@ -456,26 +456,25 @@ Set region for CLI
 
 ```
 USAGE
-  $ csdx config:set:region [REGION] [--cda <value> --cma <value> --ui-host <value> -n <value>] [--developer-hub
-    <value>] [--personalize <value>] [--launch <value>] [--studio <value>] [--asset-management <value>]
+  $ csdx config:set:region [REGION] [--cda <value> --cma <value> --ui-host <value> --name <value>] [--developer-hub
+    <value>] [--personalize <value>] [--launch <value>] [--studio <value>] [--cs-assets <value>]
 
 ARGUMENTS
   [REGION]  Name for the region
 
 FLAGS
-  -n, --name=<value>              Name for the region, if this flag is added then cda, cma and ui-host flags are
-                                  required
-      --asset-management=<value>  Custom host to set for Asset Management API
-      --cda=<value>               Custom host to set for content delivery API, if this flag is added then cma, ui-host
-                                  and name flags are required
-      --cma=<value>               Custom host to set for content management API, , if this flag is added then cda,
-                                  ui-host and name flags are required
-      --developer-hub=<value>     Custom host to set for Developer hub API
-      --launch=<value>            Custom host to set for Launch API
-      --personalize=<value>       Custom host to set for Personalize API
-      --studio=<value>            Custom host to set for Studio API
-      --ui-host=<value>           Custom UI host to set for CLI, if this flag is added then cda, cma and name flags are
-                                  required
+  --cda=<value>            Custom host to set for content delivery API, if this flag is added then cma, ui-host and name
+                           flags are required
+  --cma=<value>            Custom host to set for content management API, , if this flag is added then cda, ui-host and
+                           name flags are required
+  --cs-assets=<value>      Custom host to set for Contentstack Assets API
+  --developer-hub=<value>  Custom host to set for Developer hub API
+  --launch=<value>         Custom host to set for Launch API
+  --name=<value>           Name for the region, if this flag is added then cda, cma and ui-host flags are required
+  --personalize=<value>    Custom host to set for Personalize API
+  --studio=<value>         Custom host to set for Studio API
+  --ui-host=<value>        Custom UI host to set for CLI, if this flag is added then cda, cma and name flags are
+                           required
 
 DESCRIPTION
   Set region for CLI
@@ -507,7 +506,7 @@ EXAMPLES
 
   $ csdx config:set:region --cma <custom_cma_host_url> --cda <custom_cda_host_url> --ui-host <custom_ui_host_url> --name "India" --studio <custom_studio_url>
 
-  $ csdx config:set:region --cma <custom_cma_host_url> --cda <custom_cda_host_url> --ui-host <custom_ui_host_url> --name "India" --asset-management <asset_management_url>
+  $ csdx config:set:region --cma <custom_cma_host_url> --cda <custom_cda_host_url> --ui-host <custom_ui_host_url> --name "India" --cs-assets <cs_assets_url>
 
   $ csdx config:set:region --cda <custom_cda_host_url> --cma <custom_cma_host_url> --ui-host <custom_ui_host_url> --name "India" --developer-hub <custom_developer_hub_url> --launch <custom_launch_url> --personalize <custom_personalize_url> --studio <custom_studio_url>
 ```

--- a/packages/contentstack-config/package.json
+++ b/packages/contentstack-config/package.json
@@ -90,5 +90,9 @@
       "config:remove:rate-limit": "RLRM"
     }
   },
-  "repository": "contentstack/cli"
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/contentstack/cli.git",
+    "directory": "packages/contentstack-config"
+  }
 }

--- a/packages/contentstack-config/src/commands/config/set/early-access-header.ts
+++ b/packages/contentstack-config/src/commands/config/set/early-access-header.ts
@@ -6,8 +6,8 @@ export default class SetEarlyAccessHeaderCommand extends Command {
   static description = 'Set Early Access header';
   static aliases: string[] = ['config:set:ea-header'];
   static flags: FlagInput = {
-    'header-alias': flags.string({ description: '(optional) Provide the Early Access header value.' }),
-    header: flags.string({ description: '(optional) Provide the Early Access header alias name.' }),
+    'header-alias': flags.string({ description: '(optional) Provide a name (alias) for this Early Access header.' }),
+    header: flags.string({ description: '(optional) Provide the Early Access header value.' }),
   };
   static examples: string[] = [
     '$ <%= config.bin %> <%= command.id %>',

--- a/packages/contentstack-utilities/package.json
+++ b/packages/contentstack-utilities/package.json
@@ -14,7 +14,8 @@
   },
   "repository": {
     "type": "git",
-    "url": ""
+    "url": "git+https://github.com/contentstack/cli.git",
+    "directory": "packages/contentstack-utilities"
   },
   "keywords": [
     "contentstack",

--- a/packages/contentstack/README.md
+++ b/packages/contentstack/README.md
@@ -1,6 +1,6 @@
 # @contentstack/cli
 
-Use Contentstack Command-line Interface to command Contentstack for executing a set of operations from the terminal. To get started with CLI, refer to the [CLI’s documentation](https://www.contentstack.com/docs/developers/cli)
+Use Contentstack Command-line Interface to command Contentstack for executing a set of operations from the terminal. To get started with CLI, refer to the [CLI’s documentation](https://www.contentstack.com/docs/headless-cms/cli)
 
 [![License](https://img.shields.io/npm/l/@contentstack/cli)](https://github.com/contentstack/cli/blob/main/LICENSE)
 
@@ -18,7 +18,7 @@ $ npm install -g @contentstack/cli
 $ csdx COMMAND
 running command...
 $ csdx (--version|-v)
-@contentstack/cli/2.0.0-beta.19 darwin-arm64 node-v22.13.1
+@contentstack/cli/2.0.0-beta.26 darwin-arm64 node-v22.21.1
 $ csdx --help [COMMAND]
 USAGE
   $ csdx COMMAND
@@ -33,6 +33,7 @@ USAGE
 * [`csdx auth:logout`](#csdx-authlogout)
 * [`csdx auth:tokens`](#csdx-authtokens)
 * [`csdx auth:tokens:add [-a <value>] [--delivery] [--management] [-e <value>] [-k <value>] [-y] [--token <value>]`](#csdx-authtokensadd--a-value---delivery---management--e-value--k-value--y---token-value)
+* [`csdx auth:tokens:list`](#csdx-authtokenslist)
 * [`csdx auth:tokens:remove`](#csdx-authtokensremove)
 * [`csdx auth:whoami`](#csdx-authwhoami)
 * [`csdx cm:bootstrap`](#csdx-cmbootstrap)
@@ -41,25 +42,20 @@ USAGE
 * [`csdx cm:branches:delete [-uid <value>] [-k <value>]`](#csdx-cmbranchesdelete--uid-value--k-value)
 * [`csdx cm:branches:diff [--base-branch <value>] [--compare-branch <value>] [-k <value>][--module <value>] [--format <value>] [--csv-path <value>]`](#csdx-cmbranchesdiff---base-branch-value---compare-branch-value--k-value--module-value---format-value---csv-path-value)
 * [`csdx cm:branches:merge [-k <value>][--compare-branch <value>] [--no-revert] [--export-summary-path <value>] [--use-merge-summary <value>] [--comment <value>] [--base-branch <value>]`](#csdx-cmbranchesmerge--k-value--compare-branch-value---no-revert---export-summary-path-value---use-merge-summary-value---comment-value---base-branch-value)
-<<<<<<< HEAD
-=======
 * [`csdx cm:branches:merge-status -k <value> --merge-uid <value>`](#csdx-cmbranchesmerge-status--k-value---merge-uid-value)
-* [`csdx cm:bulk-publish`](#csdx-cmbulk-publish)
+* [`csdx cm:export-to-csv`](#csdx-cmexport-to-csv)
 * [`csdx cm:stacks:audit`](#csdx-cmstacksaudit)
 * [`csdx cm:stacks:audit:fix`](#csdx-cmstacksauditfix)
+* [`csdx cm:stacks:bulk-am-assets`](#csdx-cmstacksbulk-am-assets)
 * [`csdx cm:stacks:bulk-assets`](#csdx-cmstacksbulk-assets)
 * [`csdx cm:stacks:bulk-entries`](#csdx-cmstacksbulk-entries)
+* [`csdx cm:stacks:bulk-taxonomies`](#csdx-cmstacksbulk-taxonomies)
 * [`csdx cm:stacks:clone [--source-branch <value>] [--target-branch <value>] [--source-management-token-alias <value>] [--destination-management-token-alias <value>] [-n <value>] [--type a|b] [--source-stack-api-key <value>] [--destination-stack-api-key <value>] [--import-webhook-status disable|current]`](#csdx-cmstacksclone---source-branch-value---target-branch-value---source-management-token-alias-value---destination-management-token-alias-value--n-value---type-ab---source-stack-api-key-value---destination-stack-api-key-value---import-webhook-status-disablecurrent)
 * [`csdx cm:stacks:export [--config <value>] [--stack-api-key <value>] [--data-dir <value>] [--alias <value>] [--module <value>] [--content-types <value>] [--branch <value>] [--secured-assets]`](#csdx-cmstacksexport---config-value---stack-api-key-value---data-dir-value---alias-value---module-value---content-types-value---branch-value---secured-assets)
 * [`csdx cm:stacks:import [--config <value>] [--stack-api-key <value>] [--data-dir <value>] [--alias <value>] [--module <value>] [--backup-dir <value>] [--branch <value>] [--import-webhook-status disable|current]`](#csdx-cmstacksimport---config-value---stack-api-key-value---data-dir-value---alias-value---module-value---backup-dir-value---branch-value---import-webhook-status-disablecurrent)
-* [`csdx cm:stacks:import-setup [-k <value>] [-d <value>] [-a <value>] [--modules <value,value>]`](#csdx-cmstacksimport-setup--k-value--d-value--a-value---modules-valuevalue)
+* [`csdx cm:stacks:import-setup [-k <value>] [-d <value>] [-a <value>] [--module <value>...]`](#csdx-cmstacksimport-setup--k-value--d-value--a-value---module-value)
 * [`csdx cm:stacks:migration [-k <value>] [-a <value>] [--file-path <value>] [--branch <value>] [--config-file <value>] [--config <value>] [--multiple]`](#csdx-cmstacksmigration--k-value--a-value---file-path-value---branch-value---config-file-value---config-value---multiple)
-* [`csdx cm:stacks:publish`](#csdx-cmstackspublish)
-* [`csdx cm:stacks:publish-clear-logs`](#csdx-cmstackspublish-clear-logs)
-* [`csdx cm:stacks:publish-configure`](#csdx-cmstackspublish-configure)
-* [`csdx cm:stacks:publish-revert`](#csdx-cmstackspublish-revert)
-* [`csdx cm:stacks:seed [--repo <value>] [--org <value>] [-k <value>] [-n <value>] [-y <value>] [-s <value>] [--locale <value>]`](#csdx-cmstacksseed---repo-value---org-value--k-value--n-value--y-value--s-value---locale-value)
-* [`csdx csdx cm:stacks:unpublish [-a <value>] [-e <value>] [-c <value>] [-y] [--locale <value>] [--branch <value>] [--retry-failed <value>] [--bulk-unpublish <value>] [--content-type <value>] [--delivery-token <value>] [--only-assets] [--only-entries]`](#csdx-csdx-cmstacksunpublish--a-value--e-value--c-value--y---locale-value---branch-value---retry-failed-value---bulk-unpublish-value---content-type-value---delivery-token-value---only-assets---only-entries)
+* [`csdx cm:stacks:seed [--repo <value>] [--org <value>] [--stack-api-key <value>] [--stack-name <value>] [-y] [--alias <value>] [--locale <value>]`](#csdx-cmstacksseed---repo-value---org-value---stack-api-key-value---stack-name-value--y---alias-value---locale-value)
 * [`csdx config:get:base-branch`](#csdx-configgetbase-branch)
 * [`csdx config:get:ea-header`](#csdx-configgetea-header)
 * [`csdx config:get:early-access-header`](#csdx-configgetearly-access-header)
@@ -86,6 +82,7 @@ USAGE
 * [`csdx launch:functions`](#csdx-launchfunctions)
 * [`csdx launch:logs`](#csdx-launchlogs)
 * [`csdx launch:open`](#csdx-launchopen)
+* [`csdx launch:rollback`](#csdx-launchrollback)
 * [`csdx login`](#csdx-login)
 * [`csdx logout`](#csdx-logout)
 * [`csdx plugins`](#csdx-plugins)
@@ -98,7 +95,6 @@ USAGE
 * [`csdx plugins:uninstall [PLUGIN]`](#csdx-pluginsuninstall-plugin)
 * [`csdx plugins:unlink [PLUGIN]`](#csdx-pluginsunlink-plugin)
 * [`csdx plugins:update`](#csdx-pluginsupdate)
-* [`csdx tokens`](#csdx-tokens)
 * [`csdx whoami`](#csdx-whoami)
 
 ## `csdx auth:login`
@@ -163,7 +159,7 @@ _See code: [@contentstack/cli-auth](https://github.com/contentstack/cli/blob/mai
 
 ## `csdx auth:tokens`
 
-Lists all existing tokens added to the session
+Manage authentication tokens for API access
 
 ```
 USAGE
@@ -181,13 +177,14 @@ TABLE FLAGS
   --sort=<value>     Sort the table by a column. Use "-" for descending.
 
 DESCRIPTION
-  Lists all existing tokens added to the session
-
-ALIASES
-  $ csdx tokens
+  Manage authentication tokens for API access
 
 EXAMPLES
-  $ csdx auth:tokens
+  $ csdx auth:tokens:list
+
+  $ csdx auth:tokens:add --alias mytoken
+
+  $ csdx auth:tokens:remove --alias mytoken
 ```
 
 _See code: [@contentstack/cli-auth](https://github.com/contentstack/cli/blob/main/packages/contentstack-auth/src/commands/auth/tokens/index.ts)_
@@ -238,17 +235,44 @@ EXAMPLES
 
 _See code: [@contentstack/cli-auth](https://github.com/contentstack/cli/blob/main/packages/contentstack-auth/src/commands/auth/tokens/add.ts)_
 
+## `csdx auth:tokens:list`
+
+Lists all existing tokens added to the session
+
+```
+USAGE
+  $ csdx auth:tokens:list [--columns <value>] [--sort <value>] [--filter <value>] [--csv] [--no-truncate]
+    [--no-header] [--output csv|json|yaml]
+
+TABLE FLAGS
+  --columns=<value>  Specify columns to display, comma-separated.
+  --csv              Output results in CSV format.
+  --filter=<value>   Filter rows by a column value (e.g., name=foo).
+  --no-header        Hide table headers in output.
+  --no-truncate      Prevent truncation of long text in columns.
+  --output=<option>  Specify output format: csv, json, or yaml.
+                     <options: csv|json|yaml>
+  --sort=<value>     Sort the table by a column. Use "-" for descending.
+
+DESCRIPTION
+  Lists all existing tokens added to the session
+
+EXAMPLES
+  $ csdx auth:tokens:list
+```
+
+_See code: [@contentstack/cli-auth](https://github.com/contentstack/cli/blob/main/packages/contentstack-auth/src/commands/auth/tokens/list.ts)_
+
 ## `csdx auth:tokens:remove`
 
 Removes selected tokens
 
 ```
 USAGE
-  $ csdx auth:tokens:remove [-a <value>] [-i]
+  $ csdx auth:tokens:remove [-a <value>]
 
 FLAGS
   -a, --alias=<value>  Alias (name) of the token to delete.
-  -i, --ignore         Ignores if the token is not present.
 
 DESCRIPTION
   Removes selected tokens
@@ -263,14 +287,14 @@ _See code: [@contentstack/cli-auth](https://github.com/contentstack/cli/blob/mai
 
 ## `csdx auth:whoami`
 
-Display current users email address
+Display current user's email address
 
 ```
 USAGE
   $ csdx auth:whoami
 
 DESCRIPTION
-  Display current users email address
+  Display current user's email address
 
 ALIASES
   $ csdx whoami
@@ -319,7 +343,7 @@ EXAMPLES
   $ csdx cm:bootstrap --app-name "kickstart-next" --project-dir <path/to/setup/the/app> --run-dev-server
 ```
 
-_See code: [@contentstack/cli-cm-bootstrap](https://github.com/contentstack/cli/blob/main/packages/contentstack-bootstrap/src/commands/cm/bootstrap.ts)_
+_See code: [@contentstack/cli-cm-bootstrap](https://github.com/contentstack/cli-plugins/blob/main/packages/contentstack-bootstrap/src/commands/cm/bootstrap.ts)_
 
 ## `csdx cm:branches`
 
@@ -344,7 +368,7 @@ EXAMPLES
   $ csdx cm:branches -k <stack api key>
 ```
 
-_See code: [@contentstack/cli-cm-branches](https://github.com/contentstack/cli/blob/main/packages/contentstack-export/src/commands/cm/branches/index.ts)_
+_See code: [@contentstack/cli-cm-branches](https://github.com/contentstack/cli-plugins/blob/main/packages/contentstack-branches/src/commands/cm/branches/index.ts)_
 
 ## `csdx cm:branches:create`
 
@@ -372,7 +396,7 @@ EXAMPLES
   $ csdx cm:branches:create --source main --uid new_branch --stack-api-key bltxxxxxxxx
 ```
 
-_See code: [@contentstack/cli-cm-branches](https://github.com/contentstack/cli/blob/main/packages/contentstack-export/src/commands/cm/branches/create.ts)_
+_See code: [@contentstack/cli-cm-branches](https://github.com/contentstack/cli-plugins/blob/main/packages/contentstack-branches/src/commands/cm/branches/create.ts)_
 
 ## `csdx cm:branches:delete [-uid <value>] [-k <value>]`
 
@@ -401,7 +425,7 @@ EXAMPLES
   $ csdx cm:branches:delete --uid main --stack-api-key bltxxxxxxxx --yes
 ```
 
-_See code: [@contentstack/cli-cm-branches](https://github.com/contentstack/cli/blob/main/packages/contentstack-export/src/commands/cm/branches/delete.ts)_
+_See code: [@contentstack/cli-cm-branches](https://github.com/contentstack/cli-plugins/blob/main/packages/contentstack-branches/src/commands/cm/branches/delete.ts)_
 
 ## `csdx cm:branches:diff [--base-branch <value>] [--compare-branch <value>] [-k <value>][--module <value>] [--format <value>] [--csv-path <value>]`
 
@@ -457,7 +481,7 @@ EXAMPLES
   $ csdx cm:branches:diff --stack-api-key "bltxxxxxxxx" --base-branch "main" --compare-branch "develop" --module "content-types" --format "detailed-text" --csv-path "./reports/diff-report.csv"
 ```
 
-_See code: [@contentstack/cli-cm-branches](https://github.com/contentstack/cli/blob/main/packages/contentstack-export/src/commands/cm/branches/diff.ts)_
+_See code: [@contentstack/cli-cm-branches](https://github.com/contentstack/cli-plugins/blob/main/packages/contentstack-branches/src/commands/cm/branches/diff.ts)_
 
 ## `csdx cm:branches:merge [-k <value>][--compare-branch <value>] [--no-revert] [--export-summary-path <value>] [--use-merge-summary <value>] [--comment <value>] [--base-branch <value>]`
 
@@ -496,10 +520,8 @@ EXAMPLES
   $ csdx cm:branches:merge -k bltxxxxxxxx --compare-branch feature-branch --no-revert
 ```
 
-_See code: [@contentstack/cli-cm-branches](https://github.com/contentstack/cli/blob/main/packages/contentstack-export/src/commands/cm/branches/merge.ts)_
+_See code: [@contentstack/cli-cm-branches](https://github.com/contentstack/cli-plugins/blob/main/packages/contentstack-branches/src/commands/cm/branches/merge.ts)_
 
-<<<<<<< HEAD
-=======
 ## `csdx cm:branches:merge-status -k <value> --merge-uid <value>`
 
 Check the status of a branch merge job
@@ -521,1677 +543,49 @@ EXAMPLES
   $ csdx cm:branches:merge-status --stack-api-key bltxxxxxxxx --merge-uid merge_abc123
 ```
 
-_See code: [@contentstack/cli-cm-branches](https://github.com/contentstack/cli/blob/main/packages/contentstack-export/src/commands/cm/branches/merge-status.ts)_
+_See code: [@contentstack/cli-cm-branches](https://github.com/contentstack/cli-plugins/blob/main/packages/contentstack-branches/src/commands/cm/branches/merge-status.ts)_
 
-## `csdx cm:bulk-publish`
-
-Bulk Publish script for managing entries and assets
-
-```
-USAGE
-  $ csdx cm:bulk-publish
-
-DESCRIPTION
-  Bulk Publish script for managing entries and assets
-```
-
-_See code: [@contentstack/cli-cm-bulk-publish](https://github.com/contentstack/cli/blob/main/packages/contentstack-bulk-publish/src/commands/cm/bulk-publish/index.js)_
-
-## `csdx cm:entries:update-and-publish [-a <value>] [--retry-failed <value>] [--bulk-publish <value>] [--content-types <value>] [-t <value>] [-e <value>] [-c <value>] [-y] [--locales <value>] [--branch <value>]`
-
-Add fields from updated content types to their respective entries
-
-```
-USAGE
-  $ csdx cm:bulk-publish:add-fields cm:entries:update-and-publish [-a <value>] [--retry-failed <value>] [--bulk-publish <value>]
-    [--content-types <value>] [-t <value>] [-e <value>] [-c <value>] [-y] [--locales <value>] [--branch <value>]
-
-FLAGS
-  -B, --branch=<value>            [default: main] The name of the branch where you want to perform the bulk publish
-                                  operation. If you don’t mention the branch name, then by default the content from the
-                                  main branch will be published.
-  -a, --alias=<value>             Alias (name) of the management token. You must use either the --alias flag or the
-                                  --stack-api-key flag.
-  -c, --config=<value>            (optional) The path of the optional configuration JSON file containing all the options
-                                  for a single run. Refer to the configure command to create a configuration file.
-  -e, --environments=<value>...   The name of the environment on which entries will be published. In case of multiple
-                                  environments, specify their names separated by spaces.
-  -k, --stack-api-key=<value>     API key of the source stack. You must use either the --stack-api-key flag or the
-                                  --alias flag.
-  -l, --locales=<value>...        Locales in which entries will be published, e.g., en-us. In the case of multiple
-                                  locales, specify the codes separated by spaces.
-  -t, --contentTypes=<value>...   The Contenttypes from which entries will be published.
-  -y, --yes                       Set it to true to process the command with the current configuration.
-      --api-version=<value>       API version to be used. Values [Default: 3, Nested Reference Publishing: 3.2].
-      --bulk-publish=<value>      [default: true] Set this flag to use Contentstack’s Bulk Publish APIs. It is true, by
-                                  default.
-      --content-types=<value>...  The UID of the content type ID whose entries you want to publish in bulk. In case of
-                                  multiple content types, specify their IDs separated by spaces.
-      --force                     Update and publish all entries even if no fields have been added.
-      --retry-failed=<value>      Use this option to retry publishing the failed entries from the logfile. Specify the
-                                  name of the logfile that lists failed publish calls. If this option is used, it will
-                                  override all other flags.
-
-DESCRIPTION
-  Add fields from updated content types to their respective entries
-  The update-and-publish command is used to update existing entries with the updated schema of the respective content
-  type
-
-  Note: Content types, Environments and Locales are required to execute the command successfully
-  But, if retry-failed flag is set, then only a logfile is required
-
-
-ALIASES
-  $ csdx cm:bulk-publish:add-fields
-
-EXAMPLES
-  General Usage
-
-  $ csdx cm:entries:update-and-publish --content-types [CONTENT TYPE 1] [CONTENT TYPE 2] -e [ENVIRONMENT 1] [ENVIRONMENT 2] --locales [LOCALE 1] [LOCALE 2] -a [MANAGEMENT TOKEN ALIAS]
-
-
-
-  Using --config or -c flag
-
-  Generate a config file at the current working directory using `csdx cm:stacks:publish-configure -a [ALIAS]`
-
-  $ csdx cm:entries:update-and-publish --config [PATH TO CONFIG FILE]
-
-  $ csdx cm:entries:update-and-publish -c [PATH TO CONFIG FILE]
-
-
-
-  Using --retry-failed
-
-  $ csdx cm:entries:update-and-publish --retry-failed [LOG FILE NAME]
-
-
-
-  Using --branch
-
-  $ csdx cm:entries:update-and-publish --content-types [CONTENT TYPE 1] [CONTENT TYPE 2] -e [ENVIRONMENT 1] [ENVIRONMENT 2] --locales [LOCALE 1] [LOCALE 2] -a [MANAGEMENT TOKEN ALIAS] --branch [BRANCH NAME]
-
-
-
-  Using --stack-api-key
-
-  $ csdx cm:entries:update-and-publish --content-types [CONTENT TYPE 1] [CONTENT TYPE 2] -e [ENVIRONMENT 1] [ENVIRONMENT 2] --locales [LOCALE 1] [LOCALE 2] --stack-api-key [STACK API KEY]
-```
-
-## `csdx cm:assets:publish [-a <value>] [--retry-failed <value>] [-e <value>] [--folder-uid <value>] [--bulk-publish <value>] [-c <value>] [-y] [--locales <value>] [--branch <value>] [--delivery-token <value>] [--source-env <value>]`
-
-Publish assets to the specified environments
-
-```
-USAGE
-  $ csdx cm:bulk-publish:assets cm:assets:publish [-a <value>] [--retry-failed <value>] [-e <value>] [--folder-uid <value>]
-    [--bulk-publish <value>] [-c <value>] [-y] [--locales <value>] [--branch <value>] [--delivery-token <value>]
-    [--source-env <value>]
-
-FLAGS
-  -B, --branch=<value>           [default: main] The name of the branch where you want to perform the bulk publish
-                                 operation. If you don’t mention the branch name, then by default the assets from the
-                                 main branch will be published.
-  -a, --alias=<value>            Alias (name) for the management token. You must use either the --alias flag or the
-                                 --stack-api-key flag.
-  -c, --config=<value>           (optional) The path of the optional configuration JSON file containing all the options
-                                 for a single run. Refer to the configure command to create a configuration file.
-  -e, --environments=<value>...  The name of the environment on which entries will be published. In case of multiple
-                                 environments, specify their names separated by spaces.
-  -k, --stack-api-key=<value>    API key of the source stack. You must use either the --stack-api-key flag or the
-                                 --alias flag.
-  -l, --locales=<value>...       Locales in which assets will be published, e.g., en-us. In the case of multiple
-                                 locales, specify the codes separated by spaces.
-  -y, --yes                      Set it to true to process the command with the current configuration.
-      --api-version=<value>      API version to be used. Values [Default: 3, Nested Reference Publishing: 3.2].
-      --bulk-publish=<value>     [default: true] Set this flag to use Contentstack’s Bulk Publish APIs. It is true, by
-                                 default.
-      --delivery-token=<value>   The delivery token of the source environment.
-      --folder-uid=<value>       (optional) The UID of the Assets’ folder from which the assets need to be published.
-                                 The default value is cs_root.
-      --retry-failed=<value>     Use this option to retry publishing the failed assets from the logfile. Specify the
-                                 name of the logfile that lists failed publish calls. If this option is used, it will
-                                 override all other flags.
-      --source-env=<value>       Source environment
-
-DESCRIPTION
-  Publish assets to the specified environments
-  The assets command is used to publish assets from the specified stack, to the specified environments
-
-  Note: Environment(s) and Locale(s) are required to execute the command successfully
-  But, if retryFailed flag is set, then only a logfile is required
-
-
-ALIASES
-  $ csdx cm:bulk-publish:assets
-
-EXAMPLES
-  General Usage
-
-  $ csdx cm:assets:publish --environments [ENVIRONMENT 1] [ENVIRONMENT 2] --locales [LOCALE] --alias [MANAGEMENT TOKEN ALIAS]
-
-
-
-  Using --config or -c flag
-
-  Generate a config file at the current working directory using `csdx cm:stacks:publish-configure -a [ALIAS]`
-
-  $ csdx cm:assets:publish --config [PATH TO CONFIG FILE]
-
-  $ csdx cm:assets:publish -c [PATH TO CONFIG FILE]
-
-
-
-  Using --retry-failed flag
-
-  $ csdx cm:assets:publish --retry-failed [LOG FILE NAME]
-
-
-
-  Using --branch flag
-
-  $ csdx cm:assets:publish --environments [ENVIRONMENT 1] [ENVIRONMENT 2] --locales [LOCALE] --alias [MANAGEMENT TOKEN ALIAS] --branch [BRANCH NAME]
-
-
-
-  Using --source-env
-
-  $ csdx cm:assets:publish --environments [ENVIRONMENT 1] [ENVIRONMENT 2] --locales [LOCALE] --alias [MANAGEMENT TOKEN ALIAS] --source-env [SOURCE ENVIRONMENT] --delivery-token [DELIVERY TOKEN]
-
-
-
-  Using --stack-api-key flag
-
-  $ csdx cm:assets:publish --environments [ENVIRONMENT 1] [ENVIRONMENT 2] --locales [LOCALE] --stack-api-key [STACK API KEY]
-```
-
-## `csdx cm:bulk-publish:clear`
-
-Clear the log folder
-
-```
-USAGE
-  $ csdx cm:bulk-publish:clear [--log-files-count] [-y]
-
-FLAGS
-  -y, --yes              Delete all files without asking for confirmation
-      --log-files-count  List number of log files
-
-DESCRIPTION
-  Clear the log folder
-
-ALIASES
-  $ csdx cm:bulk-publish:clear
-
-EXAMPLES
-  $ csdx cm:stacks:publish-clear-logs
-
-  $ csdx cm:stacks:publish-clear-logs --log-files-count
-
-  $ csdx cm:stacks:publish-clear-logs --yes
-
-  $ csdx cm:stacks:publish-clear-logs -y
-```
-
-## `csdx cm:bulk-publish:configure`
-
-The configure command is used to generate a configuration file for publish scripts.
-
-```
-USAGE
-  $ csdx cm:bulk-publish:configure [-a <value>] [-k <value>]
-
-FLAGS
-  -a, --alias=<value>          Name (alias) of the management token you want to use. You must use either the --alias
-                               flag or the --stack-api-key flag.
-  -k, --stack-api-key=<value>  API key of the source stack. You must use either the --stack-api-key flag or the --alias
-                               flag.
-
-DESCRIPTION
-  The configure command is used to generate a configuration file for publish scripts.
-
-ALIASES
-  $ csdx cm:bulk-publish:configure
-
-EXAMPLES
-  $ csdx cm:stacks:publish-configure
-
-  $ csdx cm:stacks:publish-configure -a <management_token_alias>
-
-  $ csdx cm:stacks:publish-configure --alias <management_token_alias>
-
-  $ csdx cm:stacks:publish-configure --stack-api-key <stack_api_key>
-```
-
-## `csdx cm:bulk-publish:cross-publish [-a <value>] [--retry-failed <value>] [--bulk-publish <value>] [--content-type <value>] [--locales <value>] [--source-env <value>] [--environments <value>] [--delivery-token <value>] [-c <value>] [-y] [--branch <value>] [--onlyAssets] [--onlyEntries] [--include-variants]`
-
-Publish entries and assets from one environment to other environments
-
-```
-USAGE
-  $ csdx cm:bulk-publish:cross-publish [-a <value>] [--retry-failed <value>] [--bulk-publish <value>] [--content-type <value>]
-    [--locales <value>] [--source-env <value>] [--environments <value>] [--delivery-token <value>] [-c <value>] [-y]
-    [--branch <value>] [--onlyAssets] [--onlyEntries] [--include-variants]
-
-FLAGS
-  -B, --branch=<value>           [default: main] Specify the branch to fetch the content (by default the main branch is
-                                 selected)
-  -a, --alias=<value>            Alias(name) for the management token
-  -c, --config=<value>           Path to the config file
-  -k, --stack-api-key=<value>    Stack API key to be used
-  -y, --yes                      Agree to process the command with the current configuration
-      --api-version=<value>      API version to be used. Values [Default: 3, Nested Reference Publishing: 3.2].
-      --bulk-publish=<value>     [default: true] Set this flag to use Contentstack’s Bulk Publish APIs. It is true, by
-                                 default.
-      --content-type=<value>...  The Contenttypes from which entries will be published
-      --delivery-token=<value>   The delivery token of the source environment.
-      --environments=<value>...  Destination Environments
-      --include-variants         Include Variants flag will publish all associated variant entries.
-      --locales=<value>          Source locale
-      --onlyAssets               Unpublish only assets
-      --onlyEntries              Unpublish only entries
-      --retry-failed=<value>     (optional) Retry publishing failed entries from the logfile (this flag overrides all
-                                 other flags)
-      --source-env=<value>       Source Env
-
-DESCRIPTION
-  Publish entries and assets from one environment to other environments
-  The cross-publish command is used to publish entries and assets from one environment to other environments
-
-  Note: Content Type, Environment, Destination Environment(s) and Locale are required to execute the command
-  successfully
-  But, if retryFailed flag is set, then only a logfile is required
-
-
-EXAMPLES
-  General Usage
-
-  $ csdx cm:bulk-publish:cross-publish --content-type [CONTENT TYPE] --source-env [SOURCE ENV] --environments [DESTINATION ENVIRONMENT] --locales [LOCALE] -a [MANAGEMENT TOKEN ALIAS] --delivery-token [DELIVERY TOKEN]
-
-
-
-  Using --config or -c flag
-
-  Generate a config file at the current working directory using `csdx cm:bulk-publish:configure -a [ALIAS]`
-
-  $ csdx cm:bulk-publish:cross-publish --config [PATH TO CONFIG FILE]
-
-  $ csdx cm:bulk-publish:cross-publish -c [PATH TO CONFIG FILE]
-
-
-
-  Using --retry-failed flag
-
-  $ csdx cm:bulk-publish:cross-publish --retry-failed [LOG FILE NAME]
-
-  $ csdx cm:bulk-publish:cross-publish -r [LOG FILE NAME]
-
-
-
-  Using --branch flag
-
-  $ csdx cm:bulk-publish:cross-publish --content-type [CONTENT TYPE] --source-env [SOURCE ENV] --environments [DESTINATION ENVIRONMENT] --locales [LOCALE] -a [MANAGEMENT TOKEN ALIAS] --delivery-token [DELIVERY TOKEN] --branch [BRANCH NAME]
-
-
-
-  Using --stack-api-key flag
-
-  $ csdx cm:bulk-publish:cross-publish --content-type [CONTENT TYPE] --source-env [SOURCE ENV] --environments [DESTINATION ENVIRONMENT] --locales [LOCALE] --stack-api-key [STACK API KEY] --delivery-token [DELIVERY TOKEN]
-
-
-
-  Using --include-variants flag
-
-  $ csdx cm:bulk-publish:cross-publish --content-type [CONTENT TYPE] --source-env [SOURCE ENV] --environments [DESTINATION ENVIRONMENT] --locales [LOCALE] --stack-api-key [STACK API KEY] --delivery-token [DELIVERY TOKEN] [--include-variants]
-```
-
-_See code: [@contentstack/cli-cm-bulk-publish](https://github.com/contentstack/cli/blob/main/packages/contentstack-bulk-publish/src/commands/cm/bulk-publish/cross-publish.js)_
-
-## `csdx cm:entries:publish [-a <value>] [--retry-failed <value>] [--bulk-publish <value>] [--publish-all-content-types] [--content-types <value>] [--locales <value>] [-e <value>] [-c <value>] [-y] [--branch <value>] [--delivery-token <value>] [--source-env <value>] [--entry-uid <value>] [--include-variants]`
-
-Publish entries from multiple contenttypes to multiple environments and locales
-
-```
-USAGE
-  $ csdx cm:bulk-publish:entries cm:entries:publish [-a <value>] [--retry-failed <value>] [--bulk-publish <value>]
-    [--publish-all-content-types] [--content-types <value>] [--locales <value>] [-e <value>] [-c <value>] [-y] [--branch
-    <value>] [--delivery-token <value>] [--source-env <value>] [--entry-uid <value>] [--include-variants]
-
-FLAGS
-  -B, --branch=<value>             [default: main] The name of the branch where you want to perform the bulk publish
-                                   operation. If you don’t mention the branch name, then by default the content from
-                                   main branch will be published.
-  -a, --alias=<value>              Alias (name) of the management token. You must use either the --alias flag or the
-                                   --stack-api-key flag.
-  -c, --config=<value>             (optional) The path of the optional configuration JSON file containing all the
-                                   options for a single run. Refer to the configure command to create a configuration
-                                   file.
-  -e, --environments=<value>...    The name of the environment on which entries will be published. In case of multiple
-                                   environments, specify their names separated by spaces.
-  -k, --stack-api-key=<value>      API key of the source stack. You must use either the --stack-api-key flag or the
-                                   --alias flag.
-  -l, --locales=<value>...         Locales in which entries will be published, e.g., en-us. In the case of multiple
-                                   locales, specify the codes separated by spaces.
-  -y, --yes                        Set it to true to process the command with the current configuration.
-      --api-version=<value>        API version to be used. Values [Default: 3, Nested Reference Publishing: 3.2].
-      --bulk-publish=<value>       [default: true] Set this flag to use Contentstack's Bulk Publish APIs. This flag is
-                                   set to true, by default.
-      --content-types=<value>...   The UID of the content type(s) whose entries you want to publish in bulk. In case of
-                                   multiple content types, specify the IDs separated by spaces.
-      --delivery-token=<value>     The delivery token of the source environment.
-      --entry-uid=<value>          Entry Uid for publish all associated variant entries.
-      --include-variants           Include Variants flag will publish all associated variant entries with base entry.
-      --publish-all-content-types  (optional) Set it to true to bulk publish entries from all content types. If the
-                                   --content-types option is already used, then you cannot use this option.
-      --retry-failed=<value>       (optional) Use this option to retry publishing the failed entries/ assets from the
-                                   logfile. Specify the name of the logfile that lists failed publish calls. If this
-                                   option is used, it will override all other flags.
-      --source-env=<value>         Source environment
-
-DESCRIPTION
-  Publish entries from multiple contenttypes to multiple environments and locales
-  The publish command is used to publish entries from the specified content types, to the
-  specified environments and locales
-
-  Note: Content Types, Environments and Locales are required to execute the command successfully
-  But, if retry-failed flag is set, then only a logfile is required
-
-
-ALIASES
-  $ csdx cm:bulk-publish:entries
-
-EXAMPLES
-  General Usage
-
-  $ csdx cm:entries:publish --content-types [CONTENT TYPE 1] [CONTENT TYPE 2] -e [ENVIRONMENT 1] [ENVIRONMENT 2] --locales [LOCALE 1] [LOCALE 2] -a [MANAGEMENT TOKEN ALIAS]
-
-
-
-  Using --config or -c flag
-
-  Generate a config file at the current working directory using `csdx cm:stacks:publish-configure -a [ALIAS]`
-
-  $ csdx cm:entries:publish --config [PATH TO CONFIG FILE]
-
-  $ csdx cm:entries:publish -c [PATH TO CONFIG FILE]
-
-
-
-  Using --retry-failed
-
-  $ csdx cm:entries:publish --retry-failed [LOG FILE NAME]
-
-  $ csdx cm:entries:publish -r [LOG FILE NAME]
-
-
-
-  Using --branch
-
-  $ csdx cm:entries:publish --content-types [CONTENT TYPE 1] [CONTENT TYPE 2] -e [ENVIRONMENT 1] [ENVIRONMENT 2] --locales [LOCALE 1] [LOCALE 2] -a [MANAGEMENT TOKEN ALIAS] --branch [BRANCH NAME]
-
-
-
-  Using --source-env
-
-  $ csdx cm:entries:publish --content-types [CONTENT TYPE 1] [CONTENT TYPE 2] -e [ENVIRONMENT 1] [ENVIRONMENT 2] --locales [LOCALE 1] [LOCALE 2] -a [MANAGEMENT TOKEN ALIAS] --source-env [SOURCE ENVIRONMENT] --delivery-token [DELIVERY TOKEN]
-
-
-
-  Using --stack-api-key
-
-  $ csdx cm:entries:publish -e [ENVIRONMENT 1] [ENVIRONMENT 2] --locales [LOCALE 1] [LOCALE 2] --stack-api-key [STACK API KEY] --source-env [SOURCE ENVIRONMENT] --delivery-token [DELIVERY TOKEN]
-
-
-
-  Using --include-variants
-
-  $ csdx cm:entries:publish --content-types [CONTENT TYPE 1] [CONTENT TYPE 2] -e [ENVIRONMENT 1] [ENVIRONMENT 2] --locales [LOCALE 1] [LOCALE 2] --stack-api-key [STACK API KEY] --source-env [SOURCE ENVIRONMENT] --delivery-token [DELIVERY TOKEN] [--include-variants]
-
-
-
-  Using --entry-uid and --include-variants
-
-  $ csdx cm:entries:publish --content-types [CONTENT TYPE 1] [CONTENT TYPE 2] -e [ENVIRONMENT 1] [ENVIRONMENT 2] --locales [LOCALE 1] [LOCALE 2] --stack-api-key [STACK API KEY] --source-env [SOURCE ENVIRONMENT] --delivery-token [DELIVERY TOKEN] --entry-uid [ENTRY UID] [--include-variants]
-```
-
-## `csdx cm:entries:publish-modified [-a <value>] [--retry-failed <value>] [--bulk-publish <value>] [--source-env <value>] [--content-types <value>] [--locales <value>] [-e <value>] [-c <value>] [-y] [--branch <value>]`
-
-Publish edited entries from a specified content type to the given locales and environments
-
-```
-USAGE
-  $ csdx cm:bulk-publish:entry-edits cm:entries:publish-modified [-a <value>] [--retry-failed <value>] [--bulk-publish <value>]
-    [--source-env <value>] [--content-types <value>] [--locales <value>] [-e <value>] [-c <value>] [-y] [--branch
-    <value>]
-
-FLAGS
-  -B, --branch=<value>            [default: main] The name of the branch where you want to perform the bulk publish
-                                  operation. If you don't mention the branch name, then by default the entries from main
-                                  branch will be published.
-  -a, --alias=<value>             Alias (name) of the management token. You must use either the --alias flag or the
-                                  --stack-api-key flag.
-  -c, --config=<value>            (optional) The path of the optional configuration JSON file containing all the options
-                                  for a single run. Refer to the configure command to create a configuration file.
-  -e, --environments=<value>...   The name of the environment(s) on which the entries will be published. In case of
-                                  multiple environments, specify their names separated by spaces.
-  -k, --stack-api-key=<value>     API key of the source stack. You must use either the --stack-api-key flag or the
-                                  --alias flag.
-  -l, --locales=<value>...        Locales in which entries will be published, e.g., en-us. In the case of multiple
-                                  locales, specify the codes separated by spaces.
-  -y, --yes                       Set it to true to process the command with the current configuration.
-      --api-version=<value>       API version to be used. Values [Default: 3, Nested Reference Publishing: 3.2].
-      --bulk-publish=<value>      [default: true] Set this flag to use Contentstack's Bulk Publish APIs. It is true, by
-                                  default.
-      --content-types=<value>...  The UID of the content type(s) whose edited entries you want to publish in bulk. In
-                                  case of multiple content types, specify the IDs separated by spaces.
-      --retry-failed=<value>      (optional) Use this option to retry publishing the failed entries/assets from the
-                                  logfile. Specify the name of the logfile that lists failed publish calls. If this
-                                  option is used, it will override all other flags
-      --source-env=<value>        The name of the source environment where the entries were initially published.
-
-DESCRIPTION
-  Publish edited entries from a specified content type to the given locales and environments
-  The publish-modified command is used to publish entries from the specified content types, to the
-  specified environments and locales
-
-  Note: Content type(s), Source Environment, Destination Environment(s) and Locale(s) are required to execute the
-  command successfully
-  But, if retry-failed flag is set, then only a logfile is required
-
-
-ALIASES
-  $ csdx cm:bulk-publish:entry-edits
-
-EXAMPLES
-  General Usage
-
-  $ csdx cm:entries:publish-modified --content-types [CONTENT TYPE 1] [CONTENT TYPE 2] --source-env [SOURCE_ENV] -e [ENVIRONMENT 1] [ENVIRONMENT 2] --locales [LOCALE 1] [LOCALE 2] -a [MANAGEMENT TOKEN ALIAS]
-
-
-
-  Using --config or -c flag
-
-  Generate a config file at the current working directory using `csdx cm:stacks:publish-configure -a [ALIAS]`
-
-  $ csdx cm:entries:publish-modified --config [PATH TO CONFIG FILE]
-
-  $ csdx cm:entries:publish-modified -c [PATH TO CONFIG FILE]
-
-
-
-  Using --retry-failed
-
-  $ csdx cm:entries:publish-modified --retry-failed [LOG FILE NAME]
-
-  $ csdx cm:entries:publish-modified -r [LOG FILE NAME]
-
-
-
-  Using --branch
-
-  $ csdx cm:entries:publish-modified --content-types [CONTENT TYPE 1] [CONTENT TYPE 2] --source-env [SOURCE_ENV] -e [ENVIRONMENT 1] [ENVIRONMENT 2] --locales [LOCALE 1] [LOCALE 2] -a [MANAGEMENT TOKEN ALIAS] --branch [BRANCH NAME]
-
-
-
-  Using --stack-api-key
-
-  $ csdx cm:entries:publish-modified --content-types [CONTENT TYPE 1] [CONTENT TYPE 2] --source-env [SOURCE_ENV] -e [ENVIRONMENT 1] [ENVIRONMENT 2] --locales [LOCALE 1] [LOCALE 2] -stack-api-key [STACK API KEY]
-```
-
-## `csdx cm:entries:publish-non-localized-fields [-a <value>] [--retry-failed <value>] [--bulk-publish <value>] [--source-env <value>] [--content-types <value>] [-e <value>] [-c <value>] [-y] [--branch <value>]`
-
-Publish non-localized fields for the given content types, from a particular source environment to the specified environments
-
-```
-USAGE
-  $ csdx cm:bulk-publish:nonlocalized-field-changes cm:entries:publish-non-localized-fields [-a <value>] [--retry-failed <value>]
-    [--bulk-publish <value>] [--source-env <value>] [--content-types <value>] [-e <value>] [-c <value>] [-y] [--branch
-    <value>]
-
-FLAGS
-  -B, --branch=<value>            [default: main] The name of the branch where you want to perform the bulk publish
-                                  operation. If you don’t mention the branch name, then by default the content from the
-                                  main branch will be published.
-  -a, --alias=<value>             Alias (name) of the management token. You must use either the --alias flag or the
-                                  --stack-api-key flag.
-  -c, --config=<value>            (optional) The path of the optional configuration JSON file containing all the options
-                                  for a single run. Refer to the configure command to create a configuration file.
-  -e, --environments=<value>...   The name of the environment on which entries will be published. In case of multiple
-                                  environments, specify their names separated by spaces.
-  -k, --stack-api-key=<value>     API key of the source stack. You must use either the --stack-api-key flag or the
-                                  --alias flag.
-  -y, --yes                       Set it to true to process the command with the current configuration.
-      --api-version=<value>       API version to be used. Values [Default: 3, Nested Reference Publishing: 3.2].
-      --bulk-publish=<value>      [default: true] Set this flag to use Contentstack’s Bulk Publish APIs. It is true, by
-                                  default.
-      --content-types=<value>...  The UID of the content type whose entries you want to publish in bulk. In case of
-                                  multiple content types, specify their IDs separated by spaces.
-      --retry-failed=<value>      Use this option to retry publishing the failed entries from the logfile. Specify the
-                                  name of the logfile that lists failed publish calls. If this option is used, it will
-                                  override all other flags.
-      --source-env=<value>        The name of the source environment.
-
-DESCRIPTION
-  Publish non-localized fields for the given content types, from a particular source environment to the specified
-  environments
-  The non-localized field changes command is used to publish non-localized field changes from the given content types to
-  the specified environments
-
-  Note: Content types, Environments and Source Environment are required to execute this command successfully.
-  But, if retryFailed flag is set, then only a logfile is required
-
-ALIASES
-  $ csdx cm:bulk-publish:nonlocalized-field-changes
-
-EXAMPLES
-  General Usage
-
-  $ csdx cm:entries:publish-non-localized-fields --content-types [CONTENT TYPE 1] [CONTENT TYPE 2] --environments [ENVIRONMENT 1] [ENVIRONMENT 2] --alias [MANAGEMENT TOKEN ALIAS] --source-env [SOURCE ENV]
-
-
-
-  Using --config or -c flag
-
-  Generate a config file at the current working directory using `csdx cm:bulk-publish:configure -a [ALIAS]`
-
-  $ csdx cm:entries:publish-non-localized-fields --config [PATH TO CONFIG FILE]
-
-  $ csdx cm:entries:publish-non-localized-fields -c [PATH TO CONFIG FILE]
-
-
-
-  Using --retry-failed flag
-
-  $ csdx cm:entries:publish-non-localized-fields --retry-failed [LOG FILE NAME]
-
-
-
-  Using --branch flag
-
-  $ csdx cm:entries:publish-non-localized-fields --content-types [CONTENT TYPE 1] [CONTENT TYPE 2] --environments [ENVIRONMENT 1] [ENVIRONMENT 2] --alias [MANAGEMENT TOKEN ALIAS] --source-env [SOURCE ENV] --branch [BRANCH NAME]
-
-
-
-  Using --stack-api-key flag
-
-  $ csdx cm:entries:publish-non-localized-fields --content-types [CONTENT TYPE 1] [CONTENT TYPE 2] --environments [ENVIRONMENT 1] [ENVIRONMENT 2] --stack-api-key [STACK API KEY] --source-env [SOURCE ENV]
-```
-
-## `csdx cm:bulk-publish:revert`
-
-Revert publish operations by using a log file
-
-```
-USAGE
-  $ csdx cm:bulk-publish:revert [--retry-failed <value>] [--log-file <value>]
-
-FLAGS
-  --log-file=<value>      Path of the success logfile of a particular publish action.
-  --retry-failed=<value>  (optional)  Use this option to retry publishing the failed entries from the logfile. Specify
-                          the name of the logfile that lists failed publish calls. If this option is used, it will
-                          override all other flags.
-
-DESCRIPTION
-  Revert publish operations by using a log file
-  The revert command is used to revert all publish operations performed using bulk-publish script.
-  A log file name is required to execute revert command
-
-
-ALIASES
-  $ csdx cm:bulk-publish:revert
-
-EXAMPLES
-  Using --log-file
-
-  cm:bulk-publish:revert --log-file [LOG FILE NAME]
-
-
-
-  Using --retry-failed
-
-  cm:bulk-publish:revert --retry-failed [LOG FILE NAME]
-```
-
-## `csdx csdx cm:stacks:unpublish [-a <value>] [-e <value>] [-c <value>] [-y] [--locale <value>] [--branch <value>] [--retry-failed <value>] [--bulk-unpublish <value>] [--content-type <value>] [--delivery-token <value>] [--only-assets] [--only-entries]`
-
-Unpublish entries or assets of given content types from the specified environment
-
-```
-USAGE
-  $ csdx cm:bulk-publish:unpublish csdx cm:stacks:unpublish [-a <value>] [-e <value>] [-c <value>] [-y] [--locale <value>]
-    [--branch <value>] [--retry-failed <value>] [--bulk-unpublish <value>] [--content-type <value>] [--delivery-token
-    <value>] [--only-assets] [--only-entries]
-
-FLAGS
-  -B, --branch=<value>          [default: main] Specify the branch to fetch the content from (default is main branch)
-  -a, --alias=<value>           Alias(name) for the management token
-  -c, --config=<value>          Path to the config file
-  -e, --environment=<value>     Source Environment
-  -k, --stack-api-key=<value>   Stack API key to be used
-  -l, --locale=<value>          Locale filter
-  -y, --yes                     Agree to process the command with the current configuration
-      --api-version=<value>     API version to be used. Values [Default: 3, Nested Reference Publishing: 3.2].
-      --bulk-unpublish=<value>  [default: true] This flag is set to true by default. It indicates that contentstack's
-                                bulkpublish API will be used to unpublish the entries and assets
-      --content-type=<value>    Content type filter
-      --delivery-token=<value>  The delivery token of the source environment.
-      --retry-failed=<value>    Retry publishing failed entries from the logfile (optional, overrides all other flags)
-
-DESCRIPTION
-  Unpublish entries or assets of given content types from the specified environment
-  The unpublish command is used to unpublish entries or assets from given environment
-
-  Environment (Source Environment) and Locale are required to execute the command successfully
-  But, if retry-failed flag is set, then only a logfile is required
-
-  A content type can be specified for unpublishing entries, but if no content-type(s) is/are specified and --only-assets
-  is not used,
-  then all entries from all content types will be unpublished from the source environment
-
-  Note: --only-assets can be used to unpublish only assets and --only-entries can be used to unpublish only entries.
-  (--only-assets and --only-entries cannot be used together at the same time)
-
-
-ALIASES
-  $ csdx cm:bulk-publish:unpublish
-
-EXAMPLES
-  General Usage
-
-  $ csdx cm:stacks:unpublish --bulk-unpublish --content-type [CONTENT TYPE] --environment [SOURCE ENV] --locale [LOCALE] --alias [MANAGEMENT TOKEN ALIAS] ----delivery-token [DELIVERY TOKEN]
-
-
-
-  Using --config or -c flag
-
-  Generate a config file at the current working directory using `csdx cm:bulk-publish:configure --alias [ALIAS]`
-
-  $ csdx cm:stacks:unpublish --config [PATH TO CONFIG FILE]
-
-  $ csdx cm:stacks:unpublish -c [PATH TO CONFIG FILE]
-
-
-
-  Using --retry-failed flag
-
-  $ csdx cm:stacks:unpublish --retry-failed [LOG FILE NAME]
-
-
-
-  No content type
-
-  $ csdx cm:stacks:unpublish --environment [SOURCE ENV] --locale [LOCALE] (Will unpublish all entries from all content types and assets from the source environment)
-
-
-
-  Using --only-assets
-
-  $ csdx cm:stacks:unpublish --environment [SOURCE ENV] --locale [LOCALE] --only-assets (Will unpublish only assets from the source environment)
-
-
-
-  Using --only-entries
-
-  $ csdx cm:stacks:unpublish --environment [SOURCE ENV] --locale [LOCALE] --only-entries (Will unpublish only entries, all entries, from the source environment)
-
-  $ csdx cm:stacks:unpublish --contentType [CONTENT TYPE] --environment [SOURCE ENV] --locale [LOCALE] --only-entries (Will unpublish only entries, (from CONTENT TYPE) from the source environment)
-
-
-
-  Using --branch flag
-
-  $ csdx cm:stacks:unpublish --bulk-unpublish --content-type [CONTENT TYPE] --environment [SOURCE ENV] --locale [LOCALE] --alias [MANAGEMENT TOKEN ALIAS] --delivery-token [DELIVERY TOKEN] --branch [BRANCH NAME]
-
-
-
-  Using --stack-api-key flag
-
-  $ csdx cm:stacks:unpublish --bulk-unpublish --content-type [CONTENT TYPE] --environment [SOURCE ENV] --locale [LOCALE] --stack-api-key [STACK API KEY] --delivery-token [DELIVERY TOKEN]
-```
-
-## `csdx cm:entries:publish-only-unpublished [-a <value>] [--retry-failed <value>] [--bulk-publish <value>] [--source-env <value>] [--content-types <value>] [--locales <value>] [-e <value>] [-c <value>] [-y] [--branch <value>]`
-
-Publish unpublished entries from the source environment, to other environments and locales
-
-```
-USAGE
-  $ csdx cm:bulk-publish:unpublished-entries cm:entries:publish-only-unpublished [-a <value>] [--retry-failed <value>] [--bulk-publish
-    <value>] [--source-env <value>] [--content-types <value>] [--locales <value>] [-e <value>] [-c <value>] [-y]
-    [--branch <value>]
-
-FLAGS
-  -B, --branch=<value>            [default: main] The name of the branch where you want to perform the bulk publish
-                                  operation. If you don't mention the branch name, then by default the entries from main
-                                  branch will be published.
-  -a, --alias=<value>             Alias (name) of the management token. You must use either the --alias flag or the
-                                  --stack-api-key flag.
-  -b, --bulk-publish=<value>      [default: true] Set this flag to use Contentstack's Bulk Publish APIs. It is true, by
-                                  default.
-  -c, --config=<value>            (optional)  The path of the optional configuration JSON file containing all the
-                                  options for a single run. Refer to the configure command to create a configuration
-                                  file.
-  -e, --environments=<value>...   The name of the environment on which entries will be published. In case of multiple
-                                  environments, specify their names separated by spaces.
-  -k, --stack-api-key=<value>     API key of the source stack. You must use either the --stack-api-key flag or the
-                                  --alias flag.
-  -y, --yes                       Set it to true to process the command with the current configuration.
-      --api-version=<value>       API version to be used. Values [Default: 3, Nested Reference Publishing: 3.2]..
-      --content-types=<value>...  The UID of the content type(s) whose entries you want to publish in bulk. In case of
-                                  multiple content types, specify their IDs separated by spaces.
-      --locales=<value>           Locale in which entries will be published, e.g., en-us
-      --retry-failed=<value>      (optional) Use this option to retry publishing the failed entries from the logfile. It
-                                  is optional. Specify the name of the logfile that lists failed publish calls. If this
-                                  option is used, it will override all other flags.
-      --source-env=<value>        The name of the source environment where the entries were initially published.
-
-DESCRIPTION
-  Publish unpublished entries from the source environment, to other environments and locales
-  The publish-only-unpublished command is used to publish unpublished entries from the source environment, to other
-  environments and locales
-
-  Note: Content type(s), Source Environment, Destination Environment(s) and Source Locale are required to execute the
-  command successfully
-  But, if retry-failed flag is set, then only a logfile is required
-
-
-ALIASES
-  $ csdx cm:bulk-publish:unpublished-entries
-
-EXAMPLES
-  General Usage
-
-  $ csdx cm:entries:publish-only-unpublished -b --content-types [CONTENT TYPES] -e [ENVIRONMENTS] --locales LOCALE -a [MANAGEMENT TOKEN ALIAS] -source-env [SOURCE ENV]
-
-
-
-  Using --config or -c flag
-
-  Generate a config file at the current working directory using `csdx cm:bulk-publish:configure -a [ALIAS]`
-
-  $ csdx cm:entries:publish-only-unpublished --config [PATH TO CONFIG FILE]
-
-  $ csdx cm:entries:publish-only-unpublished -c [PATH TO CONFIG FILE]
-
-
-
-  Using --retry-failed
-
-  $ csdx cm:entries:publish-only-unpublished --retry-failed [LOG FILE NAME]
-
-
-
-  Using --branch
-
-  $ csdx cm:entries:publish-only-unpublished -b --content-types [CONTENT TYPES] -e [ENVIRONMENTS] --locales LOCALE -a [MANAGEMENT TOKEN ALIAS] --branch [BRANCH NAME] -source-env [SOURCE ENV]
-
-
-
-  Using --stack-api-key
-
-  $ csdx cm:entries:publish-only-unpublished -b --content-types [CONTENT TYPES] -e [ENVIRONMENTS] --locales LOCALE -a [MANAGEMENT TOKEN ALIAS] --stack-api-key [STACK API KEY] -source-env [SOURCE ENV]
-```
-
-## `csdx cm:entries:migrate-html-rte`
-
-Migration script to migrate content from HTML RTE to JSON RTE
-
-```
-USAGE
-  $ csdx cm:entries:migrate-html-rte [-c <value>] [-a <value>] [--stack-api-key <value>] [--content-type <value>]
-    [--global-field] [-y] [--branch <value>] [--html-path <value> --json-path <value>] [--delay <value>] [--locale
-    <value>] [--batch-limit <value>]
-
-FLAGS
-  -a, --alias=<value>          Enter the alias name. You must use either the --alias flag or the --stack-api-key flag.
-  -c, --config-path=<value>    Specify the path where your config file is located.
-  -y, --yes                    Avoids reconfirmation of your configuration.
-      --batch-limit=<value>    [default: 50] Provide batch limit for updating entries (default: 50).
-      --branch=<value>         The name of the branch to be used.
-      --content-type=<value>   Specify the UID of the content type for which you want to migrate HTML RTE content.
-      --delay=<value>          [default: 1000] To set the interval time between the migration of HTML RTE to JSON RTE in
-                               subsequent entries of a content type. The default value is 1,000 milliseconds.
-      --global-field           Checks whether the specified UID belongs to a content type or a global field. This flag
-                               is set to false by default.
-      --html-path=<value>      Enter the path to the HTML RTE whose content you want to migrate.
-      --json-path=<value>      Enter the path to the JSON RTE to which you want to migrate the HTML RTE content.
-      --locale=<value>         The locale from which entries will be migrated.
-      --stack-api-key=<value>  API key of the source stack. You must use either the --stack-api-key flag or the --alias
-                               flag.
-
-DESCRIPTION
-  Migration script to migrate content from HTML RTE to JSON RTE
-
-ALIASES
-  $ csdx cm:migrate-rte
-
-EXAMPLES
-  General Usage
-
-  $ csdx cm:entries:migrate-html-rte --config-path path/to/config.json
-
-
-
-  Using Flags
-
-  $ csdx cm:entries:migrate-html-rte --alias alias --content-type content_type_uid --html-path html-path --json-path json-path
-
-
-
-  Nested RTE
-
-  $ csdx cm:entries:migrate-html-rte --alias alias --content-type content_type_uid --html-path modular_block_uid.block_uid.html_rte_uid --json-path modular_block_uid.block_uid.json_rte_uid
-
-
-
-  $ csdx cm:entries:migrate-html-rte --alias alias --content-type content_type_uid --html-path group_uid.html_rte_uid --json-path group_uid.json_rte_uid
-
-
-
-  Global Field
-
-  $ csdx cm:entries:migrate-html-rte --alias alias --content-type global_field_uid --global-field --html-path html-path --json-path json-path
-```
-
-_See code: [@contentstack/cli-cm-migrate-rte](https://github.com/contentstack/cli/blob/main/packages/contentstack-migrate-rte/src/commands/cm/entries/migrate-html-rte.js)_
-
-## `csdx cm:entries:publish [-a <value>] [--retry-failed <value>] [--bulk-publish <value>] [--publish-all-content-types] [--content-types <value>] [--locales <value>] [-e <value>] [-c <value>] [-y] [--branch <value>] [--delivery-token <value>] [--source-env <value>] [--entry-uid <value>] [--include-variants]`
-
-Publish entries from multiple contenttypes to multiple environments and locales
-
-```
-USAGE
-  $ csdx cm:entries:publish [-a <value>] [--retry-failed <value>] [--bulk-publish <value>] [--publish-all-content-types]
-    [--content-types <value>] [--locales <value>] [-e <value>] [-c <value>] [-y] [--branch <value>] [--delivery-token
-    <value>] [--source-env <value>] [--entry-uid <value>] [--include-variants]
-
-FLAGS
-  -B, --branch=<value>             [default: main] The name of the branch where you want to perform the bulk publish
-                                   operation. If you don’t mention the branch name, then by default the content from
-                                   main branch will be published.
-  -a, --alias=<value>              Alias (name) of the management token. You must use either the --alias flag or the
-                                   --stack-api-key flag.
-  -c, --config=<value>             (optional) The path of the optional configuration JSON file containing all the
-                                   options for a single run. Refer to the configure command to create a configuration
-                                   file.
-  -e, --environments=<value>...    The name of the environment on which entries will be published. In case of multiple
-                                   environments, specify their names separated by spaces.
-  -k, --stack-api-key=<value>      API key of the source stack. You must use either the --stack-api-key flag or the
-                                   --alias flag.
-  -l, --locales=<value>...         Locales in which entries will be published, e.g., en-us. In the case of multiple
-                                   locales, specify the codes separated by spaces.
-  -y, --yes                        Set it to true to process the command with the current configuration.
-      --api-version=<value>        API version to be used. Values [Default: 3, Nested Reference Publishing: 3.2].
-      --bulk-publish=<value>       [default: true] Set this flag to use Contentstack's Bulk Publish APIs. This flag is
-                                   set to true, by default.
-      --content-types=<value>...   The UID of the content type(s) whose entries you want to publish in bulk. In case of
-                                   multiple content types, specify the IDs separated by spaces.
-      --delivery-token=<value>     The delivery token of the source environment.
-      --entry-uid=<value>          Entry Uid for publish all associated variant entries.
-      --include-variants           Include Variants flag will publish all associated variant entries with base entry.
-      --publish-all-content-types  (optional) Set it to true to bulk publish entries from all content types. If the
-                                   --content-types option is already used, then you cannot use this option.
-      --retry-failed=<value>       (optional) Use this option to retry publishing the failed entries/ assets from the
-                                   logfile. Specify the name of the logfile that lists failed publish calls. If this
-                                   option is used, it will override all other flags.
-      --source-env=<value>         Source environment
-
-DESCRIPTION
-  Publish entries from multiple contenttypes to multiple environments and locales
-  The publish command is used to publish entries from the specified content types, to the
-  specified environments and locales
-
-  Note: Content Types, Environments and Locales are required to execute the command successfully
-  But, if retry-failed flag is set, then only a logfile is required
-
-
-ALIASES
-  $ csdx cm:bulk-publish:entries
-
-EXAMPLES
-  General Usage
-
-  $ csdx cm:entries:publish --content-types [CONTENT TYPE 1] [CONTENT TYPE 2] -e [ENVIRONMENT 1] [ENVIRONMENT 2] --locales [LOCALE 1] [LOCALE 2] -a [MANAGEMENT TOKEN ALIAS]
-
-
-
-  Using --config or -c flag
-
-  Generate a config file at the current working directory using `csdx cm:stacks:publish-configure -a [ALIAS]`
-
-  $ csdx cm:entries:publish --config [PATH TO CONFIG FILE]
-
-  $ csdx cm:entries:publish -c [PATH TO CONFIG FILE]
-
-
-
-  Using --retry-failed
-
-  $ csdx cm:entries:publish --retry-failed [LOG FILE NAME]
-
-  $ csdx cm:entries:publish -r [LOG FILE NAME]
-
-
-
-  Using --branch
-
-  $ csdx cm:entries:publish --content-types [CONTENT TYPE 1] [CONTENT TYPE 2] -e [ENVIRONMENT 1] [ENVIRONMENT 2] --locales [LOCALE 1] [LOCALE 2] -a [MANAGEMENT TOKEN ALIAS] --branch [BRANCH NAME]
-
-
-
-  Using --source-env
-
-  $ csdx cm:entries:publish --content-types [CONTENT TYPE 1] [CONTENT TYPE 2] -e [ENVIRONMENT 1] [ENVIRONMENT 2] --locales [LOCALE 1] [LOCALE 2] -a [MANAGEMENT TOKEN ALIAS] --source-env [SOURCE ENVIRONMENT] --delivery-token [DELIVERY TOKEN]
-
-
-
-  Using --stack-api-key
-
-  $ csdx cm:entries:publish -e [ENVIRONMENT 1] [ENVIRONMENT 2] --locales [LOCALE 1] [LOCALE 2] --stack-api-key [STACK API KEY] --source-env [SOURCE ENVIRONMENT] --delivery-token [DELIVERY TOKEN]
-
-
-
-  Using --include-variants
-
-  $ csdx cm:entries:publish --content-types [CONTENT TYPE 1] [CONTENT TYPE 2] -e [ENVIRONMENT 1] [ENVIRONMENT 2] --locales [LOCALE 1] [LOCALE 2] --stack-api-key [STACK API KEY] --source-env [SOURCE ENVIRONMENT] --delivery-token [DELIVERY TOKEN] [--include-variants]
-
-
-
-  Using --entry-uid and --include-variants
-
-  $ csdx cm:entries:publish --content-types [CONTENT TYPE 1] [CONTENT TYPE 2] -e [ENVIRONMENT 1] [ENVIRONMENT 2] --locales [LOCALE 1] [LOCALE 2] --stack-api-key [STACK API KEY] --source-env [SOURCE ENVIRONMENT] --delivery-token [DELIVERY TOKEN] --entry-uid [ENTRY UID] [--include-variants]
-```
-
-_See code: [@contentstack/cli-cm-bulk-publish](https://github.com/contentstack/cli/blob/main/packages/contentstack-bulk-publish/src/commands/cm/entries/publish.js)_
-
-## `csdx cm:entries:publish-modified [-a <value>] [--retry-failed <value>] [--bulk-publish <value>] [--source-env <value>] [--content-types <value>] [--locales <value>] [-e <value>] [-c <value>] [-y] [--branch <value>]`
-
-Publish edited entries from a specified content type to the given locales and environments
-
-```
-USAGE
-  $ csdx cm:entries:publish-modified [-a <value>] [--retry-failed <value>] [--bulk-publish <value>] [--source-env <value>]
-    [--content-types <value>] [--locales <value>] [-e <value>] [-c <value>] [-y] [--branch <value>]
-
-FLAGS
-  -B, --branch=<value>            [default: main] The name of the branch where you want to perform the bulk publish
-                                  operation. If you don't mention the branch name, then by default the entries from main
-                                  branch will be published.
-  -a, --alias=<value>             Alias (name) of the management token. You must use either the --alias flag or the
-                                  --stack-api-key flag.
-  -c, --config=<value>            (optional) The path of the optional configuration JSON file containing all the options
-                                  for a single run. Refer to the configure command to create a configuration file.
-  -e, --environments=<value>...   The name of the environment(s) on which the entries will be published. In case of
-                                  multiple environments, specify their names separated by spaces.
-  -k, --stack-api-key=<value>     API key of the source stack. You must use either the --stack-api-key flag or the
-                                  --alias flag.
-  -l, --locales=<value>...        Locales in which entries will be published, e.g., en-us. In the case of multiple
-                                  locales, specify the codes separated by spaces.
-  -y, --yes                       Set it to true to process the command with the current configuration.
-      --api-version=<value>       API version to be used. Values [Default: 3, Nested Reference Publishing: 3.2].
-      --bulk-publish=<value>      [default: true] Set this flag to use Contentstack's Bulk Publish APIs. It is true, by
-                                  default.
-      --content-types=<value>...  The UID of the content type(s) whose edited entries you want to publish in bulk. In
-                                  case of multiple content types, specify the IDs separated by spaces.
-      --retry-failed=<value>      (optional) Use this option to retry publishing the failed entries/assets from the
-                                  logfile. Specify the name of the logfile that lists failed publish calls. If this
-                                  option is used, it will override all other flags
-      --source-env=<value>        The name of the source environment where the entries were initially published.
-
-DESCRIPTION
-  Publish edited entries from a specified content type to the given locales and environments
-  The publish-modified command is used to publish entries from the specified content types, to the
-  specified environments and locales
-
-  Note: Content type(s), Source Environment, Destination Environment(s) and Locale(s) are required to execute the
-  command successfully
-  But, if retry-failed flag is set, then only a logfile is required
-
-
-ALIASES
-  $ csdx cm:bulk-publish:entry-edits
-
-EXAMPLES
-  General Usage
-
-  $ csdx cm:entries:publish-modified --content-types [CONTENT TYPE 1] [CONTENT TYPE 2] --source-env [SOURCE_ENV] -e [ENVIRONMENT 1] [ENVIRONMENT 2] --locales [LOCALE 1] [LOCALE 2] -a [MANAGEMENT TOKEN ALIAS]
-
-
-
-  Using --config or -c flag
-
-  Generate a config file at the current working directory using `csdx cm:stacks:publish-configure -a [ALIAS]`
-
-  $ csdx cm:entries:publish-modified --config [PATH TO CONFIG FILE]
-
-  $ csdx cm:entries:publish-modified -c [PATH TO CONFIG FILE]
-
-
-
-  Using --retry-failed
-
-  $ csdx cm:entries:publish-modified --retry-failed [LOG FILE NAME]
-
-  $ csdx cm:entries:publish-modified -r [LOG FILE NAME]
-
-
-
-  Using --branch
-
-  $ csdx cm:entries:publish-modified --content-types [CONTENT TYPE 1] [CONTENT TYPE 2] --source-env [SOURCE_ENV] -e [ENVIRONMENT 1] [ENVIRONMENT 2] --locales [LOCALE 1] [LOCALE 2] -a [MANAGEMENT TOKEN ALIAS] --branch [BRANCH NAME]
-
-
-
-  Using --stack-api-key
-
-  $ csdx cm:entries:publish-modified --content-types [CONTENT TYPE 1] [CONTENT TYPE 2] --source-env [SOURCE_ENV] -e [ENVIRONMENT 1] [ENVIRONMENT 2] --locales [LOCALE 1] [LOCALE 2] -stack-api-key [STACK API KEY]
-```
-
-_See code: [@contentstack/cli-cm-bulk-publish](https://github.com/contentstack/cli/blob/main/packages/contentstack-bulk-publish/src/commands/cm/entries/publish-modified.js)_
-
-## `csdx cm:entries:publish-non-localized-fields [-a <value>] [--retry-failed <value>] [--bulk-publish <value>] [--source-env <value>] [--content-types <value>] [-e <value>] [-c <value>] [-y] [--branch <value>]`
-
-Publish non-localized fields for the given content types, from a particular source environment to the specified environments
-
-```
-USAGE
-  $ csdx cm:entries:publish-non-localized-fields [-a <value>] [--retry-failed <value>] [--bulk-publish <value>] [--source-env <value>]
-    [--content-types <value>] [-e <value>] [-c <value>] [-y] [--branch <value>]
-
-FLAGS
-  -B, --branch=<value>            [default: main] The name of the branch where you want to perform the bulk publish
-                                  operation. If you don’t mention the branch name, then by default the content from the
-                                  main branch will be published.
-  -a, --alias=<value>             Alias (name) of the management token. You must use either the --alias flag or the
-                                  --stack-api-key flag.
-  -c, --config=<value>            (optional) The path of the optional configuration JSON file containing all the options
-                                  for a single run. Refer to the configure command to create a configuration file.
-  -e, --environments=<value>...   The name of the environment on which entries will be published. In case of multiple
-                                  environments, specify their names separated by spaces.
-  -k, --stack-api-key=<value>     API key of the source stack. You must use either the --stack-api-key flag or the
-                                  --alias flag.
-  -y, --yes                       Set it to true to process the command with the current configuration.
-      --api-version=<value>       API version to be used. Values [Default: 3, Nested Reference Publishing: 3.2].
-      --bulk-publish=<value>      [default: true] Set this flag to use Contentstack’s Bulk Publish APIs. It is true, by
-                                  default.
-      --content-types=<value>...  The UID of the content type whose entries you want to publish in bulk. In case of
-                                  multiple content types, specify their IDs separated by spaces.
-      --retry-failed=<value>      Use this option to retry publishing the failed entries from the logfile. Specify the
-                                  name of the logfile that lists failed publish calls. If this option is used, it will
-                                  override all other flags.
-      --source-env=<value>        The name of the source environment.
-
-DESCRIPTION
-  Publish non-localized fields for the given content types, from a particular source environment to the specified
-  environments
-  The non-localized field changes command is used to publish non-localized field changes from the given content types to
-  the specified environments
-
-  Note: Content types, Environments and Source Environment are required to execute this command successfully.
-  But, if retryFailed flag is set, then only a logfile is required
-
-ALIASES
-  $ csdx cm:bulk-publish:nonlocalized-field-changes
-
-EXAMPLES
-  General Usage
-
-  $ csdx cm:entries:publish-non-localized-fields --content-types [CONTENT TYPE 1] [CONTENT TYPE 2] --environments [ENVIRONMENT 1] [ENVIRONMENT 2] --alias [MANAGEMENT TOKEN ALIAS] --source-env [SOURCE ENV]
-
-
-
-  Using --config or -c flag
-
-  Generate a config file at the current working directory using `csdx cm:bulk-publish:configure -a [ALIAS]`
-
-  $ csdx cm:entries:publish-non-localized-fields --config [PATH TO CONFIG FILE]
-
-  $ csdx cm:entries:publish-non-localized-fields -c [PATH TO CONFIG FILE]
-
-
-
-  Using --retry-failed flag
-
-  $ csdx cm:entries:publish-non-localized-fields --retry-failed [LOG FILE NAME]
-
-
-
-  Using --branch flag
-
-  $ csdx cm:entries:publish-non-localized-fields --content-types [CONTENT TYPE 1] [CONTENT TYPE 2] --environments [ENVIRONMENT 1] [ENVIRONMENT 2] --alias [MANAGEMENT TOKEN ALIAS] --source-env [SOURCE ENV] --branch [BRANCH NAME]
-
-
-
-  Using --stack-api-key flag
-
-  $ csdx cm:entries:publish-non-localized-fields --content-types [CONTENT TYPE 1] [CONTENT TYPE 2] --environments [ENVIRONMENT 1] [ENVIRONMENT 2] --stack-api-key [STACK API KEY] --source-env [SOURCE ENV]
-```
-
-_See code: [@contentstack/cli-cm-bulk-publish](https://github.com/contentstack/cli/blob/main/packages/contentstack-bulk-publish/src/commands/cm/entries/publish-non-localized-fields.js)_
-
-## `csdx cm:entries:publish-only-unpublished [-a <value>] [--retry-failed <value>] [--bulk-publish <value>] [--source-env <value>] [--content-types <value>] [--locales <value>] [-e <value>] [-c <value>] [-y] [--branch <value>]`
-
-Publish unpublished entries from the source environment, to other environments and locales
-
-```
-USAGE
-  $ csdx cm:entries:publish-only-unpublished [-a <value>] [--retry-failed <value>] [--bulk-publish <value>] [--source-env <value>]
-    [--content-types <value>] [--locales <value>] [-e <value>] [-c <value>] [-y] [--branch <value>]
-
-FLAGS
-  -B, --branch=<value>            [default: main] The name of the branch where you want to perform the bulk publish
-                                  operation. If you don't mention the branch name, then by default the entries from main
-                                  branch will be published.
-  -a, --alias=<value>             Alias (name) of the management token. You must use either the --alias flag or the
-                                  --stack-api-key flag.
-  -b, --bulk-publish=<value>      [default: true] Set this flag to use Contentstack's Bulk Publish APIs. It is true, by
-                                  default.
-  -c, --config=<value>            (optional)  The path of the optional configuration JSON file containing all the
-                                  options for a single run. Refer to the configure command to create a configuration
-                                  file.
-  -e, --environments=<value>...   The name of the environment on which entries will be published. In case of multiple
-                                  environments, specify their names separated by spaces.
-  -k, --stack-api-key=<value>     API key of the source stack. You must use either the --stack-api-key flag or the
-                                  --alias flag.
-  -y, --yes                       Set it to true to process the command with the current configuration.
-      --api-version=<value>       API version to be used. Values [Default: 3, Nested Reference Publishing: 3.2]..
-      --content-types=<value>...  The UID of the content type(s) whose entries you want to publish in bulk. In case of
-                                  multiple content types, specify their IDs separated by spaces.
-      --locales=<value>           Locale in which entries will be published, e.g., en-us
-      --retry-failed=<value>      (optional) Use this option to retry publishing the failed entries from the logfile. It
-                                  is optional. Specify the name of the logfile that lists failed publish calls. If this
-                                  option is used, it will override all other flags.
-      --source-env=<value>        The name of the source environment where the entries were initially published.
-
-DESCRIPTION
-  Publish unpublished entries from the source environment, to other environments and locales
-  The publish-only-unpublished command is used to publish unpublished entries from the source environment, to other
-  environments and locales
-
-  Note: Content type(s), Source Environment, Destination Environment(s) and Source Locale are required to execute the
-  command successfully
-  But, if retry-failed flag is set, then only a logfile is required
-
-
-ALIASES
-  $ csdx cm:bulk-publish:unpublished-entries
-
-EXAMPLES
-  General Usage
-
-  $ csdx cm:entries:publish-only-unpublished -b --content-types [CONTENT TYPES] -e [ENVIRONMENTS] --locales LOCALE -a [MANAGEMENT TOKEN ALIAS] -source-env [SOURCE ENV]
-
-
-
-  Using --config or -c flag
-
-  Generate a config file at the current working directory using `csdx cm:bulk-publish:configure -a [ALIAS]`
-
-  $ csdx cm:entries:publish-only-unpublished --config [PATH TO CONFIG FILE]
-
-  $ csdx cm:entries:publish-only-unpublished -c [PATH TO CONFIG FILE]
-
-
-
-  Using --retry-failed
-
-  $ csdx cm:entries:publish-only-unpublished --retry-failed [LOG FILE NAME]
-
-
-
-  Using --branch
-
-  $ csdx cm:entries:publish-only-unpublished -b --content-types [CONTENT TYPES] -e [ENVIRONMENTS] --locales LOCALE -a [MANAGEMENT TOKEN ALIAS] --branch [BRANCH NAME] -source-env [SOURCE ENV]
-
-
-
-  Using --stack-api-key
-
-  $ csdx cm:entries:publish-only-unpublished -b --content-types [CONTENT TYPES] -e [ENVIRONMENTS] --locales LOCALE -a [MANAGEMENT TOKEN ALIAS] --stack-api-key [STACK API KEY] -source-env [SOURCE ENV]
-```
-
-_See code: [@contentstack/cli-cm-bulk-publish](https://github.com/contentstack/cli/blob/main/packages/contentstack-bulk-publish/src/commands/cm/entries/publish-only-unpublished.js)_
-
-## `csdx cm:entries:unpublish`
-
-Unpublish entries from the given environment
-
-```
-USAGE
-  $ csdx cm:entries:unpublish [-a <value>] [-k <value>] [-e <value>] [-c <value>] [-y] [--locale <value>] [--branch
-    <value>] [--retry-failed <value>] [--bulk-unpublish <value>] [--api-version <value>] [--content-type <value>]
-    [--delivery-token <value>] [--include-variants]
-
-FLAGS
-  -a, --alias=<value>           Alias (name) for the management token. You must use either the --alias flag or the
-                                --stack-api-key flag.
-  -c, --config=<value>          (optional) Path to the configuration JSON file containing all options for a single run.
-                                Refer to the configure command to create a configuration file.
-  -e, --environment=<value>     The name of the environment from where entries/assets need to be unpublished.
-  -k, --stack-api-key=<value>   API key of the source stack. You must use either the --stack-api-key flag or the --alias
-                                flag.
-  -y, --yes                     Set to true to process the command with the current configuration.
-      --api-version=<value>     API version to be used. Values [Default: 3, Nested Reference Publishing: 3.2].
-      --branch=<value>          [default: main] Specify the branch to fetch the content. If not mentioned, the main
-                                branch will be used by default.
-      --bulk-unpublish=<value>  [default: true] This flag is set to true by default. It indicates that Contentstack's
-                                Bulk Publish APIs will be used to unpublish the entries.
-      --content-type=<value>    The UID of the content type whose entries you want to unpublish in bulk.
-      --delivery-token=<value>  The delivery token of the source environment.
-      --include-variants        Include Variants flag will unpublish all associated variant entries.
-      --locale=<value>          Locale from which entries/assets will be unpublished, e.g., en-us.
-      --retry-failed=<value>    (optional) Use this option to retry unpublishing the failed entries from the logfile.
-                                Specify the name of the logfile that lists failed unpublish calls. If used, this option
-                                will override all other flags.
-
-DESCRIPTION
-  Unpublish entries from the given environment
-  The unpublish command is used to unpublish entries from the given environment
-
-  Note: Environment (Source Environment) and Locale are required to execute the command successfully
-  But, if retry-failed flag is set, then only a logfile is required
-
-EXAMPLES
-  General Usage
-
-  $ csdx cm:stacks:unpublish --bulk-unpublish --content-type [CONTENT TYPE] --environment [SOURCE ENV] --locale [LOCALE] --alias [MANAGEMENT TOKEN ALIAS] --delivery-token [DELIVERY TOKEN]
-
-
-
-  Using --config or -c flag
-
-  Generate a config file at the current working directory using `csdx cm:bulk-publish:configure --alias [ALIAS]`
-
-  $ csdx cm:stacks:unpublish --config [PATH TO CONFIG FILE]
-
-  $ csdx cm:stacks:unpublish -c [PATH TO CONFIG FILE]
-
-
-
-  Using --retry-failed flag
-
-  $ csdx cm:stacks:unpublish --retry-failed [LOG FILE NAME]
-
-
-
-  Using --branch flag
-
-  $ csdx cm:stacks:unpublish --bulk-unpublish --content-type [CONTENT TYPE] --environment [SOURCE ENV] --locale [LOCALE] --alias [MANAGEMENT TOKEN ALIAS] --delivery-token [DELIVERY TOKEN] --branch [BRANCH NAME]
-
-
-
-  Using --stack-api-key flag
-
-  $ csdx cm:stacks:unpublish --bulk-unpublish --content-type [CONTENT TYPE] --environment [SOURCE ENV] --locale [LOCALE] --stack-api-key [STACK API KEY] --delivery-token [DELIVERY TOKEN]
-
-
-
-  Using --include-variants flag
-
-  $ csdx cm:stacks:unpublish --bulk-unpublish --content-type [CONTENT TYPE] --environment [SOURCE ENV] --locale [LOCALE] --stack-api-key [STACK API KEY] --delivery-token [DELIVERY TOKEN] --include-variants
-```
-
-_See code: [@contentstack/cli-cm-bulk-publish](https://github.com/contentstack/cli/blob/main/packages/contentstack-bulk-publish/src/commands/cm/entries/unpublish.js)_
-
-## `csdx cm:entries:update-and-publish [-a <value>] [--retry-failed <value>] [--bulk-publish <value>] [--content-types <value>] [-t <value>] [-e <value>] [-c <value>] [-y] [--locales <value>] [--branch <value>]`
-
-Add fields from updated content types to their respective entries
-
-```
-USAGE
-  $ csdx cm:entries:update-and-publish [-a <value>] [--retry-failed <value>] [--bulk-publish <value>] [--content-types <value>] [-t
-    <value>] [-e <value>] [-c <value>] [-y] [--locales <value>] [--branch <value>]
-
-FLAGS
-  -B, --branch=<value>            [default: main] The name of the branch where you want to perform the bulk publish
-                                  operation. If you don’t mention the branch name, then by default the content from the
-                                  main branch will be published.
-  -a, --alias=<value>             Alias (name) of the management token. You must use either the --alias flag or the
-                                  --stack-api-key flag.
-  -c, --config=<value>            (optional) The path of the optional configuration JSON file containing all the options
-                                  for a single run. Refer to the configure command to create a configuration file.
-  -e, --environments=<value>...   The name of the environment on which entries will be published. In case of multiple
-                                  environments, specify their names separated by spaces.
-  -k, --stack-api-key=<value>     API key of the source stack. You must use either the --stack-api-key flag or the
-                                  --alias flag.
-  -l, --locales=<value>...        Locales in which entries will be published, e.g., en-us. In the case of multiple
-                                  locales, specify the codes separated by spaces.
-  -t, --contentTypes=<value>...   The Contenttypes from which entries will be published.
-  -y, --yes                       Set it to true to process the command with the current configuration.
-      --api-version=<value>       API version to be used. Values [Default: 3, Nested Reference Publishing: 3.2].
-      --bulk-publish=<value>      [default: true] Set this flag to use Contentstack’s Bulk Publish APIs. It is true, by
-                                  default.
-      --content-types=<value>...  The UID of the content type ID whose entries you want to publish in bulk. In case of
-                                  multiple content types, specify their IDs separated by spaces.
-      --force                     Update and publish all entries even if no fields have been added.
-      --retry-failed=<value>      Use this option to retry publishing the failed entries from the logfile. Specify the
-                                  name of the logfile that lists failed publish calls. If this option is used, it will
-                                  override all other flags.
-
-DESCRIPTION
-  Add fields from updated content types to their respective entries
-  The update-and-publish command is used to update existing entries with the updated schema of the respective content
-  type
-
-  Note: Content types, Environments and Locales are required to execute the command successfully
-  But, if retry-failed flag is set, then only a logfile is required
-
-
-ALIASES
-  $ csdx cm:bulk-publish:add-fields
-
-EXAMPLES
-  General Usage
-
-  $ csdx cm:entries:update-and-publish --content-types [CONTENT TYPE 1] [CONTENT TYPE 2] -e [ENVIRONMENT 1] [ENVIRONMENT 2] --locales [LOCALE 1] [LOCALE 2] -a [MANAGEMENT TOKEN ALIAS]
-
-
-
-  Using --config or -c flag
-
-  Generate a config file at the current working directory using `csdx cm:stacks:publish-configure -a [ALIAS]`
-
-  $ csdx cm:entries:update-and-publish --config [PATH TO CONFIG FILE]
-
-  $ csdx cm:entries:update-and-publish -c [PATH TO CONFIG FILE]
-
-
-
-  Using --retry-failed
-
-  $ csdx cm:entries:update-and-publish --retry-failed [LOG FILE NAME]
-
-
-
-  Using --branch
-
-  $ csdx cm:entries:update-and-publish --content-types [CONTENT TYPE 1] [CONTENT TYPE 2] -e [ENVIRONMENT 1] [ENVIRONMENT 2] --locales [LOCALE 1] [LOCALE 2] -a [MANAGEMENT TOKEN ALIAS] --branch [BRANCH NAME]
-
-
-
-  Using --stack-api-key
-
-  $ csdx cm:entries:update-and-publish --content-types [CONTENT TYPE 1] [CONTENT TYPE 2] -e [ENVIRONMENT 1] [ENVIRONMENT 2] --locales [LOCALE 1] [LOCALE 2] --stack-api-key [STACK API KEY]
-```
-
-_See code: [@contentstack/cli-cm-bulk-publish](https://github.com/contentstack/cli/blob/main/packages/contentstack-bulk-publish/src/commands/cm/entries/update-and-publish.js)_
-
-## `csdx cm:stacks:export [-c <value>] [-k <value>] [-d <value>] [-a <value>] [--module <value>] [--content-types <value>] [--branch <value>] [--secured-assets]`
-
-Export content from a stack
-
-```
-USAGE
-  $ csdx cm:export cm:stacks:export [-c <value>] [-k <value>] [-d <value>] [-a <value>] [--module <value>]
-    [--content-types <value>] [--branch <value>] [--secured-assets]
-
-FLAGS
-  -B, --branch=<value>            [optional] The name of the branch where you want to export your content. If you don't
-                                  mention the branch name, then by default the content will be exported from all the
-                                  branches of your stack.
-  -a, --alias=<value>             The management token alias of the source stack from which you will export content.
-  -c, --config=<value>            [optional] Path of the config
-  -d, --data-dir=<value>          The path or the location in your file system to store the exported content. For e.g.,
-                                  ./content
-  -k, --stack-api-key=<value>     API Key of the source stack
-  -m, --module=<value>            [optional] Specific module name. If not specified, the export command will export all
-                                  the modules to the stack. The available modules are assets, content-types, entries,
-                                  environments, extensions, marketplace-apps, global-fields, labels, locales, webhooks,
-                                  workflows, custom-roles, taxonomies, and studio.
-  -t, --content-types=<value>...  [optional]  The UID of the content type(s) whose content you want to export. In case
-                                  of multiple content types, specify the IDs separated by spaces.
-  -y, --yes                       [optional] Force override all Marketplace prompts.
-      --branch-alias=<value>      (Optional) The alias of the branch from which you want to export content.
-      --secured-assets            [optional] Use this flag for assets that are secured.
-
-DESCRIPTION
-  Export content from a stack
-
-ALIASES
-  $ csdx cm:export
-
-EXAMPLES
-  $ csdx cm:stacks:export --stack-api-key <stack_api_key> --data-dir <path/of/export/destination/dir>
-
-  $ csdx cm:stacks:export --config <path/to/config/dir>
-
-  $ csdx cm:stacks:export --alias <management_token_alias>
-
-  $ csdx cm:stacks:export --alias <management_token_alias> --data-dir <path/to/export/destination/dir>
-
-  $ csdx cm:stacks:export --alias <management_token_alias> --config <path/to/config/file>
-
-  $ csdx cm:stacks:export --module <single module name>
-
-  $ csdx cm:stacks:export --branch [optional] branch name
-```
-
->>>>>>> development
 ## `csdx cm:export-to-csv`
 
 Export entries, taxonomies, terms or organization users to csv using this command
 
 ```
 USAGE
-  $ csdx cm:export-to-csv [--action entries|users|teams|taxonomies] [-a <value>] [--org <value>] [-n <value>] [-k
-    <value>] [--org-name <value>] [--locale <value>] [--content-type <value>] [--branch <value>] [--team-uid <value>]
-    [--taxonomy-uid <value>] [--include-fallback] [--fallback-locale <value>] [--delimiter <value>]
+  $ csdx cm:export-to-csv [--action entries|users|teams|taxonomies] [-a <value>] [--org <value>] [-n <value>]
+    [-k <value>] [--org-name <value>] [--locale <value>] [--content-type <value>] [--branch <value>] [--team-uid
+    <value>] [--taxonomy-uid <value>] [--include-fallback] [--fallback-locale <value>] [--delimiter <value>]
 
 FLAGS
-  -a, --alias=<value>            Alias of the management token.
-  -k, --stack-api-key=<value>    API Key of the source stack.
-  -n, --stack-name=<value>       Name of the stack that needs to be created as CSV filename.
-      --action=<option>          Option to export data (entries, users, teams, taxonomies). <options:
-                                 entries|users|teams|taxonomies>
+      --action=<option>          Option to export data (entries, users, teams, taxonomies).
                                  <options: entries|users|teams|taxonomies>
-      --branch=<value>           Branch from which entries will be exported.
-      --content-type=<value>     Content type of entries that will be exported.
-      --delimiter=<value>        [default: ,] [optional] Provide a delimiter to separate individual data fields within
-                                 the CSV file. For example: cm:export-to-csv --delimiter '|'
-      --fallback-locale=<value>  [Optional] Specify a specific fallback locale for taxonomy export. This locale will be
-                                 used when a taxonomy term doesn't exist in the primary locale. Takes priority over
-                                 branch fallback hierarchy when both are specified.
-      --include-fallback         [Optional] Include fallback locale data when exporting taxonomies. When enabled, if a
-                                 taxonomy term doesn't exist in the specified locale, it will fallback to the hierarchy
-                                 defined in the branch settings.
-      --locale=<value>           Locale of entries that will be exported.
+  -a, --alias=<value>            Alias of the management token.
       --org=<value>              Provide organization UID to clone org users.
+  -n, --stack-name=<value>       Name of the stack that needs to be created as CSV filename.
+  -k, --stack-api-key=<value>    API Key of the source stack.
       --org-name=<value>         Name of the organization that needs to be created as CSV filename.
-      --taxonomy-uid=<value>     Provide the taxonomy UID of the related terms you want to export.
+      --locale=<value>           Locale of entries that will be exported.
+      --content-type=<value>     Content type of entries that will be exported.
+      --branch=<value>           Branch from which entries will be exported.
       --team-uid=<value>         Provide the UID of a specific team in an organization.
+      --taxonomy-uid=<value>     Provide the taxonomy UID of the related terms you want to export.
+      --include-fallback         [Optional] Include fallback locale data when exporting taxonomies.
+      --fallback-locale=<value>  [Optional] Specify a specific fallback locale for taxonomy export.
+      --delimiter=<value>        [optional] Provide a delimiter to separate individual data fields within the CSV file.
 
 DESCRIPTION
   Export entries, taxonomies, terms or organization users to csv using this command
 
-ALIASES
-  $ csdx cm:export-to-csv
-
 EXAMPLES
-  $ csdx cm:export-to-csv
+  $ csdx cm:export-to-csv --action entries --alias <management_token> --stack-api-key <stack_api_key> --locale en-us --content-type <content_type_uid>
 
+  $ csdx cm:export-to-csv --action users --org <org_uid>
 
+  $ csdx cm:export-to-csv --action teams --org <org_uid>
 
-  Exporting entries to CSV
-
-  $ csdx cm:export-to-csv --action entries --locale <locale> --alias <management-token-alias> --content-type <content-type>
-
-
-
-  Exporting entries to CSV with stack name and branch
-
-  $ csdx cm:export-to-csv --action entries --locale <locale> --alias <management-token-alias> --content-type <content-type> --stack-name <stack-name> --branch <branch-name>
-
-
-
-  Exporting organization users to CSV
-
-  $ csdx cm:export-to-csv --action users --org <org-uid>
-
-
-
-  Exporting organization teams to CSV
-
-  $ csdx cm:export-to-csv --action teams --org <org-uid>
-
-
-
-  Exporting teams with specific team UID
-
-  $ csdx cm:export-to-csv --action teams --org <org-uid> --team-uid <team-uid>
-
-
-
-  Exporting taxonomies to CSV
-
-  $ csdx cm:export-to-csv --action taxonomies --alias <management-token-alias>
-
-
-
-  Exporting specific taxonomy with locale
-
-  $ csdx cm:export-to-csv --action taxonomies --alias <management-token-alias> --taxonomy-uid <taxonomy-uid> --locale <locale>
-
-
-
-  Exporting taxonomies with fallback locale
-
-  $ csdx cm:export-to-csv --action taxonomies --alias <management-token-alias> --locale <locale> --include-fallback --fallback-locale <fallback-locale>
+  $ csdx cm:export-to-csv --action taxonomies --org <org_uid> --taxonomy-uid <taxonomy_uid>
 ```
 
-_See code: [@contentstack/cli-cm-export-to-csv](https://github.com/contentstack/cli/blob/main/packages/contentstack-export-to-csv/src/commands/cm/export-to-csv.ts)_
-
-## `csdx cm:stacks:migration [-k <value>] [-a <value>] [--file-path <value>] [--branch <value>] [--config-file <value>] [--config <value>] [--multiple]`
-
-Contentstack migration script.
-
-```
-USAGE
-  $ csdx cm:migration cm:stacks:migration [-k <value>] [-a <value>] [--file-path <value>] [--branch <value>]
-    [--config-file <value>] [--config <value>] [--multiple]
-
-FLAGS
-  -a, --alias=<value>          Use this flag to add the management token alias. You must use either the --alias flag or
-                               the --stack-api-key flag.
-  -k, --stack-api-key=<value>  Use this flag to add the API key of your stack. You must use either the --stack-api-key
-                               flag or the --alias flag.
-      --branch=<value>         Use this flag to add the branch name where you want to perform the migration. (target
-                               branch name)
-      --config=<value>...      [optional] Inline configuration, <key1>:<value1>. Passing an external configuration makes
-                               the script re-usable.
-      --config-file=<value>    [optional] Path of the JSON configuration file.
-      --file-path=<value>      Use this flag to provide the path of the file of the migration script.
-      --multiple               This flag helps you to migrate multiple content files in a single instance. Mention the
-                               folder path where your migration script files are stored.
-
-DESCRIPTION
-  Contentstack migration script.
-
-ALIASES
-  $ csdx cm:migration
-
-EXAMPLES
-  $ csdx cm:migration --file-path <migration/script/file/path> -k <api-key>
-
-  $ csdx cm:migration --file-path <migration/script/file/path> -k <api-key> --branch <target branch name>
-
-  $ csdx cm:migration --config <key1>:<value1> <key2>:<value2> ... --file-path <migration/script/file/path>
-
-  $ csdx cm:migration --config-file <path/to/json/config/file> --file-path <migration/script/file/path>
-
-  $ csdx cm:migration --multiple --file-path <migration/scripts/dir/path> 
-
-  $ csdx cm:migration --alias --file-path <migration/script/file/path> -k <api-key>
-```
-
-## `csdx cm:stacks:seed [--repo <value>] [--org <value>] [-k <value>] [-n <value>] [-y <value>] [-s <value>] [--locale <value>]`
-
-Create a stack from existing content types, entries, assets, etc
-
-```
-USAGE
-  $ csdx cm:seed cm:stacks:seed [--repo <value>] [--org <value>] [-k <value>] [-n <value>] [-y <value>] [-s
-    <value>] [--locale <value>]
-
-FLAGS
-  -a, --alias=<value>          Alias of the management token
-  -k, --stack-api-key=<value>  Provide stack API key to seed content to
-  -n, --stack-name=<value>     Name of a new stack that needs to be created.
-  -o, --org=<value>            Provide Organization UID to create a new stack
-  -r, --repo=<value>           GitHub organization name or GitHub user name/repository name.
-  -s, --stack=<value>          Provide the stack UID to seed content.
-  -y, --yes=<value>            [Optional] Skip the stack confirmation.
-
-DESCRIPTION
-  Create a stack from existing content types, entries, assets, etc
-
-ALIASES
-  $ csdx cm:seed
-
-EXAMPLES
-  $ csdx cm:stacks:seed
-
-  $ csdx cm:stacks:seed --repo "account"
-
-  $ csdx cm:stacks:seed --repo "account/repository"
-
-  $ csdx cm:stacks:seed --repo "account/repository" --stack-api-key "stack-api-key" //seed content into specific stack
-
-  $ csdx cm:stacks:seed --repo "account/repository" --org "your-org-uid" --stack-name "stack-name" //create a new stack in given org uid
-```
-
-## `csdx cm:stacks:clone [--source-branch <value>] [--target-branch <value>] [--source-management-token-alias <value>] [--destination-management-token-alias <value>] [-n <value>] [--type a|b] [--source-stack-api-key <value>] [--destination-stack-api-key <value>] [--import-webhook-status disable|current]`
-
-Clone data (structure/content or both) of a stack into another stack
-
-```
-USAGE
-  $ csdx cm:stack-clone cm:stacks:clone [--source-branch <value>] [--target-branch <value>]
-    [--source-management-token-alias <value>] [--destination-management-token-alias <value>] [-n <value>] [--type a|b]
-    [--source-stack-api-key <value>] [--destination-stack-api-key <value>] [--import-webhook-status disable|current]
-
-FLAGS
-  -c, --config=<value>                              Path for the external configuration
-  -n, --stack-name=<value>                          Provide a name for the new stack to store the cloned content.
-  -y, --yes                                         Force override all Marketplace prompts.
-      --destination-management-token-alias=<value>  Destination management token alias.
-      --destination-stack-api-key=<value>           Destination stack API key
-      --import-webhook-status=<option>              [default: disable] [default: disable] (optional) The status of the
-                                                    import webhook. <options: disable|current>
-                                                    <options: disable|current>
-      --skip-audit                                  (optional) Skips the audit fix that occurs during an import
-                                                    operation.
-      --source-branch=<value>                       Branch of the source stack.
-      --source-branch-alias=<value>                 Alias of Branch of the source stack.
-      --source-management-token-alias=<value>       Source management token alias.
-      --source-stack-api-key=<value>                Source stack API key
-      --target-branch=<value>                       Branch of the target stack.
-      --target-branch-alias=<value>                 Alias of Branch of the target stack.
-      --type=<option>                               Type of data to clone. You can select option a or b.
-                                                    a) Structure (all modules except entries & assets).
-                                                    b) Structure with content (all modules including entries & assets).
-
-                                                    <options: a|b>
-
-DESCRIPTION
-  Clone data (structure/content or both) of a stack into another stack
-  Use this plugin to automate the process of cloning a stack in few steps.
-
-
-ALIASES
-  $ csdx cm:stack-clone
-
-EXAMPLES
-  $ csdx cm:stacks:clone
-
-  $ csdx cm:stacks:clone --source-branch <source-branch-name> --target-branch <target-branch-name> --yes
-
-  $ csdx cm:stacks:clone --source-stack-api-key <apiKey> --destination-stack-api-key <apiKey>
-
-  $ csdx cm:stacks:clone --source-management-token-alias <management token alias> --destination-management-token-alias <management token alias>
-
-  $ csdx cm:stacks:clone --source-branch --target-branch --source-management-token-alias <management token alias> --destination-management-token-alias <management token alias>
-
-  $ csdx cm:stacks:clone --source-branch --target-branch --source-management-token-alias <management token alias> --destination-management-token-alias <management token alias> --type <value a or b>
-```
+_See code: [@contentstack/cli-cm-export-to-csv](https://github.com/contentstack/cli-plugins/blob/main/packages/contentstack-export-to-csv/src/commands/cm/export-to-csv.ts)_
 
 ## `csdx cm:stacks:audit`
 
@@ -2206,8 +600,7 @@ USAGE
 
 FLAGS
   --modules=<option>...  Provide the list of modules to be audited
-                         <options: content-types|global-fields|entries|extensions|workflows|custom-roles|assets|field-ru
-                         les|composable-studio>
+                         <options: content-types|global-fields|entries|extensions|workflows|custom-roles|assets|field-rules|composable-studio>
   --report-path=<value>  Path to store the audit reports
 
 COMMON FLAGS
@@ -2237,10 +630,10 @@ EXAMPLES
 
   $ csdx cm:stacks:audit --report-path=<path> --filter="name=<filter-value>"
 
-  $ csdx cm:stacks:audit --report-path=<path> --modules=content-types --filter="name="<filter-value>"
+  $ csdx cm:stacks:audit --report-path=<path> --modules=content-types --filter="name=<filter-value>"
 ```
 
-_See code: [@contentstack/cli-audit](https://github.com/contentstack/audit/blob/main/packages/contentstack-audit/src/commands/cm/stacks/audit/index.ts)_
+_See code: [@contentstack/cli-audit](https://github.com/contentstack/cli-plugins/blob/main/packages/contentstack-audit/src/commands/cm/stacks/audit/index.ts)_
 
 ## `csdx cm:stacks:audit:fix`
 
@@ -2260,8 +653,7 @@ FLAGS
   --fix-only=<option>...  Provide the list of fix options
                           <options: reference|global_field|json:rte|json:extension|blocks|group|content_types>
   --modules=<option>...   Provide the list of modules to be audited
-                          <options: content-types|global-fields|entries|extensions|workflows|custom-roles|assets|field-r
-                          ules|composable-studio>
+                          <options: content-types|global-fields|entries|extensions|workflows|custom-roles|assets|field-rules|composable-studio>
   --report-path=<value>   Path to store the audit reports
 
 COMMON FLAGS
@@ -2293,10 +685,41 @@ EXAMPLES
 
   $ csdx cm:stacks:audit:fix --report-path=<path> --filter="name=<filter-value>"
 
-  $ csdx cm:stacks:audit:fix --report-path=<path> --modules=content-types --filter="name="<filter-value>" --copy-dir --copy-path=<path>
+  $ csdx cm:stacks:audit:fix --report-path=<path> --modules=content-types --filter="name=<filter-value>" --copy-dir --copy-path=<path>
 ```
 
-_See code: [@contentstack/cli-audit](https://github.com/contentstack/audit/blob/main/packages/contentstack-audit/src/commands/cm/stacks/audit/fix.ts)_
+_See code: [@contentstack/cli-audit](https://github.com/contentstack/cli-plugins/blob/main/packages/contentstack-audit/src/commands/cm/stacks/audit/fix.ts)_
+
+## `csdx cm:stacks:bulk-am-assets`
+
+Bulk delete or move assets via CS Assets API. Loads asset UIDs from a JSON file `{ "uids": [...] }`; pass organization via `--org-uid`.
+
+```
+USAGE
+  $ csdx cm:stacks:bulk-am-assets --operation delete|move --space-uid <value> --org-uid <value> --asset-uids-file
+    <value> [--workspace <value>] [--locale <value>] [--target-folder-uid <value>] [-y]
+
+FLAGS
+  -y, --yes                        Skips interactive confirmation prompts and runs the command immediately.
+      --asset-uids-file=<value>    Path to UTF-8 JSON file: exactly `{ "uids": ["uid1", "uid2"] }`
+      --locale=<value>             Locale code for bulk delete only. Not applicable for move.
+      --operation=<option>         Operation: delete (CS Assets bulk delete) or move (CS Assets bulk move)
+                                   <options: delete|move>
+      --org-uid=<value>            Organization UID for CS Assets API (organization_uid header)
+      --space-uid=<value>          CS Assets space UID
+      --target-folder-uid=<value>  Destination CS Assets folder UID for bulk move. Use "root" for root folder.
+      --workspace=<value>          [default: main] CS Assets workspace query parameter
+
+DESCRIPTION
+  Bulk delete or move assets via CS Assets API.
+
+EXAMPLES
+  $ csdx cm:stacks:bulk-am-assets --operation delete --space-uid am123 --org-uid bltcOrg --locale en-us --asset-uids-file ./assets.json
+
+  $ csdx cm:stacks:bulk-am-assets --operation move --space-uid am123 --org-uid bltcOrg --target-folder-uid amFolder --asset-uids-file ./assets.json
+```
+
+_See code: [@contentstack/cli-bulk-operations](https://github.com/contentstack/cli-plugins/blob/main/packages/contentstack-bulk-operations/src/commands/cm/stacks/bulk-am-assets.ts)_
 
 ## `csdx cm:stacks:bulk-assets`
 
@@ -2306,44 +729,27 @@ Bulk operations for assets (publish/unpublish/cross-publish)
 USAGE
   $ csdx cm:stacks:bulk-assets [-a <value>] [-k <value>] [--operation publish|unpublish] [--environments <value>...]
     [--locales <value>...] [--source-env <value>] [--source-alias <value>] [--publish-mode bulk|single] [--branch
-    <value>] [-c <value>] [-y] [--retry-failed <value>] [--revert <value>] [--bulk-operation-file <value>] [--folder-uid
-    <value>]
+    <value>] [-c <value>] [-y] [--retry-failed <value>] [--revert <value>] [--bulk-operation-file <value>]
+    [--folder-uid <value>]
 
 FLAGS
-  -a, --alias=<value>                Uses the name of a saved Management Token to authenticate the command. The command
-                                     can only access the branches allowed for that token. This option can be used as an
-                                     alternative to` --stack-api-key.`
-  -c, --config=<value>               (optional) Specifies the path to a JSON configuration file that defines the options
-                                     for the command. Use this file instead of passing multiple CLI flags for a single
-                                     run.
-  -k, --stack-api-key=<value>        API key of the source stack. You must use either the --stack-api-key flag or the
-                                     --alias flag.
-  -y, --yes                          Skips interactive confirmation prompts and runs the command immediately using the
-                                     provided options. Useful for automation and scripts.
-      --branch=<value>               [default: main] The name of the branch where you want to perform the bulk publish
-                                     operation. If you don't mention the branch name, then by default the content from
-                                     main branch will be published.
-      --bulk-operation-file=<value>  [default: bulk-operation] (optional) Folder path to store operation logs. Creates
-                                     separate files for success and failed operations. Default: bulk-operation
-      --environments=<value>...      Specifies one or more environments where the entries or assets should be published.
-                                     Separate multiple environments with spaces.
-      --folder-uid=<value>           (optional) The UID of the Assets' folder from which the assets need to be
-                                     published. The default value is cs_root.
-      --locales=<value>...           Specifies one or more locale codes for which the entries or assets should be
-                                     published. Separate multiple locales with spaces.
-      --operation=<option>           Specifies whether to `publish` or `unpublish` content.
+  -a, --alias=<value>                Management token alias.
+  -c, --config=<value>               Path to a JSON configuration file.
+  -k, --stack-api-key=<value>        API key of the source stack.
+  -y, --yes                          Skip confirmation prompts.
+      --branch=<value>               [default: main] Branch name.
+      --bulk-operation-file=<value>  [default: bulk-operation] Folder path to store operation logs.
+      --environments=<value>...      Target environments (space-separated).
+      --folder-uid=<value>           UID of the Assets folder to publish from.
+      --locales=<value>...           Locale codes (space-separated).
+      --operation=<option>           Publish or unpublish.
                                      <options: publish|unpublish>
-      --publish-mode=<option>        [default: bulk] Publish mode: bulk (uses Bulk Publish API) or single (individual
-                                     API calls)
+      --publish-mode=<option>        [default: bulk] Publish mode.
                                      <options: bulk|single>
-      --retry-failed=<value>         (optional) Use this option to retry publishing the failed entries/assets from the
-                                     logfile. Specify the name of the logfile that lists failed publish calls. If this
-                                     option is used, it will override all other flags.
-      --revert=<value>               (optional) Revert publish operations from a log folder. Specify the folder path
-                                     containing success logs. Works similar to retry-failed.
-      --source-alias=<value>         Alias name for source environment delivery token (required for cross-publish). Add
-                                     delivery token using: csdx auth:tokens:add
-      --source-env=<value>           Source environment for cross-publish
+      --retry-failed=<value>         Retry failed operations from a log file.
+      --revert=<value>               Revert publish operations from a log folder.
+      --source-alias=<value>         Delivery token alias for cross-publish source environment.
+      --source-env=<value>           Source environment for cross-publish.
 
 DESCRIPTION
   Bulk operations for assets (publish/unpublish/cross-publish)
@@ -2353,18 +759,12 @@ EXAMPLES
 
   $ csdx cm:stacks:bulk-assets --operation unpublish --environments prod --locales en-us -a myAlias
 
-  $ csdx cm:stacks:bulk-assets --operation publish --folder-uid cs_root --environments prod --locales en-us -k blt123
-
-  $ csdx cm:stacks:bulk-assets --operation publish --environments prod --locales en-us --publish-mode bulk -k blt123
-
-  $ csdx cm:stacks:bulk-assets --operation publish --source-env production --source-alias prod-delivery --environments staging,dev --locales en-us -a myAlias
+  $ csdx cm:stacks:bulk-assets --operation publish --source-env production --source-alias prod-delivery --environments staging --locales en-us -a myAlias
 
   $ csdx cm:stacks:bulk-assets --retry-failed ./bulk-operation -a myAlias
-
-  $ csdx cm:stacks:bulk-assets --revert ./bulk-operation -a myAlias
 ```
 
-_See code: [@contentstack/cli-bulk-operations](https://github.com/contentstack/cli-bulk-operations/blob/v1.0.1/src/commands/cm/stacks/bulk-assets.ts)_
+_See code: [@contentstack/cli-bulk-operations](https://github.com/contentstack/cli-plugins/blob/main/packages/contentstack-bulk-operations/src/commands/cm/stacks/bulk-assets.ts)_
 
 ## `csdx cm:stacks:bulk-entries`
 
@@ -2375,51 +775,31 @@ USAGE
   $ csdx cm:stacks:bulk-entries [-a <value>] [-k <value>] [--operation publish|unpublish] [--environments <value>...]
     [--locales <value>...] [--source-env <value>] [--source-alias <value>] [--publish-mode bulk|single] [--branch
     <value>] [-c <value>] [-y] [--retry-failed <value>] [--revert <value>] [--bulk-operation-file <value>]
-    [--content-types <value>...] [--filter draft|modified|non-localized|unpublished] [--include-variants] [--api-version
-    <value>]
+    [--content-types <value>...] [--filter draft|modified|non-localized|unpublished] [--include-variants]
+    [--api-version <value>]
 
 FLAGS
-  -a, --alias=<value>                Uses the name of a saved Management Token to authenticate the command. The command
-                                     can only access the branches allowed for that token. This option can be used as an
-                                     alternative to` --stack-api-key.`
-  -c, --config=<value>               (optional) Specifies the path to a JSON configuration file that defines the options
-                                     for the command. Use this file instead of passing multiple CLI flags for a single
-                                     run.
-  -k, --stack-api-key=<value>        API key of the source stack. You must use either the --stack-api-key flag or the
-                                     --alias flag.
-  -y, --yes                          Skips interactive confirmation prompts and runs the command immediately using the
-                                     provided options. Useful for automation and scripts.
-      --api-version=<value>          [default: 3.2] Specifies the Content Management API version used for publishing.
-                                     Use version `3.2` when publishing entries with nested references, otherwise, use
-                                     the default version 3.2
-      --branch=<value>               [default: main] The name of the branch where you want to perform the bulk publish
-                                     operation. If you don't mention the branch name, then by default the content from
-                                     main branch will be published.
-      --bulk-operation-file=<value>  [default: bulk-operation] (optional) Folder path to store operation logs. Creates
-                                     separate files for success and failed operations. Default: bulk-operation
-      --content-types=<value>...     Content type UIDs to perform operation on. If not provided, operates on all content
-                                     types.
-      --environments=<value>...      Specifies one or more environments where the entries or assets should be published.
-                                     Separate multiple environments with spaces.
-      --filter=<option>              Filter entries by status
+  -a, --alias=<value>                Management token alias.
+  -c, --config=<value>               Path to a JSON configuration file.
+  -k, --stack-api-key=<value>        API key of the source stack.
+  -y, --yes                          Skip confirmation prompts.
+      --api-version=<value>          [default: 3.2] Content Management API version.
+      --branch=<value>               [default: main] Branch name.
+      --bulk-operation-file=<value>  [default: bulk-operation] Folder path to store operation logs.
+      --content-types=<value>...     Content type UIDs. If not provided, operates on all content types.
+      --environments=<value>...      Target environments (space-separated).
+      --filter=<option>              Filter entries by status.
                                      <options: draft|modified|non-localized|unpublished>
-      --include-variants             Includes entry variants (alternate versions of a base entry) in the bulk operation.
-                                     By default, only base entries are processed.
-      --locales=<value>...           Specifies one or more locale codes for which the entries or assets should be
-                                     published. Separate multiple locales with spaces.
-      --operation=<option>           Specifies whether to `publish` or `unpublish` content.
+      --include-variants             Include entry variants in the bulk operation.
+      --locales=<value>...           Locale codes (space-separated).
+      --operation=<option>           Publish or unpublish.
                                      <options: publish|unpublish>
-      --publish-mode=<option>        [default: bulk] Publish mode: bulk (uses Bulk Publish API) or single (individual
-                                     API calls)
+      --publish-mode=<option>        [default: bulk] Publish mode.
                                      <options: bulk|single>
-      --retry-failed=<value>         (optional) Use this option to retry publishing the failed entries/assets from the
-                                     logfile. Specify the name of the logfile that lists failed publish calls. If this
-                                     option is used, it will override all other flags.
-      --revert=<value>               (optional) Revert publish operations from a log folder. Specify the folder path
-                                     containing success logs. Works similar to retry-failed.
-      --source-alias=<value>         Alias name for source environment delivery token (required for cross-publish). Add
-                                     delivery token using: csdx auth:tokens:add
-      --source-env=<value>           Source environment for cross-publish
+      --retry-failed=<value>         Retry failed operations from a log file.
+      --revert=<value>               Revert publish operations from a log folder.
+      --source-alias=<value>         Delivery token alias for cross-publish source environment.
+      --source-env=<value>           Source environment for cross-publish.
 
 DESCRIPTION
   Bulk operations for entries (publish/unpublish/cross-publish)
@@ -2429,28 +809,60 @@ EXAMPLES
 
   $ csdx cm:stacks:bulk-entries --operation publish --content-types blog,article --environments dev --locales en-us -k blt123
 
-  $ csdx cm:stacks:bulk-entries --operation unpublish --content-types blog --environments prod --locales en-us -a myAlias
-
   $ csdx cm:stacks:bulk-entries --operation publish --content-types blog --source-env production --source-alias prod-delivery --environments staging --locales en-us -a myAlias
 
-  $ csdx cm:stacks:bulk-entries --operation publish --content-types blog --environments prod --locales en-us --publish-mode bulk -k blt123
-
   $ csdx cm:stacks:bulk-entries --operation publish --content-types blog --environments prod --locales en-us --filter modified -k blt123
-
-  $ csdx cm:stacks:bulk-entries --operation publish --content-types blog --environments prod --locales en-us --filter draft -k blt123
-
-  $ csdx cm:stacks:bulk-entries --operation publish --content-types blog --environments prod --locales en-us --filter unpublished -k blt123
-
-  $ csdx cm:stacks:bulk-entries --operation publish --content-types blog --environments prod --filter non-localized -k blt123
-
-  $ csdx cm:stacks:bulk-entries --operation publish --content-types blog --environments prod --locales en-us --include-variants -k blt123
 
   $ csdx cm:stacks:bulk-entries --retry-failed ./bulk-operation
 
   $ csdx cm:stacks:bulk-entries --revert ./bulk-operation
 ```
 
-_See code: [@contentstack/cli-bulk-operations](https://github.com/contentstack/cli-bulk-operations/blob/v1.0.1/src/commands/cm/stacks/bulk-entries.ts)_
+_See code: [@contentstack/cli-bulk-operations](https://github.com/contentstack/cli-plugins/blob/main/packages/contentstack-bulk-operations/src/commands/cm/stacks/bulk-entries.ts)_
+
+## `csdx cm:stacks:bulk-taxonomies`
+
+Publish taxonomies to environments and locales
+
+```
+USAGE
+  $ csdx cm:stacks:bulk-taxonomies [-a <value>] [-k <value>] [--operation publish|unpublish] [--environments <value>...]
+    [--locales <value>...] [--source-env <value>] [--source-alias <value>] [--publish-mode bulk|single] [--branch
+    <value>] [-c <value>] [-y] [--retry-failed <value>] [--revert <value>] [--bulk-operation-file <value>]
+    [--taxonomies <value>] [--api-version <value>]
+
+FLAGS
+  -a, --alias=<value>                Management token alias.
+  -c, --config=<value>               Path to a JSON configuration file.
+  -k, --stack-api-key=<value>        API key of the source stack.
+  -y, --yes                          Skip confirmation prompts.
+      --api-version=<value>          [default: 3.2] Content Management API version.
+      --branch=<value>               [default: main] Branch name.
+      --bulk-operation-file=<value>  [default: bulk-operation] Folder path to store operation logs.
+      --environments=<value>...      Target environments (space-separated).
+      --locales=<value>...           Locale codes (space-separated).
+      --operation=<option>           Publish or unpublish.
+                                     <options: publish|unpublish>
+      --publish-mode=<option>        [default: bulk] Publish mode.
+                                     <options: bulk|single>
+      --retry-failed=<value>         Retry failed operations from a log file.
+      --revert=<value>               Revert publish operations from a log folder.
+      --source-alias=<value>         Delivery token alias for cross-publish source environment.
+      --source-env=<value>           Source environment for cross-publish.
+      --taxonomies=<value>           Comma-separated taxonomy UIDs. If omitted, all taxonomies are included.
+
+DESCRIPTION
+  Publish taxonomies to environments and locales
+
+EXAMPLES
+  $ csdx cm:stacks:bulk-taxonomies --operation publish --environments dev,staging --locales en-us --taxonomies products_tax,brands_tax -k blt123
+
+  $ csdx cm:stacks:bulk-taxonomies --operation unpublish --environments prod --locales en-us --taxonomies my_taxonomy -a myAlias
+
+  $ csdx cm:stacks:bulk-taxonomies --operation publish --environments staging --locales en-us,fr-fr --taxonomies taxonomy_a -a myAlias
+```
+
+_See code: [@contentstack/cli-bulk-operations](https://github.com/contentstack/cli-plugins/blob/main/packages/contentstack-bulk-operations/src/commands/cm/stacks/bulk-taxonomies.ts)_
 
 ## `csdx cm:stacks:clone [--source-branch <value>] [--target-branch <value>] [--source-management-token-alias <value>] [--destination-management-token-alias <value>] [-n <value>] [--type a|b] [--source-stack-api-key <value>] [--destination-stack-api-key <value>] [--import-webhook-status disable|current]`
 
@@ -2507,7 +919,7 @@ EXAMPLES
   $ csdx cm:stacks:clone --source-branch --target-branch --source-management-token-alias <management token alias> --destination-management-token-alias <management token alias> --type <value a or b>
 ```
 
-_See code: [@contentstack/cli-cm-clone](https://github.com/contentstack/cli/blob/main/packages/contentstack-clone/src/commands/cm/stacks/clone.ts)_
+_See code: [@contentstack/cli-cm-clone](https://github.com/contentstack/cli-plugins/blob/main/packages/contentstack-clone/src/commands/cm/stacks/clone.ts)_
 
 ## `csdx cm:stacks:export [--config <value>] [--stack-api-key <value>] [--data-dir <value>] [--alias <value>] [--module <value>] [--content-types <value>] [--branch <value>] [--secured-assets]`
 
@@ -2519,23 +931,41 @@ USAGE
     [--module <value>] [--content-types <value>] [--branch <value>] [--secured-assets]
 
 FLAGS
-  -a, --alias=<value>             The management token alias of the source stack from which you will export content.
-  -c, --config=<value>            [optional] Path of the config
-  -d, --data-dir=<value>          The path or the location in your file system to store the exported content. For e.g.,
-                                  ./content
-  -k, --stack-api-key=<value>     API Key of the source stack
-  -y, --yes                       [optional] Force override all Marketplace prompts.
-      --branch=<value>            [optional] The name of the branch where you want to export your content. If you don't
-                                  mention the branch name, then by default the content will be exported from all the
-                                  branches of your stack.
-      --branch-alias=<value>      (Optional) The alias of the branch from which you want to export content.
-      --content-types=<value>...  [optional]  The UID of the content type(s) whose content you want to export. In case
-                                  of multiple content types, specify the IDs separated by spaces.
-      --module=<value>            [optional] Specific module name. If not specified, the export command will export all
-                                  the modules to the stack. The available modules are assets, content-types, entries,
-                                  environments, extensions, marketplace-apps, global-fields, labels, locales, webhooks,
-                                  workflows, custom-roles, taxonomies, and studio.
-      --secured-assets            [optional] Use this flag for assets that are secured.
+  -a, --alias=<value>
+      The management token alias of the source stack from which you will export content.
+
+  -c, --config=<value>
+      [optional] Path of the config
+
+  -d, --data-dir=<value>
+      The path or the location in your file system to store the exported content. For e.g., ./content
+
+  -k, --stack-api-key=<value>
+      API Key of the source stack
+
+  -y, --yes
+      [optional] Force override all Marketplace prompts.
+
+  --branch=<value>
+      [optional] The name of the branch where you want to export your content. If you don't mention the branch name, then
+      by default the content will be exported from all the branches of your stack.
+
+  --branch-alias=<value>
+      (Optional) The alias of the branch from which you want to export content.
+
+  --content-types=<value>...
+      [optional]  The UID of the content type(s) whose content you want to export. In case of multiple content types,
+      specify the IDs separated by spaces.
+
+  --module=<option>
+      [optional] Specific module name. If not specified, the export command will export all the modules from the stack.
+      The available modules are stack, assets, locales, environments, extensions, webhooks, global-fields, entries,
+      content-types, custom-roles, workflows, labels, marketplace-apps, taxonomies, personalize, and composable-studio.
+      <options: stack|assets|locales|environments|extensions|webhooks|global-fields|entries|content-types|custom-roles|wor
+      kflows|labels|marketplace-apps|taxonomies|personalize|composable-studio>
+
+  --secured-assets
+      [optional] Use this flag for assets that are secured.
 
 DESCRIPTION
   Export content from a stack
@@ -2556,7 +986,7 @@ EXAMPLES
   $ csdx cm:stacks:export --branch [optional] branch name
 ```
 
-_See code: [@contentstack/cli-cm-export](https://github.com/contentstack/cli/blob/main/packages/contentstack-export/src/commands/cm/stacks/export.ts)_
+_See code: [@contentstack/cli-cm-export](https://github.com/contentstack/cli-plugins/blob/main/packages/contentstack-export/src/commands/cm/stacks/export.ts)_
 
 ## `csdx cm:stacks:import [--config <value>] [--stack-api-key <value>] [--data-dir <value>] [--alias <value>] [--module <value>] [--backup-dir <value>] [--branch <value>] [--import-webhook-status disable|current]`
 
@@ -2604,11 +1034,13 @@ FLAGS
       stack. <options: disable|current>
       <options: disable|current>
 
-  --module=<value>
+  --module=<option>
       [optional] Specify the module to import into the target stack. If not specified, the import command will import all
-      the modules into the stack. The available modules are assets, content-types, entries, environments, extensions,
-      marketplace-apps, global-fields, labels, locales, webhooks, workflows, custom-roles, personalize projects,
-      taxonomies, and composable-studio.
+      the modules into the stack. The available modules are stack, assets, locales, environments, extensions, webhooks,
+      global-fields, entries, content-types, custom-roles, workflows, labels, marketplace-apps, taxonomies, personalize,
+      and composable-studio.
+      <options: stack|assets|locales|environments|extensions|webhooks|global-fields|entries|content-types|custom-roles|wor
+      kflows|labels|marketplace-apps|taxonomies|personalize|composable-studio>
 
   --personalize-project-name=<value>
       (optional) Provide a unique name for the Personalize project.
@@ -2627,6 +1059,9 @@ FLAGS
 
   --skip-existing
       Skips the module exists warning messages.
+
+  --skip-taxonomy-publish
+      Skips taxonomy publishing during the import process.
 
 DESCRIPTION
   Import content from a stack
@@ -2649,15 +1084,15 @@ EXAMPLES
   $ csdx cm:stacks:import --branch <branch name>  --yes --skip-audit
 ```
 
-_See code: [@contentstack/cli-cm-import](https://github.com/contentstack/cli/blob/main/packages/contentstack-import/src/commands/cm/stacks/import.ts)_
+_See code: [@contentstack/cli-cm-import](https://github.com/contentstack/cli-plugins/blob/main/packages/contentstack-import/src/commands/cm/stacks/import.ts)_
 
-## `csdx cm:stacks:import-setup [-k <value>] [-d <value>] [-a <value>] [--modules <value,value>]`
+## `csdx cm:stacks:import-setup [-k <value>] [-d <value>] [-a <value>] [--module <value>...]`
 
 Helps to generate mappers and backup folder for importing (overwriting) specific modules
 
 ```
 USAGE
-  $ csdx cm:stacks:import-setup [-k <value>] [-d <value>] [-a <value>] [--modules <value,value>]
+  $ csdx cm:stacks:import-setup [-k <value>] [-d <value>] [-a <value>] [--module <value>...]
 
 FLAGS
   -a, --alias=<value>          The management token of the destination stack where you will import the content.
@@ -2678,10 +1113,10 @@ DESCRIPTION
   Helps to generate mappers and backup folder for importing (overwriting) specific modules
 
 EXAMPLES
-  $ csdx cm:stacks:import-setup --stack-api-key <target_stack_api_key> --data-dir <path/of/export/destination/dir> --modules <module_name, module_name> --branch <branch_name>
+  $ csdx cm:stacks:import-setup --stack-api-key <target_stack_api_key> --data-dir <path/of/export/destination/dir> --module content-types --module entries --branch <branch_name>
 ```
 
-_See code: [@contentstack/cli-cm-import-setup](https://github.com/contentstack/cli/blob/main/packages/contentstack-import-setup/src/commands/cm/stacks/import-setup.ts)_
+_See code: [@contentstack/cli-cm-import-setup](https://github.com/contentstack/cli-plugins/blob/main/packages/contentstack-import-setup/src/commands/cm/stacks/import-setup.ts)_
 
 ## `csdx cm:stacks:migration [-k <value>] [-a <value>] [--file-path <value>] [--branch <value>] [--config-file <value>] [--config <value>] [--multiple]`
 
@@ -2723,117 +1158,27 @@ EXAMPLES
 
   $ csdx cm:migration --multiple --file-path <migration/scripts/dir/path> 
 
-  $ csdx cm:migration --alias --file-path <migration/script/file/path> -k <api-key>
+  $ csdx cm:migration --alias <management-token-alias> --file-path <migration/script/file/path>
 ```
 
-_See code: [@contentstack/cli-migration](https://github.com/contentstack/cli/blob/main/packages/contentstack-migration/src/commands/cm/stacks/migration.js)_
+_See code: [@contentstack/cli-migration](https://github.com/contentstack/cli-plugins/blob/main/packages/contentstack-migration/src/commands/cm/stacks/migration.ts)_
 
-## `csdx cm:stacks:publish`
-
-Publish entries and assets to multiple environments and locales
-
-```
-USAGE
-  $ csdx cm:stacks:publish
-
-DESCRIPTION
-  Publish entries and assets to multiple environments and locales
-  The publish command is used to publish entries and assets, to the specified environments and locales.
-
-  Note: Content types, Environments and Locales are required to execute the publish entries command successfully.
-  Note: Environments and Locales are required to execute the publish assets command successfully.
-  But, if retry-failed flag is set, then only a logfile is required
-
-EXAMPLES
-  General Usage
-
-  $ csdx cm:stacks:publish --environments [ENVIRONMENT 1] [ENVIRONMENT 2] --locales [LOCALE] --alias [MANAGEMENT TOKEN ALIAS]
-
-
-
-  Using --config or -c flag
-
-  Generate a config file in the current working directory using `csdx cm:stacks:publish-configure -a [ALIAS]`
-
-  $ csdx cm:stacks:publish --config [PATH TO CONFIG FILE]
-
-  $ csdx cm:stacks:publish -c [PATH TO CONFIG FILE]
-
-
-
-  Using --retry-failed flag
-
-  $ csdx cm:stacks:publish --retry-failed [LOG FILE NAME]
-
-
-
-  Using --branch flag
-
-  $ csdx cm:stacks:publish --environments [ENVIRONMENT 1] [ENVIRONMENT 2] --locales [LOCALE] --alias [MANAGEMENT TOKEN ALIAS] --branch [BRANCH NAME]
-
-
-
-  Using --api-version flag
-
-  $ csdx cm:stacks:publish --environments [ENVIRONMENT 1] [ENVIRONMENT 2] --locales [LOCALE] --alias [MANAGEMENT TOKEN ALIAS] --api-version [API VERSION]
-```
-
-_See code: [@contentstack/cli-migration](https://github.com/contentstack/cli/blob/main/packages/contentstack-migration/src/commands/cm/stacks/migration.ts)_
-
-## `csdx cm:stacks:publish-revert`
-
-Revert publish operations by using a log file
-
-```
-USAGE
-  $ csdx cm:stacks:publish-revert [--retry-failed <value>] [--log-file <value>]
-
-FLAGS
-  --log-file=<value>      Path of the success logfile of a particular publish action.
-  --retry-failed=<value>  (optional)  Use this option to retry publishing the failed entries from the logfile. Specify
-                          the name of the logfile that lists failed publish calls. If this option is used, it will
-                          override all other flags.
-
-DESCRIPTION
-  Revert publish operations by using a log file
-  The revert command is used to revert all publish operations performed using bulk-publish script.
-  A log file name is required to execute revert command
-
-
-ALIASES
-  $ csdx cm:bulk-publish:revert
-
-EXAMPLES
-  Using --log-file
-
-  cm:bulk-publish:revert --log-file [LOG FILE NAME]
-
-
-
-  Using --retry-failed
-
-  cm:bulk-publish:revert --retry-failed [LOG FILE NAME]
-```
-
-_See code: [@contentstack/cli-cm-bulk-publish](https://github.com/contentstack/cli/blob/main/packages/contentstack-bulk-publish/src/commands/cm/stacks/publish-revert.js)_
-
-## `csdx cm:stacks:seed [--repo <value>] [--org <value>] [-k <value>] [-n <value>] [-y <value>] [-s <value>] [--locale <value>]`
+## `csdx cm:stacks:seed [--repo <value>] [--org <value>] [--stack-api-key <value>] [--stack-name <value>] [-y] [--alias <value>] [--locale <value>]`
 
 Create a stack from existing content types, entries, assets, etc
 
 ```
 USAGE
-  $ csdx cm:stacks:seed [--repo <value>] [--org <value>] [-k <value>] [-n <value>] [-y <value>] [-s <value>]
-    [--locale <value>]
+  $ csdx cm:stacks:seed [--repo <value>] [--org <value>] [--stack-api-key <value>] [--stack-name <value>] [-y]
+    [--alias <value>] [--locale <value>]
 
 FLAGS
   -a, --alias=<value>          Alias of the management token
   -k, --stack-api-key=<value>  Provide stack API key to seed content to
   -n, --stack-name=<value>     Name of a new stack that needs to be created.
-  -o, --org=<value>            Provide Organization UID to create a new stack
-  -r, --repo=<value>           GitHub organization name or GitHub user name/repository name.
-  -s, --stack=<value>          Provide the stack UID to seed content.
-  -y, --yes=<value>            [Optional] Skip the stack confirmation.
+  -y, --yes                    [Optional] Skip the stack confirmation.
+      --org=<value>            Provide Organization UID to create a new stack
+      --repo=<value>           GitHub organization name or GitHub user name/repository name.
 
 DESCRIPTION
   Create a stack from existing content types, entries, assets, etc
@@ -2850,7 +1195,7 @@ EXAMPLES
   $ csdx cm:stacks:seed --repo "account/repository" --org "your-org-uid" --stack-name "stack-name" //create a new stack in given org uid
 ```
 
-_See code: [@contentstack/cli-cm-seed](https://github.com/contentstack/cli/blob/main/packages/contentstack-seed/src/commands/cm/stacks/seed.ts)_
+_See code: [@contentstack/cli-cm-seed](https://github.com/contentstack/cli-plugins/blob/main/packages/contentstack-seed/src/commands/cm/stacks/seed.ts)_
 
 ## `csdx config:get:base-branch`
 
@@ -3259,26 +1604,25 @@ Set region for CLI
 
 ```
 USAGE
-  $ csdx config:set:region [REGION] [--cda <value> --cma <value> --ui-host <value> -n <value>] [--developer-hub
-    <value>] [--personalize <value>] [--launch <value>] [--studio <value>] [--asset-management <value>]
+  $ csdx config:set:region [REGION] [--cda <value> --cma <value> --ui-host <value> --name <value>] [--developer-hub
+    <value>] [--personalize <value>] [--launch <value>] [--studio <value>] [--cs-assets <value>]
 
 ARGUMENTS
   [REGION]  Name for the region
 
 FLAGS
-  -n, --name=<value>              Name for the region, if this flag is added then cda, cma and ui-host flags are
-                                  required
-      --asset-management=<value>  Custom host to set for Asset Management API
-      --cda=<value>               Custom host to set for content delivery API, if this flag is added then cma, ui-host
-                                  and name flags are required
-      --cma=<value>               Custom host to set for content management API, , if this flag is added then cda,
-                                  ui-host and name flags are required
-      --developer-hub=<value>     Custom host to set for Developer hub API
-      --launch=<value>            Custom host to set for Launch API
-      --personalize=<value>       Custom host to set for Personalize API
-      --studio=<value>            Custom host to set for Studio API
-      --ui-host=<value>           Custom UI host to set for CLI, if this flag is added then cda, cma and name flags are
-                                  required
+  --cda=<value>            Custom host to set for content delivery API, if this flag is added then cma, ui-host and name
+                           flags are required
+  --cma=<value>            Custom host to set for content management API, , if this flag is added then cda, ui-host and
+                           name flags are required
+  --cs-assets=<value>      Custom host to set for Contentstack Assets API
+  --developer-hub=<value>  Custom host to set for Developer hub API
+  --launch=<value>         Custom host to set for Launch API
+  --name=<value>           Name for the region, if this flag is added then cda, cma and ui-host flags are required
+  --personalize=<value>    Custom host to set for Personalize API
+  --studio=<value>         Custom host to set for Studio API
+  --ui-host=<value>        Custom UI host to set for CLI, if this flag is added then cda, cma and name flags are
+                           required
 
 DESCRIPTION
   Set region for CLI
@@ -3310,7 +1654,7 @@ EXAMPLES
 
   $ csdx config:set:region --cma <custom_cma_host_url> --cda <custom_cda_host_url> --ui-host <custom_ui_host_url> --name "India" --studio <custom_studio_url>
 
-  $ csdx config:set:region --cma <custom_cma_host_url> --cda <custom_cda_host_url> --ui-host <custom_ui_host_url> --name "India" --asset-management <asset_management_url>
+  $ csdx config:set:region --cma <custom_cma_host_url> --cda <custom_cda_host_url> --ui-host <custom_ui_host_url> --name "India" --cs-assets <cs_assets_url>
 
   $ csdx config:set:region --cda <custom_cda_host_url> --cma <custom_cma_host_url> --ui-host <custom_ui_host_url> --name "India" --developer-hub <custom_developer_hub_url> --launch <custom_launch_url> --personalize <custom_personalize_url> --studio <custom_studio_url>
 ```
@@ -3335,7 +1679,7 @@ DESCRIPTION
   Display help for csdx.
 ```
 
-_See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/6.2.40/src/commands/help.ts)_
+_See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/6.2.53/src/commands/help.ts)_
 
 ## `csdx launch`
 
@@ -3348,7 +1692,7 @@ USAGE
     <value>] [--branch <value>] [--build-command <value>] [--out-dir <value>] [--server-command <value>]
     [--variable-type Import variables from a stack|Manually add custom variables to the list|Import variables from the
     .env.local file|Skip adding environment variables...] [-a <value>] [--env-variables <value>] [--redeploy-latest]
-    [--redeploy-last-upload]
+    [--redeploy-last-upload] [--response-mode buffered|streaming]
 
 FLAGS
   -a, --alias=<value>              [optional] Alias (name) for the delivery token.
@@ -3367,6 +1711,8 @@ FLAGS
       --out-dir=<value>            [optional] Output Directory.
       --redeploy-last-upload       [optional] Redeploy with last file upload
       --redeploy-latest            [optional] Redeploy latest commit/code
+      --response-mode=<option>     [optional] Provide mode for response. <options: buffered|streaming
+                                   <options: buffered|streaming>
       --server-command=<value>     [optional] Server Command.
       --type=<option>              [optional] Type of adapters. <options: GitHub|FileUpload>
                                    <options: GitHub|FileUpload>
@@ -3401,6 +1747,8 @@ EXAMPLES
   $ csdx launch --config <path/to/launch/config/file> --type <options: GitHub|FileUpload> --name=<value> --environment=<value> --branch=<value> --build-command=<value> --framework=<option> --org=<value> --out-dir=<value>
 
   $ csdx launch --config <path/to/launch/config/file> --type <options: GitHub|FileUpload> --name=<value> --environment=<value> --branch=<value> --build-command=<value> --framework=<option> --org=<value> --out-dir=<value> --server-command=<value>
+
+  $ csdx launch --config <path/to/launch/config/file> --type <options: GitHub|FileUpload> --name=<value> --environment=<value> --branch=<value> --build-command=<value> --framework=<option> --org=<value> --out-dir=<value> --server-command=<value> --response-mode=streaming
 
   $ csdx launch --config <path/to/launch/config/file> --type <options: GitHub|FileUpload> --name=<value> --environment=<value> --branch=<value> --build-command=<value> --framework=<option> --org=<value> --out-dir=<value> --variable-type="Import variables from a stack" --alias=<value>
 
@@ -3578,6 +1926,39 @@ EXAMPLES
 
 _See code: [@contentstack/cli-launch](https://github.com/contentstack/launch-cli/blob/main/packages/contentstack-launch/src/commands/launch/open.ts)_
 
+## `csdx launch:rollback`
+
+Roll back to previous deployment
+
+```
+USAGE
+  $ csdx launch:rollback [-d <value>] [-c <value>] [--org <value>] [--project <value>] [-e <value>] [--deployment
+    <value>] [--reason <value>]
+
+FLAGS
+  -c, --config=<value>       Path to the local '.cs-launch.json' file
+  -d, --data-dir=<value>     Current working directory
+  -e, --environment=<value>  Environment name or UID
+      --deployment=<value>   [Optional] Deployment UID to roll back to
+      --org=<value>          [Optional] Provide the organization UID
+      --project=<value>      [Optional] Provide the project UID
+      --reason=<value>       [Optional] Reason for the rollback (saved to audit log)
+
+DESCRIPTION
+  Roll back to previous deployment
+
+EXAMPLES
+  $ csdx launch:rollback
+
+  $ csdx launch:rollback -d "current working directory"
+
+  $ csdx launch:rollback -c "path to the local config file"
+
+  $ csdx launch:rollback -e "environment number or uid" --deployment=<deployment UID> --org=<org UID> --project=<Project UID> --reason="restoring previous build"
+```
+
+_See code: [@contentstack/cli-launch](https://github.com/contentstack/launch-cli/blob/main/packages/contentstack-launch/src/commands/launch/rollback.ts)_
+
 ## `csdx login`
 
 User sessions login
@@ -3655,7 +2036,7 @@ EXAMPLES
   $ csdx plugins
 ```
 
-_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v5.4.55/src/commands/plugins/index.ts)_
+_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/5.4.82/src/commands/plugins/index.ts)_
 
 ## `csdx plugins:add PLUGIN`
 
@@ -3729,7 +2110,7 @@ EXAMPLES
   $ csdx plugins:inspect myplugin
 ```
 
-_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v5.4.55/src/commands/plugins/inspect.ts)_
+_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/5.4.82/src/commands/plugins/inspect.ts)_
 
 ## `csdx plugins:install PLUGIN`
 
@@ -3778,7 +2159,7 @@ EXAMPLES
     $ csdx plugins:install someuser/someplugin
 ```
 
-_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v5.4.55/src/commands/plugins/install.ts)_
+_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/5.4.82/src/commands/plugins/install.ts)_
 
 ## `csdx plugins:link PATH`
 
@@ -3809,7 +2190,7 @@ EXAMPLES
   $ csdx plugins:link myplugin
 ```
 
-_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v5.4.55/src/commands/plugins/link.ts)_
+_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/5.4.82/src/commands/plugins/link.ts)_
 
 ## `csdx plugins:remove [PLUGIN]`
 
@@ -3850,7 +2231,7 @@ FLAGS
   --reinstall  Reinstall all plugins after uninstalling.
 ```
 
-_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v5.4.55/src/commands/plugins/reset.ts)_
+_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/5.4.82/src/commands/plugins/reset.ts)_
 
 ## `csdx plugins:uninstall [PLUGIN]`
 
@@ -3878,7 +2259,7 @@ EXAMPLES
   $ csdx plugins:uninstall myplugin
 ```
 
-_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v5.4.55/src/commands/plugins/uninstall.ts)_
+_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/5.4.82/src/commands/plugins/uninstall.ts)_
 
 ## `csdx plugins:unlink [PLUGIN]`
 
@@ -3922,47 +2303,18 @@ DESCRIPTION
   Update installed plugins.
 ```
 
-_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v5.4.55/src/commands/plugins/update.ts)_
-
-## `csdx tokens`
-
-Lists all existing tokens added to the session
-
-```
-USAGE
-  $ csdx tokens [--columns <value>] [--sort <value>] [--filter <value>] [--csv] [--no-truncate]
-    [--no-header] [--output csv|json|yaml]
-
-TABLE FLAGS
-  --columns=<value>  Specify columns to display, comma-separated.
-  --csv              Output results in CSV format.
-  --filter=<value>   Filter rows by a column value (e.g., name=foo).
-  --no-header        Hide table headers in output.
-  --no-truncate      Prevent truncation of long text in columns.
-  --output=<option>  Specify output format: csv, json, or yaml.
-                     <options: csv|json|yaml>
-  --sort=<value>     Sort the table by a column. Use "-" for descending.
-
-DESCRIPTION
-  Lists all existing tokens added to the session
-
-ALIASES
-  $ csdx tokens
-
-EXAMPLES
-  $ csdx auth:tokens
-```
+_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/5.4.82/src/commands/plugins/update.ts)_
 
 ## `csdx whoami`
 
-Display current users email address
+Display current user's email address
 
 ```
 USAGE
   $ csdx whoami
 
 DESCRIPTION
-  Display current users email address
+  Display current user's email address
 
 ALIASES
   $ csdx whoami
@@ -3971,7 +2323,3 @@ EXAMPLES
   $ csdx auth:whoami
 ```
 <!-- commandsstop -->
-
-```
-
-```

--- a/packages/contentstack/package.json
+++ b/packages/contentstack/package.json
@@ -165,5 +165,9 @@
       ]
     }
   },
-  "repository": "https://github.com/contentstack/cli"
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/contentstack/cli.git",
+    "directory": "packages/contentstack"
+  }
 }


### PR DESCRIPTION

## Summary

Full audit of all READMEs, `package.json` metadata, and source files in the `cli` monorepo. Code and manifests were used as the source of truth throughout.

---

### Root `README.md`

- Updated Node.js prerequisite from v16 → **v22**
- Fixed `cm` namespace link: `bulk-publish` → `bulk-operations` (package was renamed)
- Fixed broken link syntax for `export-to-csv` and `seed` (erroneous space before `(`)
- Updated stale docs URL: `/docs/developers/cli` → `/docs/headless-cms/cli`
- Fixed `tsgen` Useful Plugins link from archived Contentstack-Solutions fork → cli-plugins monorepo

---

### `package.json` — all 5 packages

Standardized `repository` field from bare strings / empty values to npm-recommended monorepo format:

```json
{
  "type": "git",
  "url": "git+https://github.com/contentstack/cli.git",
  "directory": "packages/<pkg>"
}
```

| Package | Issue |
|---|---|
| `contentstack-utilities` | `url` was an **empty string** |
| `contentstack-auth` | bare string `"contentstack/cli"` |
| `contentstack-command` | bare string `"contentstack/cli"` |
| `contentstack-config` | bare string `"contentstack/cli"` |
| `contentstack` | bare string `"https://github.com/contentstack/cli"` (no `directory`) |

---

### `contentstack-auth`

**README:**
- Added missing `auth:tokens:list` command section (full FLAGS, DESCRIPTION, EXAMPLES, `_See code_`)
- Removed phantom `csdx tokens` alias section generated by oclif (corrupt USAGE line)
- Removed non-existent `-i, --ignore` flag from `auth:tokens:remove`
- Updated `auth:tokens` description and examples to reflect `list` as a subcommand

**Source — `auth/whoami.ts`:**
- Fixed typo: `"Display current users email address"` → `"Display current user's email address"`

---

### `contentstack-config`

**Source — `config/set/early-access-header.ts` + README:**
- Fixed **swapped flag descriptions**: `--header` was describing the alias; `--header-alias` was describing the value — both corrected in source and README
- Renamed `--asset-management` → `--cs-assets` in `config:set:region` (matches renamed flag in code)
- Removed short `-n` flag from `--name` in `config:set:region`
- Fixed stale docs URL in package intro text

---

### `contentstack` (aggregate CLI README)

This is the largest change — the aggregate README documents all 17 bundled plugins.

#### Broken `_See code_` links fixed — 13 total

| Command(s) | Old | Fixed |
|---|---|---|
| bootstrap, clone, export, import, import-setup, migration, seed | `cli/blob/main/packages/...` | `cli-plugins/blob/main/packages/...` |
| cm:branches (×6) | `cli/blob/main/packages/contentstack-export/...` | `cli-plugins/blob/main/packages/contentstack-branches/...` |
| cm:stacks:migration | `.js` extension + wrong repo | `.ts` + `cli-plugins` |
| cm:stacks:audit, audit:fix | `contentstack/audit/blob/main/...` | `cli-plugins/blob/main/packages/contentstack-audit/...` |

#### Missing command sections added

- `auth:tokens:list` — sourced from auth manifest
- `cm:branches:merge-status` — was lost in a merge conflict
- `launch:rollback` — new command, not yet documented

#### New flags documented

- `launch --response-mode=<buffered|streaming>`
- `cm:stacks:import --skip-taxonomy-publish`

#### Stale / wrong content removed

- All legacy `cm:bulk-publish`, `cm:stacks:publish`, `cm:stacks:publish-revert` sections (package removed)
- Phantom `csdx tokens` alias section
- All merge conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`) from TOC and body

#### Flag corrections

| Command | Fix |
|---|---|
| `cm:stacks:import-setup` | `--modules` → `--module` in TOC, heading, USAGE, and EXAMPLE |
| `cm:stacks:export` | `--module` updated from `=<value>` to `=<option>` with full enum list |
| `cm:stacks:import` | same as export; added `--skip-taxonomy-publish` |
| `cm:stacks:seed` | USAGE + FLAGS corrected to match manifest (`--yes` is boolean; `-o`/`-r`/`-s` short flags removed) |
| `config:set:region` | `--asset-management` → `--cs-assets`; removed `-n` short flag |

#### Other

- `@oclif/plugin-help` and `@oclif/plugin-plugins` `_See code_` version numbers bumped
- All usage-block version strings updated (node v22.13.1 → v22.21.1, package versions)

---
