### PR TITLE
fix(config): correct swapped flag descriptions in config:set:early-access-header

### DIFF
--- a/packages/contentstack-config/src/commands/config/set/early-access-header.ts
+++ b/packages/contentstack-config/src/commands/config/set/early-access-header.ts
@@ -6,8 +6,8 @@ export default class SetEarlyAccessHeaderCommand extends Command {
   static description = 'Set Early Access header';
   static aliases: string[] = ['config:set:ea-header'];
   static flags: FlagInput = {
-    'header-alias': flags.string({ description: '(optional) Provide the Early Access header value.' }),
-    header: flags.string({ description: '(optional) Provide the Early Access header alias name.' }),
+    'header-alias': flags.string({ description: '(optional) Provide a name (alias) for this Early Access header.' }),
+    header: flags.string({ description: '(optional) Provide the Early Access header value.' }),
   };
   static examples: string[] = [
     '$ <%= config.bin %> <%= command.id %>',


### PR DESCRIPTION
## Summary

- `--header-alias` had description `"(optional) Provide the Early Access header value."` — describes the value, not the alias
- `--header` had description `"(optional) Provide the Early Access header alias name."` — describes the alias, not the value
- Swapped both descriptions so each flag correctly documents what it accepts

No behavioral change — flags, runtime logic, and interactive prompts are unchanged. Help-text fix only.

## Test plan

- [ ] Run `csdx config:set:early-access-header --help` and confirm `--header` shows the value description and `--header-alias` shows the alias description

🤖 Generated with [Claude Code](https://claude.com/claude-code)