### PR TITLE
feat: warn and suggest install for opt-in launch commands

### DIFF
--- a/packages/contentstack/package.json
+++ b/packages/contentstack/package.json
@@ -156,7 +156,8 @@
       ],
       "init": [
         "./lib/hooks/init/context-init",
-        "./lib/hooks/init/utils-init"
+        "./lib/hooks/init/utils-init",
+        "./lib/hooks/init/opt-in-plugin-guide"
       ]
     }
   },

--- a/packages/contentstack/src/hooks/init/opt-in-plugin-guide.ts
+++ b/packages/contentstack/src/hooks/init/opt-in-plugin-guide.ts
@@ -1,0 +1,38 @@
+import { Hook } from '@oclif/core';
+import { cliux } from '@contentstack/cli-utilities';
+
+/**
+ * Commands whose plugins used to ship bundled with the CLI but are now opt-in.
+ * Keyed by oclif topic (the segment before the first `:` in a command id).
+ */
+const DEMOTED_PLUGINS: Record<string, string> = {
+  launch: '@contentstack/cli-launch',
+};
+
+/**
+ * When a user runs a command belonging to a demoted (now opt-in) plugin that
+ * is not installed, warn them and point to the install command instead of
+ * letting the generic "command not found" handler report it as a typo. Runs on
+ * `init`, before command resolution, so it pre-empts `@oclif/plugin-not-found`.
+ */
+const hook: Hook<'init'> = async function (opts): Promise<void> {
+  if (!opts.id) return;
+
+  const topic = opts.id.split(':')[0];
+  const pluginName = DEMOTED_PLUGINS[topic];
+  if (!pluginName) return;
+
+  // If the plugin is already installed, let normal command resolution proceed.
+  if (this.config.plugins.has(pluginName)) return;
+
+  cliux.print(
+    `\nWarning: "${topic}" is now an opt-in plugin and is not installed, so "${topic}:*" commands are unavailable.`,
+    { color: 'yellow' },
+  );
+  cliux.print('\nInstall it to enable these commands:', { color: 'yellow' });
+  cliux.print(`  csdx plugins:install ${pluginName}\n`, { color: 'green' });
+
+  this.exit(127);
+};
+
+export default hook;


### PR DESCRIPTION
## What

Adds an `init` hook that intercepts commands belonging to demoted (now opt-in) plugins when the plugin isn't installed. For `launch:*`, instead of the generic "command not found", it prints:

```
Warning: "launch" is now an opt-in plugin and is not installed, so "launch:*" commands are unavailable.

Install it to enable these commands:
  csdx plugins:install @contentstack/cli-launch
```

## Why

After the launch demotion (DX-9742), a bare "command not found" reads like a regression to users for whom `launch:*` previously worked out of the box. This gives an actionable hint pointing at the install command, consistent with the README opt-in note and the migration guide (DX-9748).

## How

- New `src/hooks/init/opt-in-plugin-guide.ts` — runs on `init` (before command resolution), so it pre-empts `@oclif/plugin-not-found` cleanly. `command_not_found` hooks run concurrently and can't reliably suppress one another, so `init` is the correct interception point.
- Driven by a `DEMOTED_PLUGINS` map (`launch` → `@contentstack/cli-launch`) for easy extension.
- No-op when the plugin **is** installed (launch runs normally); genuinely unknown commands still fall through to `plugin-not-found`'s "did you mean?".
- Registered under `oclif.hooks.init` in `package.json`.

## Verification

`node bin/dev.js launch` / `launch:<cmd>` → prints the warning + install hint, exits 127. `tsc --noEmit` clean. Control command (`foobar`) unchanged.

Related: DX-9742 (demotion), DX-9748 (migration notes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)