### PR TITLE
fix: add contents:write permission to core release workflow

### DIFF
--- a/.github/workflows/release-production-core.yml
+++ b/.github/workflows/release-production-core.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4

--- a/.github/workflows/release-production-pipeline.yml
+++ b/.github/workflows/release-production-pipeline.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   plugins:
     uses: ./.github/workflows/release-production-platform-plugins.yml


### PR DESCRIPTION
## Root Cause

`gh release create` requires `contents: write` on the `GITHUB_TOKEN`. The default token permission is `contents: read`, causing the 403:

```
HTTP 403: Resource not accessible by integration
(https://api.github.com/repos/contentstack/cli/releases)
```

## Fix

- `release-production-core.yml` — added `permissions: contents: write` at the job level (this is the reusable workflow that actually runs `gh release create`)
- `release-production-pipeline.yml` — added `permissions: contents: write` at the workflow level so it propagates into the reusable workflow call via `workflow_call`

## Files Changed

- `.github/workflows/release-production-core.yml`
- `.github/workflows/release-production-pipeline.yml`