### PR TITLE
fix: rename dist-tag v1 → v1-latest in v1-legacy release workflows

### DIFF
--- a/.github/workflows/release-production-core.yml
+++ b/.github/workflows/release-production-core.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           token: ${{ secrets.NPM_TOKEN }}
           package: ./packages/contentstack/package.json
-          tag: v1
+          tag: v1-latest
 
       - name: Create Core Production Release
         id: create_release

--- a/.github/workflows/release-production-platform-plugins.yml
+++ b/.github/workflows/release-production-platform-plugins.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           token: ${{ secrets.NPM_TOKEN }}
           package: ./packages/contentstack-utilities/package.json
-          tag: v1
+          tag: v1-latest
 
       # Command
       - name: Publishing command (Production)
@@ -51,7 +51,7 @@ jobs:
         with:
           token: ${{ secrets.NPM_TOKEN }}
           package: ./packages/contentstack-command/package.json
-          tag: v1
+          tag: v1-latest
 
       # Config
       - name: Publishing config (Production)
@@ -59,7 +59,7 @@ jobs:
         with:
           token: ${{ secrets.NPM_TOKEN }}
           package: ./packages/contentstack-config/package.json
-          tag: v1
+          tag: v1-latest
 
       # Auth
       - name: Publishing auth (Production)
@@ -67,4 +67,4 @@ jobs:
         with:
           token: ${{ secrets.NPM_TOKEN }}
           package: ./packages/contentstack-auth/package.json
-          tag: v1
+          tag: v1-latest


### PR DESCRIPTION
## Root Cause

`npm` rejects dist-tags that are valid SemVer ranges. `v1` parses as `>=1.0.0-0 <2.0.0-0` and is rejected with:

\`\`\`
npm error Tag name must not be a valid SemVer range: v1
\`\`\`

## Fix

Renamed `tag: v1` → `tag: v1-latest` in both v1-legacy release workflows.

## Files Changed

- `.github/workflows/release-production-core.yml`
- `.github/workflows/release-production-platform-plugins.yml`