### PR TITLE
feat: add v2 production release workflows

### DIFF
--- a/.github/workflows/release-production-core.yml
+++ b/.github/workflows/release-production-core.yml
@@ -1,0 +1,61 @@
+name: Release CLI Core (Production)
+
+on:
+  workflow_call:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.28.0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.x'
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install pnpm
+        run: corepack prepare pnpm@10.28.0 --activate
+
+      - name: Clean the repository
+        run: pnpm run clean:all
+
+      - name: Install root dependencies
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Build all packages
+        run: pnpm -r --sort run build
+
+      - name: Reading Configuration
+        id: release_config
+        uses: rgarcia-phi/json-to-variables@v1.1.0
+        with:
+          filename: .github/config/release.json
+          prefix: release
+
+      - name: Publishing core (Production)
+        id: publish-core
+        uses: JS-DevTools/npm-publish@v3
+        with:
+          token: ${{ secrets.NPM_TOKEN }}
+          package: ./packages/contentstack/package.json
+          tag: latest
+
+      - name: Create Core Production Release
+        id: create_release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.publish-core.outputs.version }}
+        run: |
+          TAG="core@v${VERSION}"
+          if gh release view "$TAG" &>/dev/null; then
+            echo "Release $TAG already exists — skipping."
+          else
+            gh release create "$TAG" \
+              --title "Core Production $VERSION" \
+              --generate-notes
+          fi

--- a/.github/workflows/release-production-pipeline.yml
+++ b/.github/workflows/release-production-pipeline.yml
@@ -1,0 +1,16 @@
+name: CLI Production Release Pipeline
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  plugins:
+    uses: ./.github/workflows/release-production-platform-plugins.yml
+    secrets: inherit
+
+  core:
+    needs: plugins
+    uses: ./.github/workflows/release-production-core.yml
+    secrets: inherit

--- a/.github/workflows/release-production-platform-plugins.yml
+++ b/.github/workflows/release-production-platform-plugins.yml
@@ -1,0 +1,70 @@
+name: Release CLI Platform Plugins (Production)
+
+on:
+  workflow_call:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.28.0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.x'
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install pnpm
+        run: corepack prepare pnpm@10.28.0 --activate
+
+      - name: Clean the repository
+        run: pnpm run clean:all
+
+      - name: Install root dependencies
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Build all plugins
+        run: pnpm -r --sort run build
+
+      - name: Reading Configuration
+        id: release_config
+        uses: rgarcia-phi/json-to-variables@v1.1.0
+        with:
+          filename: .github/config/release.json
+          prefix: release
+
+      # Utilities
+      - name: Publishing utilities (Production)
+        uses: JS-DevTools/npm-publish@v3
+        with:
+          token: ${{ secrets.NPM_TOKEN }}
+          package: ./packages/contentstack-utilities/package.json
+          tag: latest
+
+      # Command
+      - name: Publishing command (Production)
+        uses: JS-DevTools/npm-publish@v3
+        with:
+          token: ${{ secrets.NPM_TOKEN }}
+          package: ./packages/contentstack-command/package.json
+          tag: latest
+
+      # Config
+      - name: Publishing config (Production)
+        uses: JS-DevTools/npm-publish@v3
+        with:
+          token: ${{ secrets.NPM_TOKEN }}
+          package: ./packages/contentstack-config/package.json
+          tag: latest
+
+      # Auth
+      - name: Publishing auth (Production)
+        uses: JS-DevTools/npm-publish@v3
+        with:
+          token: ${{ secrets.NPM_TOKEN }}
+          package: ./packages/contentstack-auth/package.json
+          tag: latest

--- a/.talismanrc
+++ b/.talismanrc
@@ -3,3 +3,5 @@ fileignoreconfig:
 - filename: pnpm-lock.yaml
   checksum: 17d63745bf9d45e29848c2c512c31d7aab42c5aeb986996adf049905a31c7322
   version: '1.0'
+- filename: .github/workflows/release-production-pipeline.yml
+  checksum: dd858a2c2a3297c5651c2843ddae73ad0776a0386329200d01b051ddc489871e


### PR DESCRIPTION
## Summary

Ports production release workflows from the `development` branch to `v2-dev` for CLI v2 GA. These sit alongside the existing beta workflows — beta releases via `v2-beta` continue to work unchanged.

### New files

| File | Purpose |
|---|---|
| `release-production-pipeline.yml` | Orchestrator — triggers on `push to main` + `workflow_dispatch`, calls the two sub-workflows |
| `release-production-core.yml` | Publishes `@contentstack/cli` with `tag: latest`, creates a non-prerelease GitHub release |
| `release-production-platform-plugins.yml` | Publishes utilities / command / config / auth with `tag: latest` |

### Also

- Added `.talismanrc` exception for `secrets: inherit` in the pipeline workflow (false positive — it's a GitHub Actions keyword, not a secret)

## Test plan

- [ ] Verify all three files are present on v2-dev
- [ ] Verify `release-production-pipeline.yml` triggers on `main` with `workflow_dispatch` available
- [ ] Verify `release-production-core.yml` uses `tag: latest` and creates a non-prerelease GitHub release
- [ ] Verify existing beta workflows (`release.yml`, `release-v2-beta-*.yml`) are untouched
- [ ] After v2 GA merge to `main`, confirm the pipeline fires end-to-end

## Related

- Epic: [DX-10156 — CLI v2 Post-Release Stabilization](https://contentstack.atlassian.net/browse/DX-10156)
- Companion PR: [contentstack/cli-plugins#TBD](https://github.com/contentstack/cli-plugins)

🤖 Generated with [Claude Code](https://claude.com/claude-code)