### PR TITLE
fix(contentstack): include tslib as runtime dependency

### DIFF
--- a/packages/contentstack/package.json
+++ b/packages/contentstack/package.json
@@ -51,6 +51,7 @@
     "ora": "^8.2.0",
     "semver": "^7.8.5",
     "short-uuid": "^6.0.3",
+    "tslib": "^2.8.1",
     "winston": "^3.19.0"
   },
   "overrides": {
@@ -78,7 +79,6 @@
     "sinon": "^21.1.2",
     "tmp": "^0.2.7",
     "ts-node": "^10.9.2",
-    "tslib": "^2.8.1",
     "typescript": "^5.9.3"
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,6 +121,9 @@ importers:
       short-uuid:
         specifier: ^6.0.3
         version: 6.0.3
+      tslib:
+        specifier: ^2.8.1
+        version: 2.8.1
       winston:
         specifier: ^3.19.0
         version: 3.19.0
@@ -182,9 +185,6 @@ importers:
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@types/node@18.19.130)(typescript@5.9.3)
-      tslib:
-        specifier: ^2.8.1
-        version: 2.8.1
       typescript:
         specifier: ^5.9.3
         version: 5.9.3


### PR DESCRIPTION
Consumers can install `@contentstack/cli` without its development packages and then hit `Cannot find module 'tslib'`. The package compiles with `importHelpers: true`, so some generated JavaScript imports helpers from `tslib` at runtime even though it was only listed as a development dependency.

This moves `tslib` into the package's runtime dependencies and updates the matching pnpm lockfile entry. I regenerated the lockfile without running install scripts, built every workspace package, and packed `@contentstack/cli` to confirm that the published package metadata now includes `dependencies.tslib` and no longer lists it under `devDependencies`.

Fixes #2629.
