### PR TITLE
chore: add v1-legacy release workflows

### DIFF
--- a/.github/workflows/release-v1-legacy-core.yml
+++ b/.github/workflows/release-v1-legacy-core.yml
@@ -1,4 +1,4 @@
-name: Release CLI Core (Production)
+name: Release CLI Core v1-Legacy
 
 on:
   workflow_call:
@@ -43,7 +43,7 @@ jobs:
         with:
           token: ${{ secrets.NPM_TOKEN }}
           package: ./packages/contentstack/package.json
-          tag: v1
+          tag: v1-x
 
       - name: Create Core Production Release
         id: create_release
@@ -56,6 +56,7 @@ jobs:
             echo "Release $TAG already exists — skipping."
           else
             gh release create "$TAG" \
-              --title "Core Production $VERSION" \
-              --generate-notes
+              --title "Core v1-Legacy $VERSION" \
+              --generate-notes \
+              --latest=false
           fi

--- a/.github/workflows/release-v1-legacy-platform-plugins.yml
+++ b/.github/workflows/release-v1-legacy-platform-plugins.yml
@@ -1,4 +1,4 @@
-name: Release CLI Platform Plugins
+name: Release CLI Platform Plugins v1-Legacy
 
 on:
   workflow_call:
@@ -43,7 +43,7 @@ jobs:
         with:
           token: ${{ secrets.NPM_TOKEN }}
           package: ./packages/contentstack-utilities/package.json
-          tag: v1
+          tag: v1-x
 
       # Command
       - name: Publishing command (Production)
@@ -51,7 +51,7 @@ jobs:
         with:
           token: ${{ secrets.NPM_TOKEN }}
           package: ./packages/contentstack-command/package.json
-          tag: v1
+          tag: v1-x
 
       # Config
       - name: Publishing config (Production)
@@ -59,7 +59,7 @@ jobs:
         with:
           token: ${{ secrets.NPM_TOKEN }}
           package: ./packages/contentstack-config/package.json
-          tag: v1
+          tag: v1-x
 
       # Auth
       - name: Publishing auth (Production)
@@ -67,4 +67,4 @@ jobs:
         with:
           token: ${{ secrets.NPM_TOKEN }}
           package: ./packages/contentstack-auth/package.json
-          tag: v1
+          tag: v1-x

--- a/.github/workflows/release-v1-legacy.yml
+++ b/.github/workflows/release-v1-legacy.yml
@@ -1,4 +1,4 @@
-name: CLI Production Release Pipeline
+name: CLI v1-Legacy Release
 
 on:
   push:
@@ -7,10 +7,10 @@ on:
 
 jobs:
   plugins:
-    uses: ./.github/workflows/release-production-platform-plugins.yml
+    uses: ./.github/workflows/release-v1-legacy-platform-plugins.yml
     secrets: inherit
 
   core:
     needs: plugins
-    uses: ./.github/workflows/release-production-core.yml
+    uses: ./.github/workflows/release-v1-legacy-core.yml
     secrets: inherit


### PR DESCRIPTION
Renamed release workflow files and updated triggers/tags for v1-legacy branch support. Branch trigger changed to v1-legacy, npm dist-tag set to v1-x, and GitHub releases marked as --latest=false.