### PR TITLE
DX-9992 | Show errors and warnings on console in progress-manager mode

### DIFF
--- a/packages/contentstack-utilities/src/logger/logger.ts
+++ b/packages/contentstack-utilities/src/logger/logger.ts
@@ -85,7 +85,12 @@ export default class Logger {
       }
     }
 
-    if (showConsoleLogs) {
+    // Errors and warnings must always reach the console, even when progress bars
+    // suppress info/success/debug output — otherwise failures (e.g. an invalid
+    // stack API key or a taxonomy error) are silently swallowed in progress mode.
+    const isErrorOrWarn = level === 'error' || level === 'warn';
+
+    if (showConsoleLogs || isErrorOrWarn) {
       transports.push(
         new winston.transports.Console({
           format: winston.format.combine(

--- a/packages/contentstack-utilities/test/unit/logger.test.ts
+++ b/packages/contentstack-utilities/test/unit/logger.test.ts
@@ -233,6 +233,70 @@ describe('Logger', () => {
   });
 });
 
+describe('Console output in progress-manager mode', () => {
+  const tempDir = path.join(os.tmpdir(), `csdx-progress-log-${Date.now()}`);
+
+  function hasConsoleTransport(winLogger: any): boolean {
+    return winLogger.transports.some((t: any) => t.constructor && t.constructor.name === 'Console');
+  }
+
+  fancy
+    .stub(configHandler, 'get', (...args: any[]) => {
+      const key = args[0];
+      if (key === 'log') return { progressSupportedModule: 'bulk-operations', showConsoleLogs: false };
+      if (key === 'log.path') return tempDir;
+      if (key === 'currentCommandId') return 'bulk-operations';
+      if (key === 'sessionId') return 'test-session';
+      return undefined;
+    })
+    .it('keeps console output for errors when progress bars suppress info logs', () => {
+      const progressLogger = new Logger({ basePath: tempDir, consoleLogLevel: 'info', logLevel: 'info' });
+      expect(hasConsoleTransport(progressLogger['loggers'].error)).to.equal(true);
+    });
+
+  fancy
+    .stub(configHandler, 'get', (...args: any[]) => {
+      const key = args[0];
+      if (key === 'log') return { progressSupportedModule: 'bulk-operations', showConsoleLogs: false };
+      if (key === 'log.path') return tempDir;
+      if (key === 'currentCommandId') return 'bulk-operations';
+      if (key === 'sessionId') return 'test-session';
+      return undefined;
+    })
+    .it('keeps console output for warnings when progress bars suppress info logs', () => {
+      const progressLogger = new Logger({ basePath: tempDir, consoleLogLevel: 'info', logLevel: 'info' });
+      expect(hasConsoleTransport(progressLogger['loggers'].warn)).to.equal(true);
+    });
+
+  fancy
+    .stub(configHandler, 'get', (...args: any[]) => {
+      const key = args[0];
+      if (key === 'log') return { progressSupportedModule: 'bulk-operations', showConsoleLogs: false };
+      if (key === 'log.path') return tempDir;
+      if (key === 'currentCommandId') return 'bulk-operations';
+      if (key === 'sessionId') return 'test-session';
+      return undefined;
+    })
+    .it('suppresses console output for info logs so progress bars stay clean', () => {
+      const progressLogger = new Logger({ basePath: tempDir, consoleLogLevel: 'info', logLevel: 'info' });
+      expect(hasConsoleTransport(progressLogger['loggers'].info)).to.equal(false);
+    });
+
+  fancy
+    .stub(configHandler, 'get', (...args: any[]) => {
+      const key = args[0];
+      if (key === 'log') return { progressSupportedModule: 'bulk-operations', showConsoleLogs: true };
+      if (key === 'log.path') return tempDir;
+      if (key === 'currentCommandId') return 'bulk-operations';
+      if (key === 'sessionId') return 'test-session';
+      return undefined;
+    })
+    .it('shows console output for info logs when console logging is enabled', () => {
+      const progressLogger = new Logger({ basePath: tempDir, consoleLogLevel: 'info', logLevel: 'info' });
+      expect(hasConsoleTransport(progressLogger['loggers'].info)).to.equal(true);
+    });
+});
+
 describe('Session Log Path', () => {
   let sandbox: sinon.SinonSandbox;
   let tempDir: string;


### PR DESCRIPTION
### What
When a progress-supported module (e.g. `bulk-operations`) runs with console logs disabled (progress-bar UI mode), error and warning messages are not shown on screen. A failing bulk operation — such as an invalid stack API key or a taxonomy error — completes with nothing printed.

### Why
In `logger.ts` the Console transport was attached only when `showConsoleLogs` was true. For progress-supported modules that value defaults to `false`, so **no** level (including `error`/`warn`) got a console transport. The message was still written to the error/warn log file, but nothing reached the terminal — silently swallowed.

### Fix
`packages/contentstack-utilities/src/logger/logger.ts` — attach the Console transport when console logs are enabled **or** the level is `error`/`warn`:

```ts
const isErrorOrWarn = level === 'error' || level === 'warn';
if (showConsoleLogs || isErrorOrWarn) {
  transports.push(new winston.transports.Console({ ... }));
}
```

Each level has its own winston logger instance, so this surfaces errors and warnings while keeping `info`/`success`/`debug` hidden — the progress bars stay clean. No change to the `showConsoleLogs: true` path.

### Impact
- Taxonomy error messages are now shown under the progress manager.
- Warnings are now displayed for bulk operations in progress mode.

### Tests
New `Console output in progress-manager mode` block in `logger.test.ts`, 4 cases: error surfaces, warn surfaces, info stays hidden, and console-on regression. Full utilities suite green (198 passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)